### PR TITLE
Use more compact varint encoding for entities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bevy = { version = "0.11", default-features = false, features = ["bevy_scene"] }
 bincode = "1.3"
 serde = "1.0"
 strum = { version = "0.25", features = ["derive"] }
+varint-rs = "2.2"
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,6 +8,7 @@ use bevy::{
 use bevy_renet::{renet::Bytes, transport::client_connected};
 use bevy_renet::{renet::RenetClient, transport::NetcodeClientPlugin, RenetClientPlugin};
 use bincode::{DefaultOptions, Options};
+use varint_rs::VarintReader;
 
 use crate::replicon_core::{
     replication_rules::{Mapper, Replication, ReplicationRules},
@@ -190,10 +191,10 @@ fn deserialize_despawns(
 
 /// Deserializes `entity` from compressed index and generation, for details see [`ReplicationBuffer::write_entity()`].
 fn deserialize_entity(cursor: &mut Cursor<Bytes>) -> Result<Entity, bincode::Error> {
-    let flagged_index: u64 = DefaultOptions::new().deserialize_from(&mut *cursor)?;
+    let flagged_index: u64 = cursor.read_u64_varint()?;
     let has_generation = (flagged_index & 1) > 0;
     let generation = if has_generation {
-        DefaultOptions::new().deserialize_from(&mut *cursor)?
+        cursor.read_u32_varint()?
     } else {
         0u32
     };

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,6 +28,7 @@ use crate::replicon_core::{
 };
 use despawn_tracker::{DespawnTracker, DespawnTrackerPlugin};
 use removal_tracker::{RemovalTracker, RemovalTrackerPlugin};
+use varint_rs::VarintWriter;
 
 pub const SERVER_ID: u64 = 0;
 
@@ -670,9 +671,9 @@ impl ReplicationBuffer {
         let flag = entity.generation() > 0;
         flagged_index |= flag as u64;
 
-        DefaultOptions::new().serialize_into(&mut self.message, &flagged_index)?;
+        self.message.write_u64_varint(flagged_index)?;
         if flag {
-            DefaultOptions::new().serialize_into(&mut self.message, &entity.generation())?;
+            self.message.write_u32_varint(entity.generation())?;
         }
 
         Ok(())


### PR DESCRIPTION
### Problem

Bincode varints are [length prefixed](https://carlmastrangelo.com/blog/lets-make-a-varint), which uses more bytes than the 'continuation bits' style. This means entity serialization is wasting bytes.

### Solution

Use continuation bit varints instead, from [this crate](https://docs.rs/bytes-varint/1.0.3/bytes_varint/index.html). Unfortunately it is not simple to use continuation bit varints for generic serialization, since we rely on bincode for that.