### PR TITLE
bug fix: entities spawned in tick 0 will not being replicated

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -122,7 +122,8 @@ pub(super) struct LastTick(pub(super) Tick);
 
 impl Default for LastTick {
     fn default() -> Self {
-        Self(Tick::new(0))
+        // Start at -1 so we can get entities spawned in Tick 0.
+        Self(Tick::new(u32::MAX))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn insert_replicaiton() {
+    fn insert_replication() {
         let mut app = App::new();
         app.add_plugins(ReplicationPlugins)
             .replicate::<TableComponent>()


### PR DESCRIPTION
If an entity is spawned in World tick 0, then it won't be replicated until changed because clients' initial 'acked' tick is 0 (i.e. clients claim that they ack tick 0). Currently no entities can actually be spawned in tick 0 as an artifact of bevy's design (entities spawned in startup systems seem to start at tick 2), however that could change in the future.

This fix sets the default 'acked' tick to -1 so entities added in tick 0 will be captured by the replication system. Changes are replicated when [delta between top tick and last-acked tick] > [delta between top tick and component last-changed tick], so this fix guarantees the first delta is maximized.

I also snuck in a typo fix :p.