### PR TITLE
Add Default to Replication component

### DIFF
--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -190,7 +190,7 @@ pub(crate) struct ReplicationInfo {
 }
 
 /// Marks entity for replication.
-#[derive(Component, Clone, Copy)]
+#[derive(Component, Clone, Copy, Default)]
 pub struct Replication;
 
 /// Replication will be ignored for `T` if this component is present on the same entity.


### PR DESCRIPTION
`Default` was removed for some reason, putting it back.