### PR TITLE
Make the simple_box example update continuously while unfocused

### DIFF
--- a/bevy_replicon_renet/examples/simple_box.rs
+++ b/bevy_replicon_renet/examples/simple_box.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 fn main() {
     App::new()
         .init_resource::<Cli>() // Parse CLI before creating window.
-        // Makes the server update continuously even while unfocused.
+        // Makes the server/client update continuously even while unfocused.
         .insert_resource(WinitSettings {
             focused_mode: Continuous,
             unfocused_mode: Continuous,

--- a/bevy_replicon_renet/examples/simple_box.rs
+++ b/bevy_replicon_renet/examples/simple_box.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bevy::prelude::*;
+use bevy::winit::{UpdateMode::Continuous, WinitSettings};
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
     renet::{
@@ -25,6 +26,11 @@ use serde::{Deserialize, Serialize};
 fn main() {
     App::new()
         .init_resource::<Cli>() // Parse CLI before creating window.
+        // Makes the server update continuously even while unfocused.
+        .insert_resource(WinitSettings {
+            focused_mode: Continuous,
+            unfocused_mode: Continuous,
+        })
         .add_plugins((
             DefaultPlugins,
             RepliconPlugins,

--- a/bevy_replicon_renet/examples/simple_box.rs
+++ b/bevy_replicon_renet/examples/simple_box.rs
@@ -7,8 +7,10 @@ use std::{
     time::SystemTime,
 };
 
-use bevy::prelude::*;
-use bevy::winit::{UpdateMode::Continuous, WinitSettings};
+use bevy::{
+    prelude::*,
+    winit::{UpdateMode::Continuous, WinitSettings},
+};
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
     renet::{


### PR DESCRIPTION
If the server window was unfocused, the client and server would have different deltas, causing the client's box to move significantly faster.