### PR TITLE
Change `ClientEventAppExt::add_mapped_client_event` to clone the events instead of draining them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `ClientEventAppExt::add_mapped_client_event` to clone the event instead of draining it. This means that mapped client events must now implement `Clone`
+
 ### Fixed
 
 - Misuse of `Vec::reserve` that would cause excess allocations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed `ClientEventAppExt::add_mapped_client_event` to clone the event instead of draining it. This means that mapped client events must now implement `Clone`
+- Changed `ClientEventAppExt::add_mapped_client_event` to clone the events instead of draining them. This means that mapped client events must now implement `Clone`
 
 ### Fixed
 
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- API for custom server messages now uses `server_event::serialize_with`  and `server_event::deserialize_with`. For more details see the example in the docs.
+- API for custom server messages now uses `server_event::serialize_with` and `server_event::deserialize_with`. For more details see the example in the docs.
 - Speedup serialization for multiple clients by reusing already serialized components and entities.
 - Hide extra functionality from `ServerEventQueue`.
 - Move server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ To do this, use [`ClientEventAppExt::add_mapped_client_event()`] and implement [
 # app.add_plugins(ReplicationPlugins);
 app.add_mapped_client_event::<MappedEvent>(EventType::Ordered);
 
-#[derive(Debug, Deserialize, Event, Serialize)]
+#[derive(Debug, Deserialize, Event, Serialize, Clone)]
 struct MappedEvent(Entity);
 
 impl MapNetworkEntities for MappedEvent {
@@ -318,6 +318,8 @@ impl MapNetworkEntities for MappedEvent {
     }
 }
 ```
+
+As shown above, mapped client events must also implement [`Clone`].
 
 There is also [`ClientEventAppExt::add_client_event_with()`] to register an event with special sending and receiving functions.
 This could be used for sending events that contain `Box<dyn Reflect>`, which require access to the `AppTypeRegistry` resource.

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -23,7 +23,9 @@ pub trait ClientEventAppExt {
     ) -> &mut Self;
 
     /// Same as [`Self::add_client_event`], but additionally maps client entities to server before sending.
-    fn add_mapped_client_event<T: Event + Serialize + DeserializeOwned + MapNetworkEntities>(
+    fn add_mapped_client_event_drained<
+        T: Event + Serialize + DeserializeOwned + MapNetworkEntities,
+    >(
         &mut self,
         send_type: impl Into<SendType>,
     ) -> &mut Self;
@@ -114,13 +116,15 @@ impl ClientEventAppExt for App {
         self.add_client_event_with::<T, _, _>(send_type, sending_system::<T>, receiving_system::<T>)
     }
 
-    fn add_mapped_client_event<T: Event + Serialize + DeserializeOwned + MapNetworkEntities>(
+    fn add_mapped_client_event_drained<
+        T: Event + Serialize + DeserializeOwned + MapNetworkEntities,
+    >(
         &mut self,
         send_type: impl Into<SendType>,
     ) -> &mut Self {
         self.add_client_event_with::<T, _, _>(
             send_type,
-            mapping_and_sending_system::<T>,
+            mapping_and_sending_system_drained::<T>,
             receiving_system::<T>,
         )
     }
@@ -193,7 +197,7 @@ fn sending_system<T: Event + Serialize>(
     }
 }
 
-fn mapping_and_sending_system<T: Event + MapNetworkEntities + Serialize>(
+fn mapping_and_sending_system_drained<T: Event + MapNetworkEntities + Serialize>(
     mut events: ResMut<Events<T>>,
     mut client: ResMut<RenetClient>,
     entity_map: Res<ServerEntityMap>,

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -57,7 +57,7 @@ fn mapping_and_sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .add_mapped_client_event_drained::<MappedEvent>(EventType::Ordered);
+            .add_mapped_client_event::<MappedEvent>(EventType::Ordered);
     }
 
     connect::single_client(&mut server_app, &mut client_app);
@@ -108,7 +108,7 @@ fn local_resending() {
 #[derive(Deserialize, Event, Serialize)]
 struct DummyEvent;
 
-#[derive(Deserialize, Event, Serialize)]
+#[derive(Deserialize, Event, Serialize, Clone)]
 struct MappedEvent(Entity);
 
 impl MapNetworkEntities for MappedEvent {

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -57,7 +57,7 @@ fn mapping_and_sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .add_mapped_client_event::<MappedEvent>(EventType::Ordered);
+            .add_mapped_client_event_drained::<MappedEvent>(EventType::Ordered);
     }
 
     connect::single_client(&mut server_app, &mut client_app);


### PR DESCRIPTION
Resolves #195.
The original functionality is accessible via `ClientEventAppExt::add_mapped_client_event_drained`, in case a client event cannot/shouldn't implement `Clone`