### PR TITLE
Add links to all third-party types in docs

### DIFF
--- a/bevy_replicon_renet/src/lib.rs
+++ b/bevy_replicon_renet/src/lib.rs
@@ -11,7 +11,7 @@ Renet by default uses the netcode transport which is re-exported by the `renet_t
 
 ## Initialization
 
-Add [`RepliconRenetPlugins`] along with `RepliconPlugins`:
+Add [`RepliconRenetPlugins`] along with [`RepliconPlugins`]:
 
 ```
 use bevy::prelude::*;

--- a/src/client.rs
+++ b/src/client.rs
@@ -483,38 +483,38 @@ pub enum ClientSet {
     ///
     /// Used by messaging backend implementations.
     ///
-    /// Runs in `PreUpdate`.
+    /// Runs in [`PreUpdate`].
     ReceivePackets,
     /// Systems that receive data from [`RepliconClient`].
     ///
     /// Used by `bevy_replicon`.
     ///
-    /// Runs in `PreUpdate`.
+    /// Runs in [`PreUpdate`].
     Receive,
     /// Systems that send data to [`RepliconClient`].
     ///
     /// Used by `bevy_replicon`.
     ///
-    /// Runs in `PostUpdate`.
+    /// Runs in [`PostUpdate`].
     Send,
     /// Systems that send packets to the messaging backend.
     ///
     /// Used by messaging backend implementations.
     ///
-    /// Runs in `PostUpdate`.
+    /// Runs in [`PostUpdate`].
     SendPackets,
     /// Systems that reset queued server events.
     ///
-    /// Runs in `PreUpdate` immediately after the client connects to ensure client sessions have a fresh start.
+    /// Runs in [`PreUpdate`] immediately after the client connects to ensure client sessions have a fresh start.
     ///
-    /// This is a separate set from `ClientSet::Reset` because the reset requirements for events are different
+    /// This is a separate set from [`ClientSet::Reset`] because the reset requirements for events are different
     /// from the replicon client internals.
     /// It is best practice to discard client-sent and server-received events while the client is not connected
     /// in order to guarantee clean separation between connection sessions.
     ResetEvents,
     /// Systems that reset the client.
     ///
-    /// Runs in `PreUpdate` when the client just disconnected.
+    /// Runs in [`PreUpdate`] when the client just disconnected.
     ///
     /// You may want to disable this set if you want to preserve client replication state across reconnects.
     /// In that case, you need to manually repair the client state (or use something like

--- a/src/core/replicon_channels.rs
+++ b/src/core/replicon_channels.rs
@@ -30,7 +30,7 @@ pub struct RepliconChannels {
 
     /// Stores the default max memory usage bytes for all channels.
     ///
-    /// This value will be used instead of `None`.
+    /// This value will be used instead of [`None`].
     /// By default set to `5 * 1024 * 1024`.
     pub default_max_bytes: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ struct DummyComponent;
 
 If your component contains an entity then it cannot be deserialized as is
 because entity IDs are different on server and client. The client should do the
-mapping. Therefore, to replicate such components properly, they need implement
-[`MapEntities`](bevy::ecs::entity::MapEntities) trait and registered
+mapping. Therefore, to replicate such components properly, they need to implement
+the [`MapEntities`](bevy::ecs::entity::MapEntities) trait and register
 using [`AppReplicationExt::replicate_mapped()`]:
 
 ```

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -46,7 +46,7 @@ pub trait ClientEventAppExt {
 
     # Examples
 
-    Serialize an event with `Box<dyn Reflect>`:
+    Serialize an event with [`Box<dyn Reflect>`]:
 
     ```
     use bevy::{prelude::*, reflect::serde::{ReflectSerializer, UntypedReflectDeserializer}};

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -54,7 +54,7 @@ pub trait ServerEventAppExt {
 
     # Examples
 
-    Serialize an event with `Box<dyn Reflect>`:
+    Serialize an event with [`Box<dyn Reflect>`]:
 
     ```
     use std::io::Cursor;

--- a/src/parent_sync.rs
+++ b/src/parent_sync.rs
@@ -72,9 +72,9 @@ impl ParentSyncPlugin {
 
 /// Updates entity parent on change.
 ///
-/// Removes the parent if `None`.
-/// The component captures changes in `PostUpdate` on server before sending
-/// and applies them on `PreUpdate` after receive on clients or scene deserialization.
+/// Removes the parent if [`None`].
+/// The component captures changes in [`PostUpdate`] on server before sending
+/// and applies them on [`PreUpdate`] after receive on clients or scene deserialization.
 #[derive(Component, Default, Reflect, Clone, Copy, Serialize, Deserialize)]
 #[reflect(Component, MapEntities)]
 pub struct ParentSync(Option<Entity>);

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -14,7 +14,7 @@ So on deserialization you need to insert it back if you want entities to continu
 
 # Panics
 
-Panics if any replicated component is not registered using `register_type()`
+Panics if any replicated component is not registered using [`App::register_type`]
 or `#[reflect(Component)]` is missing.
 
 # Examples

--- a/src/server.rs
+++ b/src/server.rs
@@ -490,32 +490,32 @@ pub enum ServerSet {
     ///
     /// Used by the messaging backend.
     ///
-    /// Runs in `PreUpdate`.
+    /// Runs in [`PreUpdate`].
     ReceivePackets,
     /// Systems that emit [`ServerEvent`].
     ///
     /// The messaging backend should convert its own connection events into [`ServerEvents`](ServerEvent)
     /// in this set.
     ///
-    /// Runs in `PreUpdate`.
+    /// Runs in [`PreUpdate`].
     SendEvents,
     /// Systems that receive data from [`RepliconServer`].
     ///
     /// Used by `bevy_replicon`.
     ///
-    /// Runs in `PreUpdate`.
+    /// Runs in [`PreUpdate`].
     Receive,
     /// Systems that send data to [`RepliconServer`].
     ///
     /// Used by `bevy_replicon`.
     ///
-    /// Runs in `PostUpdate` on server tick, see [`TickPolicy`].
+    /// Runs in [`PostUpdate`] on server tick, see [`TickPolicy`].
     Send,
     /// Systems that send packets to the messaging backend.
     ///
     /// Used by the messaging backend.
     ///
-    /// Runs in `PostUpdate` on server tick, see [`TickPolicy`].
+    /// Runs in [`PostUpdate`] on server tick, see [`TickPolicy`].
     SendPackets,
 }
 
@@ -621,7 +621,7 @@ fn confirm_bullet(
 
 If the client is connected and receives the replication data for the server entity mapping,
 replicated data will be applied to the client's original entity instead of spawning a new one.
-You can detect when the mapping is replicated by querying for `Added<Replication>` on your original
+You can detect when the mapping is replicated by querying for [`Added<Replication>`] on your original
 client entity.
 
 If client's original entity is not found, a new entity will be spawned on the client,

--- a/src/server/connected_clients/client_visibility.rs
+++ b/src/server/connected_clients/client_visibility.rs
@@ -326,7 +326,7 @@ enum BlacklistInfo {
 /// Visibility state for an entity in the current tick, from the perspective of one client.
 ///
 /// Note that the distinction between 'lost visibility' and 'don't have visibility' is not exposed here.
-/// There is only `Visibility::Hidden` to encompass both variants.
+/// There is only [`Visibility::Hidden`] to encompass both variants.
 ///
 /// Lost visibility is handled separately with [`ClientVisibility::drain_lost_visibility`].
 #[derive(PartialEq, Default, Clone, Copy)]

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -672,8 +672,8 @@ fn can_pack(header_size: usize, base: usize, add: usize) -> bool {
 /// Serializes `entity` by writing its index and generation as separate varints.
 ///
 /// The index is first prepended with a bit flag to indicate if the generation
-/// is serialized or not. It is not serialized if <= 1; note that generations are `NonZeroU32`
-/// and a value of zero is used in `Option<Entity>` to signify `None`, so generation 1 is the first
+/// is serialized or not. It is not serialized if <= 1; note that generations are [`NonZeroU32`](std::num::NonZeroU32)
+/// and a value of zero is used in [`Option<Entity>`] to signify [`None`], so generation 1 is the first
 /// generation.
 fn serialize_entity(cursor: &mut Cursor<Vec<u8>>, entity: Entity) -> bincode::Result<()> {
     let mut flagged_index = (entity.index() as u64) << 1;


### PR DESCRIPTION
The issue has been fixed:
https://mastodon.social/@imperio@toot.cat/112014123840616210. Now links to non-reexported types will work on docs.rs.