### PR TITLE
Rename `Replication` into `Replicated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename `Replication` into `Replicated`. Old name is still available via deprecated alias.
 - Send all component mappings, inserts, removals and despawns over reliable channel in form of deltas and component updates over unreliable channel packed by packet size. This significantly reduces the possibility of packet loss.
 - Replace `REPLICATION_CHANNEL_ID` with `ReplicationChannel` enum. The previous constant corresponded to the unreliable channel.
 - Server events use tick with the last change instead of waiting for replication message without changes.

--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -65,7 +65,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
 
                     server_app
                         .world
-                        .spawn_batch(vec![(Replication, C::default()); ENTITIES as usize]);
+                        .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
 
                     let instant = Instant::now();
                     server_app.update();
@@ -96,7 +96,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
 
                 server_app
                     .world
-                    .spawn_batch(vec![(Replication, C::default()); ENTITIES as usize]);
+                    .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
                 let mut query = server_app.world.query::<&mut C>();
 
                 server_app.update();
@@ -139,7 +139,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
 
                 server_app
                     .world
-                    .spawn_batch(vec![(Replication, C::default()); ENTITIES as usize]);
+                    .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
 
                 server_app.update();
                 server_app.exchange_with_client(&mut client_app);
@@ -163,7 +163,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
 
             server_app
                 .world
-                .spawn_batch(vec![(Replication, C::default()); ENTITIES as usize]);
+                .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
             let mut query = server_app.world.query::<&mut C>();
 
             server_app.update();

--- a/bevy_replicon_renet/examples/simple_box.rs
+++ b/bevy_replicon_renet/examples/simple_box.rs
@@ -265,7 +265,7 @@ struct PlayerBundle {
     player: Player,
     position: PlayerPosition,
     color: PlayerColor,
-    replication: Replication,
+    replicated: Replicated,
 }
 
 impl PlayerBundle {
@@ -274,7 +274,7 @@ impl PlayerBundle {
             player: Player(client_id),
             position: PlayerPosition(position),
             color: PlayerColor(color),
-            replication: Replication,
+            replicated: Replicated,
         }
     }
 }

--- a/bevy_replicon_renet/examples/tic_tac_toe.rs
+++ b/bevy_replicon_renet/examples/tic_tac_toe.rs
@@ -634,7 +634,7 @@ struct GridNode;
 struct SymbolBundle {
     symbol: Symbol,
     cell_index: CellIndex,
-    replication: Replication,
+    replicated: Replicated,
 }
 
 impl SymbolBundle {
@@ -642,7 +642,7 @@ impl SymbolBundle {
         Self {
             cell_index: CellIndex(index),
             symbol,
-            replication: Replication,
+            replicated: Replicated,
         }
     }
 }
@@ -656,7 +656,7 @@ struct CellIndex(usize);
 struct PlayerBundle {
     player: Player,
     symbol: Symbol,
-    replication: Replication,
+    replicated: Replicated,
 }
 
 impl PlayerBundle {
@@ -664,7 +664,7 @@ impl PlayerBundle {
         Self {
             player: Player(client_id),
             symbol,
-            replication: Replication,
+            replicated: Replicated,
         }
     }
 

--- a/bevy_replicon_renet/tests/transport.rs
+++ b/bevy_replicon_renet/tests/transport.rs
@@ -66,7 +66,7 @@ fn replication() {
 
     setup(&mut server_app, &mut client_app);
 
-    server_app.world.spawn(Replication);
+    server_app.world.spawn(Replicated);
 
     server_app.update();
     client_app.update();

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,7 +18,7 @@ use crate::core::{
     replication_fns::ReplicationFns,
     replicon_channels::{ReplicationChannel, RepliconChannels},
     replicon_tick::RepliconTick,
-    Replication,
+    Replicated,
 };
 use client_mapper::ServerEntityMap;
 use diagnostics::ClientStats;
@@ -345,7 +345,7 @@ fn apply_entity_mappings(
 
         if let Some(mut entity) = world.get_entity_mut(client_entity) {
             debug!("received mapping from {server_entity:?} to {client_entity:?}");
-            entity.insert(Replication);
+            entity.insert(Replicated);
             entity_map.insert(server_entity, client_entity);
         } else {
             // Entity could be despawned on client already.
@@ -374,7 +374,7 @@ fn apply_init_components(
         let data_size: u16 = bincode::deserialize_from(&mut *cursor)?;
 
         let client_entity =
-            entity_map.get_by_server_or_insert(server_entity, || world.spawn(Replication).id());
+            entity_map.get_by_server_or_insert(server_entity, || world.spawn(Replicated).id());
         entity_ticks.insert(client_entity, replicon_tick);
 
         let (mut entity_markers, mut commands, mut query) = state.get_mut(world);

--- a/src/client/client_mapper.rs
+++ b/src/client/client_mapper.rs
@@ -1,6 +1,6 @@
 use bevy::{ecs::entity::EntityHashMap, prelude::*, utils::hashbrown::hash_map::Entry};
 
-use crate::core::Replication;
+use crate::core::Replicated;
 
 /// Maps server entities into client entities inside components.
 ///
@@ -17,7 +17,7 @@ impl EntityMapper for ClientMapper<'_, '_, '_> {
             .server_to_client
             .entry(entity)
             .or_insert_with(|| {
-                let client_entity = self.commands.spawn(Replication).id();
+                let client_entity = self.commands.spawn(Replicated).id();
                 self.entity_map
                     .client_to_server
                     .insert(client_entity, entity);

--- a/src/core.rs
+++ b/src/core.rs
@@ -18,7 +18,7 @@ pub struct RepliconCorePlugin;
 
 impl Plugin for RepliconCorePlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Replication>()
+        app.register_type::<Replicated>()
             .init_resource::<RepliconTick>()
             .init_resource::<RepliconChannels>()
             .init_resource::<ReplicationFns>()
@@ -27,10 +27,13 @@ impl Plugin for RepliconCorePlugin {
     }
 }
 
+#[deprecated(note = "use `Replicated` instead")]
+pub type Replication = Replicated;
+
 /// Marks entity for replication.
 #[derive(Component, Clone, Copy, Default, Reflect, Debug)]
 #[reflect(Component)]
-pub struct Replication;
+pub struct Replicated;
 
 /// Unique client ID.
 ///

--- a/src/core/replication_rules.rs
+++ b/src/core/replication_rules.rs
@@ -13,7 +13,7 @@ use super::replication_fns::{rule_fns::RuleFns, FnsInfo, ReplicationFns};
 pub trait AppRuleExt {
     /// Creates a replication rule for a single component.
     ///
-    /// The component will be replicated if its entity contains the [`Replication`](super::Replication)
+    /// The component will be replicated if its entity contains the [`Replicated`](super::Replicated)
     /// marker component.
     ///
     /// Component will be serialized and deserialized as-is using bincode.
@@ -255,7 +255,7 @@ app.replicate_group::<PlayerBundle>();
 struct PlayerBundle {
     transform: Transform,
     player: Player,
-    replication: Replication,
+    replicated: Replicated,
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,12 +81,12 @@ and components need to be replicated.
 
 #### Entities
 
-By default no entities are replicated. Add the [`Replication`] marker
+By default no entities are replicated. Add the [`Replicated`] marker
 component on the server for entities you want to replicate.
 
-On clients [`Replication`] will be automatically inserted to newly-replicated entities.
+On clients [`Replicated`] will be automatically inserted to newly-replicated entities.
 
-If you remove the [`Replication`] component from an entity on the server, it will be despawned on all clients.
+If you remove the [`Replicated`] component from an entity on the server, it will be despawned on all clients.
 
 #### Components
 
@@ -209,7 +209,7 @@ fn init_player(
 struct PlayerBundle {
     player: Player,
     transform: Transform,
-    replication: Replication,
+    replicated: Replicated,
 }
 
 #[derive(Component, Deserialize, Serialize)]
@@ -458,6 +458,9 @@ pub mod server;
 pub mod test_app;
 
 pub mod prelude {
+    #[allow(deprecated)]
+    pub use super::core::Replication;
+
     pub use super::{
         client::{
             diagnostics::{ClientDiagnosticsPlugin, ClientStats},
@@ -469,7 +472,7 @@ pub mod prelude {
             common_conditions::*,
             replication_rules::AppRuleExt,
             replicon_channels::{ChannelKind, RepliconChannel, RepliconChannels},
-            ClientId, Replication, RepliconCorePlugin,
+            ClientId, Replicated, RepliconCorePlugin,
         },
         network_event::{
             client_event::{ClientEventAppExt, FromClient},

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,11 +1,11 @@
 use bevy::{ecs::entity::EntityHashMap, prelude::*, scene::DynamicEntity};
 
-use crate::{core::replication_rules::ReplicationRules, Replication};
+use crate::{core::replication_rules::ReplicationRules, Replicated};
 
 /**
 Fills scene with all replicated entities and their components.
 
-Entities won't have the [`Replication`] component.
+Entities won't have the [`Replicated`] component.
 So on deserialization you need to insert it back if you want entities to continue to replicate.
 
 # Panics
@@ -40,14 +40,14 @@ let mut scene = scene_deserializer
     .deserialize(&mut deserializer)
     .expect("ron should be convertible to scene");
 
-// Re-insert `Replication` component.
+// Re-insert `Replicated` component.
 for entity in &mut scene.entities {
-    entity.components.push(Replication.clone_value());
+    entity.components.push(Replicated.clone_value());
 }
 ```
 */
 pub fn replicate_into(scene: &mut DynamicScene, world: &World) {
-    let Some(marker_id) = world.component_id::<Replication>() else {
+    let Some(marker_id) = world.component_id::<Replicated>() else {
         // Components are initialized lazily.
         // If there is no replication marker, then we have nothing to replicate.
         return;

--- a/src/server.rs
+++ b/src/server.rs
@@ -637,7 +637,7 @@ fn confirm_bullet(
 
 If the client is connected and receives the replication data for the server entity mapping,
 replicated data will be applied to the client's original entity instead of spawning a new one.
-You can detect when the mapping is replicated by querying for [`Added<Replication>`] on your original
+You can detect when the mapping is replicated by querying for [`Added<Replicated>`] on your original
 client entity.
 
 If client's original entity is not found, a new entity will be spawned on the client,

--- a/src/server/despawn_buffer.rs
+++ b/src/server/despawn_buffer.rs
@@ -1,9 +1,9 @@
 use bevy::prelude::*;
 
 use super::{ServerPlugin, ServerSet};
-use crate::core::{common_conditions::server_running, Replication};
+use crate::core::{common_conditions::server_running, Replicated};
 
-/// Treats removals of [`Replication`] component as despawns and stores them into [`DespawnBuffer`] resource.
+/// Treats removals of [`Replicated`] component as despawns and stores them into [`DespawnBuffer`] resource.
 ///
 /// Used to avoid missing events in case the server's tick policy is not [`TickPolicy::EveryFrame`].
 pub(super) struct DespawnBufferPlugin;
@@ -22,7 +22,7 @@ impl Plugin for DespawnBufferPlugin {
 
 impl DespawnBufferPlugin {
     fn buffer_despawns(
-        mut removed_replications: RemovedComponents<Replication>,
+        mut removed_replications: RemovedComponents<Replicated>,
         mut despawn_buffer: ResMut<DespawnBuffer>,
     ) {
         for entity in removed_replications.read() {
@@ -52,7 +52,7 @@ mod tests {
 
         app.update();
 
-        app.world.spawn(Replication).despawn();
+        app.world.spawn(Replicated).despawn();
 
         app.update();
 

--- a/src/server/removal_buffer.rs
+++ b/src/server/removal_buffer.rs
@@ -14,7 +14,7 @@ use bevy::{
 use super::{ServerPlugin, ServerSet};
 use crate::core::{
     common_conditions::server_running, replication_fns::FnsInfo,
-    replication_rules::ReplicationRules, Replication,
+    replication_rules::ReplicationRules, Replicated,
 };
 
 /// Buffers all replicated component removals in [`RemovalBuffer`] resource.
@@ -77,7 +77,7 @@ struct RemovalReader<'w, 's> {
     remove_events: &'w RemovedComponentEvents,
 
     /// Filter for replicated and valid entities.
-    replicated: Query<'w, 's, (), With<Replication>>,
+    replicated: Query<'w, 's, (), With<Replicated>>,
 }
 
 impl RemovalReader<'_, '_> {
@@ -205,7 +205,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{replication_fns::ReplicationFns, replication_rules::AppRuleExt, Replication},
+        core::{replication_fns::ReplicationFns, replication_rules::AppRuleExt, Replicated},
         server::replicon_server::RepliconServer,
     };
 
@@ -222,7 +222,7 @@ mod tests {
         app.update();
 
         app.world
-            .spawn((Replication, ComponentA))
+            .spawn((Replicated, ComponentA))
             .remove::<ComponentA>();
 
         app.update();
@@ -245,7 +245,7 @@ mod tests {
         app.update();
 
         app.world
-            .spawn((Replication, ComponentA))
+            .spawn((Replicated, ComponentA))
             .remove::<ComponentA>();
 
         app.update();
@@ -271,7 +271,7 @@ mod tests {
         app.update();
 
         app.world
-            .spawn((Replication, ComponentA, ComponentB))
+            .spawn((Replicated, ComponentA, ComponentB))
             .remove::<(ComponentA, ComponentB)>();
 
         app.update();
@@ -297,7 +297,7 @@ mod tests {
         app.update();
 
         app.world
-            .spawn((Replication, ComponentA, ComponentB))
+            .spawn((Replicated, ComponentA, ComponentB))
             .remove::<ComponentA>();
 
         app.update();
@@ -324,7 +324,7 @@ mod tests {
         app.update();
 
         app.world
-            .spawn((Replication, ComponentA, ComponentB))
+            .spawn((Replicated, ComponentA, ComponentB))
             .remove::<(ComponentA, ComponentB)>();
 
         app.update();
@@ -351,7 +351,7 @@ mod tests {
         app.update();
 
         app.world
-            .spawn((Replication, ComponentA, ComponentB))
+            .spawn((Replicated, ComponentA, ComponentB))
             .remove::<ComponentA>();
 
         app.update();
@@ -376,7 +376,7 @@ mod tests {
 
         app.update();
 
-        app.world.spawn((ComponentA, Replication)).despawn();
+        app.world.spawn((ComponentA, Replicated)).despawn();
 
         app.update();
 

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -10,12 +10,12 @@ use bevy::{
     utils::tracing::enabled,
 };
 
-use crate::core::{replication_fns::FnsId, replication_rules::ReplicationRules, Replication};
+use crate::core::{replication_fns::FnsId, replication_rules::ReplicationRules, Replicated};
 
 /// Cached information about all replicated archetypes.
 #[derive(Deref)]
 pub(crate) struct ReplicatedArchetypes {
-    /// ID of [`Replication`] component.
+    /// ID of [`Replicated`] component.
     marker_id: ComponentId,
 
     /// Highest processed archetype ID.
@@ -27,7 +27,7 @@ pub(crate) struct ReplicatedArchetypes {
 }
 
 impl ReplicatedArchetypes {
-    /// ID of the [`Replication`] component.
+    /// ID of the [`Replicated`] component.
     pub(crate) fn marker_id(&self) -> ComponentId {
         self.marker_id
     }
@@ -95,7 +95,7 @@ impl ReplicatedArchetypes {
 impl FromWorld for ReplicatedArchetypes {
     fn from_world(world: &mut World) -> Self {
         Self {
-            marker_id: world.init_component::<Replication>(),
+            marker_id: world.init_component::<Replicated>(),
             generation: ArchetypeGeneration::initial(),
             archetypes: Default::default(),
         }
@@ -150,7 +150,7 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<ReplicationRules>();
 
-        app.world.spawn(Replication);
+        app.world.spawn(Replicated);
 
         let archetypes = match_archetypes(&mut app.world);
         assert_eq!(archetypes.len(), 1);
@@ -166,7 +166,7 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate::<ComponentA>();
 
-        app.world.spawn((Replication, ComponentB));
+        app.world.spawn((Replicated, ComponentB));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();
@@ -180,7 +180,7 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate::<ComponentA>();
 
-        app.world.spawn((Replication, ComponentA));
+        app.world.spawn((Replicated, ComponentA));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();
@@ -194,7 +194,7 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replication, ComponentA, ComponentB));
+        app.world.spawn((Replicated, ComponentA, ComponentB));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();
@@ -208,7 +208,7 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replication, ComponentA));
+        app.world.spawn((Replicated, ComponentA));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();
@@ -223,7 +223,7 @@ mod tests {
             .replicate::<ComponentA>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replication, ComponentA, ComponentB));
+        app.world.spawn((Replicated, ComponentA, ComponentB));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();
@@ -239,7 +239,7 @@ mod tests {
             .replicate::<ComponentB>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replication, ComponentA, ComponentB));
+        app.world.spawn((Replicated, ComponentA, ComponentB));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();
@@ -255,7 +255,7 @@ mod tests {
             .replicate_group::<(ComponentA, ComponentB)>();
 
         app.world
-            .spawn((Replication, ComponentA, ComponentB, ComponentC));
+            .spawn((Replicated, ComponentA, ComponentB, ComponentC));
 
         let archetypes = match_archetypes(&mut app.world);
         let archetype = archetypes.first().unwrap();

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -33,7 +33,7 @@ for app in [&mut server_app, &mut client_app] {
 // - client app will be in connected state.
 server_app.connect_client(&mut client_app);
 
-server_app.world.spawn(Replication);
+server_app.world.spawn(Replicated);
 
 // Run tick for each app and trigger message exchange.
 server_app.update();

--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -34,7 +34,7 @@ fn small_component() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, BoolComponent(false)))
+        .spawn((Replicated, BoolComponent(false)))
         .id();
 
     server_app.update();
@@ -84,7 +84,7 @@ fn package_size_component() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, VecComponent::default()))
+        .spawn((Replicated, VecComponent::default()))
         .id();
 
     server_app.update();
@@ -134,12 +134,12 @@ fn command_fns() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, OriginalComponent(false)))
+        .spawn((Replicated, OriginalComponent(false)))
         .id();
 
     let client_entity = client_app
         .world
-        .spawn((Replication, ReplacedComponent(false)))
+        .spawn((Replicated, ReplacedComponent(false)))
         .id();
 
     client_app
@@ -194,12 +194,12 @@ fn marker() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, OriginalComponent(false)))
+        .spawn((Replicated, OriginalComponent(false)))
         .id();
 
     let client_entity = client_app
         .world
-        .spawn((Replication, ReplaceMarker, ReplacedComponent(false)))
+        .spawn((Replicated, ReplaceMarker, ReplacedComponent(false)))
         .id();
 
     client_app
@@ -251,7 +251,7 @@ fn many_entities() {
     const ENTITIES_COUNT: u32 = 300;
     server_app
         .world
-        .spawn_batch([(Replication, BoolComponent(false)); ENTITIES_COUNT as usize]);
+        .spawn_batch([(Replicated, BoolComponent(false)); ENTITIES_COUNT as usize]);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -301,7 +301,7 @@ fn with_insertion() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, BoolComponent(false)))
+        .spawn((Replicated, BoolComponent(false)))
         .id();
 
     server_app.update();
@@ -343,7 +343,7 @@ fn with_despawn() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, BoolComponent(false)))
+        .spawn((Replicated, BoolComponent(false)))
         .id();
 
     server_app.update();
@@ -390,7 +390,7 @@ fn buffering() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, BoolComponent(false)))
+        .spawn((Replicated, BoolComponent(false)))
         .id();
 
     let previous_tick = *server_app.world.resource::<RepliconTick>();
@@ -453,7 +453,7 @@ fn acknowledgment() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, BoolComponent(false)))
+        .spawn((Replicated, BoolComponent(false)))
         .id();
 
     server_app.update();

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -20,8 +20,8 @@ fn single() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
-    let client_entity = client_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
+    let client_entity = client_app.world.spawn(Replicated).id();
 
     client_app
         .world
@@ -57,17 +57,17 @@ fn with_heirarchy() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_child_entity = server_app.world.spawn(Replication).id();
+    let server_child_entity = server_app.world.spawn(Replicated).id();
     let server_entity = server_app
         .world
-        .spawn(Replication)
+        .spawn(Replicated)
         .push_children(&[server_child_entity])
         .id();
 
-    let client_child_entity = client_app.world.spawn(Replication).id();
+    let client_child_entity = client_app.world.spawn(Replicated).id();
     let client_entity = client_app
         .world
-        .spawn(Replication)
+        .spawn(Replicated)
         .push_children(&[client_child_entity])
         .id();
 
@@ -105,11 +105,11 @@ fn after_spawn() {
 
     server_app.connect_client(&mut client_app);
 
-    // Insert and remove `Replication` to trigger spawn and despawn for client at the same time.
+    // Insert and remove `Replicated` to trigger spawn and despawn for client at the same time.
     server_app
         .world
-        .spawn((Replication, DummyComponent))
-        .remove::<Replication>();
+        .spawn((Replicated, DummyComponent))
+        .remove::<Replicated>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -32,7 +32,7 @@ fn table_storage() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -71,7 +71,7 @@ fn sparse_set_storage() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -113,7 +113,7 @@ fn mapped_existing_entity() {
     // Make client and server have different entity IDs.
     server_app.world.spawn_empty();
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
     let server_map_entity = server_app.world.spawn_empty().id();
     let client_map_entity = client_app.world.spawn_empty().id();
 
@@ -163,7 +163,7 @@ fn mapped_new_entity() {
     // Make client and server have different entity IDs.
     server_app.world.spawn_empty();
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
     let server_map_entity = server_app.world.spawn_empty().id();
 
     server_app.update();
@@ -209,7 +209,7 @@ fn command_fns() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -253,8 +253,8 @@ fn marker() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
-    let client_entity = client_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
+    let client_entity = client_app.world.spawn(Replicated).id();
 
     client_app
         .world
@@ -302,7 +302,7 @@ fn group() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -340,7 +340,7 @@ fn not_replicated() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -381,7 +381,7 @@ fn after_removal() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, TableComponent)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/other.rs
+++ b/tests/other.rs
@@ -163,7 +163,7 @@ fn diagnostics() {
     server_app.connect_client(&mut client_app);
 
     let client_entity = client_app.world.spawn_empty().id();
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();
@@ -177,7 +177,7 @@ fn diagnostics() {
         },
     );
 
-    server_app.world.spawn(Replication).despawn();
+    server_app.world.spawn(Replicated).despawn();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -24,8 +24,8 @@ fn single() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
-    let client_entity = client_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let client_entity = client_app.world.spawn((Replicated, DummyComponent)).id();
 
     client_app
         .world
@@ -71,11 +71,8 @@ fn command_fns() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
-    let client_entity = client_app
-        .world
-        .spawn((Replication, RemovingComponent))
-        .id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let client_entity = client_app.world.spawn((Replicated, RemovingComponent)).id();
 
     client_app
         .world
@@ -122,10 +119,10 @@ fn marker() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
     let client_entity = client_app
         .world
-        .spawn((Replication, RemoveMarker, RemovingComponent))
+        .spawn((Replicated, RemoveMarker, RemovingComponent))
         .id();
 
     client_app
@@ -170,12 +167,12 @@ fn group() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, (GroupComponentA, GroupComponentB)))
+        .spawn((Replicated, (GroupComponentA, GroupComponentB)))
         .id();
 
     let client_entity = client_app
         .world
-        .spawn((Replication, (GroupComponentA, GroupComponentB)))
+        .spawn((Replicated, (GroupComponentA, GroupComponentB)))
         .id();
 
     client_app
@@ -220,12 +217,12 @@ fn not_replicated() {
 
     let server_entity = server_app
         .world
-        .spawn((Replication, NotReplicatedComponent))
+        .spawn((Replicated, NotReplicatedComponent))
         .id();
 
     let client_entity = client_app
         .world
-        .spawn((Replication, NotReplicatedComponent))
+        .spawn((Replicated, NotReplicatedComponent))
         .id();
 
     client_app
@@ -268,8 +265,8 @@ fn after_insertion() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
-    let client_entity = client_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let client_entity = client_app.world.spawn((Replicated, DummyComponent)).id();
 
     client_app
         .world
@@ -313,8 +310,8 @@ fn with_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
-    let client_entity = client_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let client_entity = client_app.world.spawn((Replicated, DummyComponent)).id();
 
     client_app
         .world
@@ -331,7 +328,7 @@ fn with_despawn() {
         .world
         .entity_mut(server_entity)
         .remove::<DummyComponent>()
-        .remove::<Replication>();
+        .remove::<Replicated>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -9,7 +9,7 @@ fn replicated_entity() {
         .register_type::<DummyComponent>()
         .replicate::<DummyComponent>();
 
-    let entity = app.world.spawn((Replication, DummyComponent)).id();
+    let entity = app.world.spawn((Replicated, DummyComponent)).id();
 
     let mut scene = DynamicScene::default();
     scene::replicate_into(&mut scene, &app.world);
@@ -27,7 +27,7 @@ fn empty_entity() {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins);
 
-    let entity = app.world.spawn(Replication).id();
+    let entity = app.world.spawn(Replicated).id();
 
     // Extend with replicated components.
     let mut scene = DynamicScene::default();
@@ -67,7 +67,7 @@ fn entity_update() {
 
     let entity = app
         .world
-        .spawn((Replication, DummyComponent, OtherReflectedComponent))
+        .spawn((Replicated, DummyComponent, OtherReflectedComponent))
         .id();
 
     // Populate scene only with a single non-replicated component.

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -177,7 +177,7 @@ fn event_queue() {
     server_app.connect_client(&mut client_app);
 
     // Spawn entity to trigger world change.
-    server_app.world.spawn((Replication, DummyComponent));
+    server_app.world.spawn((Replicated, DummyComponent));
     let previous_tick = *server_app.world.resource::<RepliconTick>();
 
     server_app.update();
@@ -226,7 +226,7 @@ fn different_ticks() {
     server_app.connect_client(&mut client_app1);
 
     // Spawn entity to trigger world change.
-    server_app.world.spawn((Replication, DummyComponent));
+    server_app.world.spawn((Replicated, DummyComponent));
 
     // Update client 1 to initialize their replicon tick.
     server_app.update();

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -20,7 +20,7 @@ fn empty() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -28,7 +28,7 @@ fn empty() {
 
     let client_entity = client_app
         .world
-        .query_filtered::<Entity, With<Replication>>()
+        .query_filtered::<Entity, With<Replicated>>()
         .single(&client_app.world);
 
     let entity_map = client_app.world.resource::<ServerEntityMap>();
@@ -61,7 +61,7 @@ fn with_component() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world.spawn((Replication, DummyComponent));
+    server_app.world.spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -69,7 +69,7 @@ fn with_component() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 
@@ -104,7 +104,7 @@ fn with_old_component() {
     server_app
         .world
         .entity_mut(server_entity)
-        .insert(Replication);
+        .insert(Replicated);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -112,7 +112,7 @@ fn with_old_component() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 
@@ -132,7 +132,7 @@ fn before_connection() {
     }
 
     // Spawn an entity before client connected.
-    server_app.world.spawn((Replication, DummyComponent));
+    server_app.world.spawn((Replicated, DummyComponent));
 
     server_app.connect_client(&mut client_app);
 
@@ -141,7 +141,7 @@ fn before_connection() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 
@@ -166,7 +166,7 @@ fn pre_spawn() {
     server_app.world.spawn_empty();
 
     let client_entity = client_app.world.spawn_empty().id();
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();
@@ -198,7 +198,7 @@ fn pre_spawn() {
 
     let client_entity = client_app.world.entity(client_entity);
     assert!(
-        client_entity.contains::<Replication>(),
+        client_entity.contains::<Replicated>(),
         "server should confirm replication of client entity"
     );
     assert!(
@@ -230,12 +230,12 @@ fn after_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    // Remove and insert `Replication` to trigger despawn and spawn for client at the same time.
+    // Remove and insert `Replicated` to trigger despawn and spawn for client at the same time.
     server_app
         .world
-        .spawn((Replication, DummyComponent))
-        .remove::<Replication>()
-        .insert(Replication);
+        .spawn((Replicated, DummyComponent))
+        .remove::<Replicated>()
+        .insert(Replicated);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -243,7 +243,7 @@ fn after_despawn() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -19,7 +19,7 @@ fn all() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();
@@ -34,7 +34,7 @@ fn all() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 
     // Reverse visibility back.
@@ -48,7 +48,7 @@ fn all() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 
@@ -70,7 +70,7 @@ fn empty_blacklist() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world.spawn((Replication, DummyComponent));
+    server_app.world.spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -78,7 +78,7 @@ fn empty_blacklist() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 
@@ -100,7 +100,7 @@ fn blacklist() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();
@@ -126,7 +126,7 @@ fn blacklist() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 }
 
@@ -148,7 +148,7 @@ fn blacklist_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();
@@ -186,7 +186,7 @@ fn empty_whitelist() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world.spawn((Replication, DummyComponent));
+    server_app.world.spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -216,7 +216,7 @@ fn whitelist() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();
@@ -231,7 +231,7 @@ fn whitelist() {
 
     client_app
         .world
-        .query_filtered::<(), (With<Replication>, With<DummyComponent>)>()
+        .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
         .single(&client_app.world);
 
     // Reverse visibility.
@@ -267,7 +267,7 @@ fn whitelist_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replication).id();
+    let server_entity = server_app.world.spawn(Replicated).id();
 
     let client = client_app.world.resource::<RepliconClient>();
     let client_id = client.id().unwrap();


### PR DESCRIPTION
Old name is still available via deprecated alias.