### PR TITLE
Add `ServerSet::StoreHierarchy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ServerSet::StoreHierarchy` for systems that store hierarchy changes in `ParentSync`.
+
 ## [0.24.1] - 2024-03-07
 
 ### Fixed

--- a/src/parent_sync.rs
+++ b/src/parent_sync.rs
@@ -18,6 +18,8 @@ pub struct ParentSyncPlugin;
 /// Automatically updates hierarchy on client if [`ParentSync`] component is present on entity.
 ///
 /// This allows to save / replicate hierarchy using only single component.
+/// If your system runs in [`PostUpdate`] and modifies hierarchy with [`ParentSync`],
+/// you need to run it before [`ServerSet::StoreHierarchy`].
 impl Plugin for ParentSyncPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Option<Entity>>()
@@ -28,7 +30,7 @@ impl Plugin for ParentSyncPlugin {
                 PostUpdate,
                 (Self::store_changes, Self::store_removals)
                     .run_if(has_authority)
-                    .before(ServerSet::Send),
+                    .in_set(ServerSet::StoreHierarchy),
             );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -79,7 +79,12 @@ impl Plugin for ServerPlugin {
             )
             .configure_sets(
                 PostUpdate,
-                (ServerSet::Send, ServerSet::SendPackets).chain(),
+                (
+                    ServerSet::StoreHierarchy,
+                    ServerSet::Send,
+                    ServerSet::SendPackets,
+                )
+                    .chain(),
             )
             .add_systems(Startup, Self::setup_channels)
             .add_systems(
@@ -504,6 +509,10 @@ pub enum ServerSet {
     ///
     /// Runs in [`PreUpdate`].
     Receive,
+    /// Systems that store hierarchy changes in [`ParentSync`](super::parent_sync::ParentSync).
+    ///
+    /// Runs in [`PostUpdate`].
+    StoreHierarchy,
     /// Systems that send data to [`RepliconServer`].
     ///
     /// Used by `bevy_replicon`.


### PR DESCRIPTION
For systems that store hierarchy changes in `ParentSync`.