### PR TITLE
Remove "entity" from panic message

### DIFF
--- a/src/network_event.rs
+++ b/src/network_event.rs
@@ -13,6 +13,6 @@ impl EntityMapper for EventMapper<'_> {
         *self
             .0
             .get(&entity)
-            .unwrap_or_else(|| panic!("entity {entity:?} should be mappable"))
+            .unwrap_or_else(|| panic!("{entity:?} should be mappable"))
     }
 }


### PR DESCRIPTION
`{entity:?}` already contains the word "Entity". And in the rest of the codebase we also omit "entity".