### PR TITLE
Allow calling `dont_replicate::<T>` with the insertion of `T`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Control over client visibility of entities.
 
+### Changed
+
+- Allow calling `dont_replicate::<T>` with the insertion of `T` instead of after `Replication` insertion.
+
 ## [0.20.0] - 2024-01-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allow calling `dont_replicate::<T>` with the insertion of `T` instead of after `Replication` insertion.
+- `dont_replicate::<T>` can panic only in `debug_assertions` is enabled.
 
 ## [0.20.0] - 2024-01-13
 

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -49,7 +49,7 @@ impl EntityDontReplicateExt for EntityWorldMut<'_> {
         if cfg!(debug_assertions) {
             let component_name = any::type_name::<T>();
             assert!(
-                !self.contains::<T>(),
+                !self.contains::<DontReplicate<T>>(),
                 "`dont_replicate::<{component_name}>` shouldn't be called twice for the same entity"
             );
 

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -11,7 +11,8 @@ pub trait CommandDontReplicateExt {
 
     # Panics
 
-    Panics if called on an entity without `T` or if `T` was inserted in a different tick.
+    Panics if was called on this entity before, or `T` component is missing,
+    or if `T` was inserted in a different tick.
 
     # Examples
 

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -11,7 +11,7 @@ pub trait CommandDontReplicateExt {
 
     # Panics
 
-    Panics if `debug_assertions` is enabled and if was called on this entity before
+    Panics if `debug_assertions` is enabled and if called on this entity once before
     or if `T` component was present before this tick.
 
     # Examples

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -6,7 +6,8 @@ pub trait CommandDontReplicateExt {
     /**
     Disables replication for component `T`.
 
-    May only be called on an entity without `T` or if it inserted on it this tick.
+    May only be called on an entity without `T` or if `T` was inserted on it this tick.
+    May only be called once per entity.
 
     # Panics
 

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -10,7 +10,8 @@ pub trait CommandDontReplicateExt {
 
     # Panics
 
-    Panics if was called on this entity before or if `T` component was present before this tick.
+    Panics if `debug_assertions` is enabled and if was called on this entity before
+    or if `T` component was present before this tick.
 
     # Examples
 
@@ -63,7 +64,6 @@ impl EntityDontReplicateExt for EntityWorldMut<'_> {
         }
 
         self.insert(DontReplicate::<T>(PhantomData));
-
         self
     }
 }

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -7,11 +7,11 @@ pub trait CommandDontReplicateExt {
     /**
     Disables replication for component `T`.
 
-    May only be called on an entity if  [`T`] was inserted on it this tick.
+    May only be called on an entity if  `T` was inserted on it this tick.
 
     # Panics
 
-    Panics if called on an entity without [`T`] or if [`T`] was inserted in a different tick.
+    Panics if called on an entity without `T` or if `T` was inserted in a different tick.
 
     # Examples
 

--- a/tests/init_replication.rs
+++ b/tests/init_replication.rs
@@ -415,6 +415,91 @@ fn insertion() {
 }
 
 #[test]
+fn dont_replicate_after_insertion() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<TableComponent>();
+    }
+
+    connect::single_client(&mut server_app, &mut client_app);
+
+    let server_entity = server_app.world.spawn(Replication).id();
+    let client_entity = client_app.world.spawn(Replication).id();
+
+    client_app
+        .world
+        .resource_mut::<ServerEntityMap>()
+        .insert(server_entity, client_entity);
+
+    server_app.update();
+    client_app.update();
+
+    // Reinsert and disable replication.
+    server_app
+        .world
+        .entity_mut(server_entity)
+        .insert(TableComponent)
+        .dont_replicate::<TableComponent>();
+
+    server_app.update();
+    client_app.update();
+
+    let client_entity = client_app.world.entity(client_entity);
+    assert!(!client_entity.contains::<TableComponent>());
+}
+
+#[test]
+fn dont_replicate_after_reinsertion() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<TableComponent>();
+    }
+
+    connect::single_client(&mut server_app, &mut client_app);
+
+    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+    let client_entity = client_app.world.spawn((Replication, TableComponent)).id();
+
+    client_app
+        .world
+        .resource_mut::<ServerEntityMap>()
+        .insert(server_entity, client_entity);
+
+    server_app.update();
+    client_app.update();
+
+    // Reinsert and disable replication.
+    server_app
+        .world
+        .entity_mut(server_entity)
+        .remove::<TableComponent>()
+        .insert(TableComponent)
+        .dont_replicate::<TableComponent>();
+
+    server_app.update();
+    client_app.update();
+
+    let client_entity = client_app.world.entity(client_entity);
+    assert!(!client_entity.contains::<TableComponent>());
+}
+
+#[test]
 fn removal() {
     let mut server_app = App::new();
     let mut client_app = App::new();

--- a/tests/init_replication.rs
+++ b/tests/init_replication.rs
@@ -442,7 +442,7 @@ fn dont_replicate_after_insertion() {
     server_app.update();
     client_app.update();
 
-    // Reinsert and disable replication.
+    // Insert and disable replication.
     server_app
         .world
         .entity_mut(server_entity)


### PR DESCRIPTION
Instead of after `Replication` insertion.