### PR TITLE
Remove `CommandFns`

### DIFF
--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -4,10 +4,7 @@ use bevy::{prelude::*, utils::Duration};
 use bevy_replicon::{
     client::client_mapper::{ClientMapper, ServerEntityMap},
     core::{
-        replication_fns::{
-            command_fns::{self, CommandFns},
-            rule_fns::RuleFns,
-        },
+        replication_fns::{command_fns, rule_fns::RuleFns},
         replicon_tick::RepliconTick,
     },
     prelude::*,
@@ -124,10 +121,7 @@ fn command_fns() {
             }),
         ))
         .replicate::<OriginalComponent>()
-        .set_command_fns(CommandFns::new(
-            replace,
-            command_fns::default_remove::<ReplacedComponent>,
-        ));
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
     }
 
     server_app.connect_client(&mut client_app);
@@ -184,10 +178,10 @@ fn marker() {
         ))
         .register_marker::<ReplaceMarker>()
         .replicate::<OriginalComponent>()
-        .set_marker_fns::<ReplaceMarker, _>(CommandFns::new(
+        .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        ));
+        );
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -4,10 +4,7 @@ use bevy::{ecs::entity::MapEntities, prelude::*};
 use bevy_replicon::{
     client::client_mapper::{ClientMapper, ServerEntityMap},
     core::{
-        replication_fns::{
-            command_fns::{self, CommandFns},
-            rule_fns::RuleFns,
-        },
+        replication_fns::{command_fns, rule_fns::RuleFns},
         replicon_tick::RepliconTick,
     },
     prelude::*,
@@ -201,10 +198,7 @@ fn command_fns() {
             }),
         ))
         .replicate::<OriginalComponent>()
-        .set_command_fns(CommandFns::new(
-            replace,
-            command_fns::default_remove::<ReplacedComponent>,
-        ));
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
     }
 
     server_app.connect_client(&mut client_app);
@@ -245,10 +239,10 @@ fn marker() {
         ))
         .register_marker::<ReplaceMarker>()
         .replicate::<OriginalComponent>()
-        .set_marker_fns::<ReplaceMarker, _>(CommandFns::new(
+        .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        ));
+        );
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,8 +1,6 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::client_mapper::ServerEntityMap,
-    core::replication_fns::command_fns::{self, CommandFns},
-    prelude::*,
+    client::client_mapper::ServerEntityMap, core::replication_fns::command_fns, prelude::*,
     test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
@@ -63,10 +61,10 @@ fn command_fns() {
             }),
         ))
         .replicate::<DummyComponent>()
-        .set_command_fns(CommandFns::new(
+        .set_command_fns(
             command_fns::default_write::<DummyComponent>,
             command_fns::default_remove::<RemovingComponent>,
-        ));
+        );
     }
 
     server_app.connect_client(&mut client_app);
@@ -114,10 +112,10 @@ fn marker() {
         ))
         .register_marker::<RemoveMarker>()
         .replicate::<DummyComponent>()
-        .set_marker_fns::<RemoveMarker, DummyComponent>(CommandFns::new(
+        .set_marker_fns::<RemoveMarker, DummyComponent>(
             command_fns::default_write,
             command_fns::default_remove::<RemovingComponent>,
-        ));
+        );
     }
 
     server_app.connect_client(&mut client_app);


### PR DESCRIPTION
After API rework in #233, we now pass structs instead of functions directly.

It's quite convenient for rule functions since
in-place deserialization can now be optionally specified via the builder pattern. Additionally, users can conveniently create it with default functions when writing `ReplicationGroup` manually.

But any of this doesn't make sense for command functions. And internally we immediately convert the struct into `UntypedCommandFns`. We never convert it back into a typed version as `UntypedRuleFns`.

So I removed `CommandFns`. Now users just pass command functions directly and we store them erased inside `UntypedCommandFns` as before. This should make the markers API more ergonomic.