### PR TITLE
Refactor client mapping to use ClientMapped component

### DIFF
--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -101,12 +101,20 @@ pub struct ReplicationRules {
 
     /// ID of [`Replication`] component.
     marker_id: ComponentId,
+
+    /// ID of [`ClientMapped`] component.
+    mapping_id: ComponentId,
 }
 
 impl ReplicationRules {
     /// ID of [`Replication`] component.
     pub(crate) fn get_marker_id(&self) -> ComponentId {
         self.marker_id
+    }
+
+    /// ID of [`ClientMapped`] component.
+    pub(crate) fn get_client_mapped_id(&self) -> ComponentId {
+        self.mapping_id
     }
 
     /// Returns mapping of replicated components to their replication IDs.
@@ -144,6 +152,7 @@ impl FromWorld for ReplicationRules {
             info: Default::default(),
             ids: Default::default(),
             marker_id: world.init_component::<Replication>(),
+            mapping_id: world.init_component::<ClientMapped>(),
             despawn_fn: despawn_recursive,
         }
     }

--- a/src/server/replicated_archetypes_info.rs
+++ b/src/server/replicated_archetypes_info.rs
@@ -22,6 +22,11 @@ impl ReplicatedArchetypesInfo {
         self.info.iter()
     }
 
+    /// Returns an iterator over archetypes that are client mapped.
+    pub(super) fn iter_client_mapped(&self) -> impl Iterator<Item = &ReplicatedArchetypeInfo> {
+        self.info.iter().filter(|a| a.client_mapped)
+    }
+
     /// Updates internal view of the [`World`]'s replicated archetypes.
     ///
     /// If this is not called before querying data, the results may not accurately reflect what is in the world.
@@ -41,6 +46,9 @@ impl ReplicatedArchetypesInfo {
                 };
                 if archetype.contains(replication_info.dont_replicate_id) {
                     continue;
+                }
+                if archetype.contains(replication_rules.get_client_mapped_id()) {
+                    archetype_info.client_mapped = true;
                 }
 
                 // SAFETY: component ID obtained from this archetype.
@@ -72,6 +80,7 @@ impl Default for ReplicatedArchetypesInfo {
 pub(super) struct ReplicatedArchetypeInfo {
     pub(super) id: ArchetypeId,
     pub(super) components: Vec<ReplicatedComponentInfo>,
+    client_mapped: bool,
 }
 
 impl ReplicatedArchetypeInfo {
@@ -79,6 +88,7 @@ impl ReplicatedArchetypeInfo {
         Self {
             id,
             components: Default::default(),
+            client_mapped: false,
         }
     }
 }

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -146,7 +146,7 @@ impl ReplicationBuffer {
     /// Should be called only inside array.
     /// Increases array length by 1.
     /// See also [`Self::start_array`].
-    pub(super) fn write_client_mapping(&mut self, mapping: &ClientMapping) -> bincode::Result<()> {
+    pub(super) fn write_client_mapping(&mut self, mapping: &ClientMapped) -> bincode::Result<()> {
         debug_assert!(self.inside_array);
 
         serialize_entity(&mut self.cursor, mapping.server_entity)?;


### PR DESCRIPTION
### Problem

Repair-style reconnect recovery requires re-sending client mappings. The resource-based approach to tracking new mappings is not compatible with re-sending because we need to clean up client data on the server after a disconnect (so mappings must be lost).

### Solution

Using a component for client mappings ensures they will be preserved across client reconnects, and will be naturally cleaned up when entities are despawned.