### PR TITLE
Provide context structs for all functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `deserialize_component` into `default_deserialize` and move into `rule_fns` module.
 - Rename `deserialize_mapped_component` into `default_deserialize_mapped` and move into `rule_fns` module.
 - Rename `remove_component` into `default_remove` and move into `command_fns` module.
+- Now serialization/deserialization, removal, despawn and writing functions accept context to access additional information.
 - Move `despawn_recursive` into `replication_fns` module.
 
 ### Removed

--- a/src/client.rs
+++ b/src/client.rs
@@ -181,7 +181,10 @@ fn apply_replication(
             return true;
         }
 
-        trace!("applying buffered update message for {replicon_tick:?}");
+        trace!(
+            "applying buffered update message for {:?}",
+            update.message_tick
+        );
         if let Err(e) = apply_update_components(
             &mut Cursor::new(&*update.message),
             world,

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use crate::core::{
     command_markers::CommandMarkers,
     common_conditions::{client_connected, client_just_connected, client_just_disconnected},
     replication_fns::{
-        ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+        ctx::{DeleteCtx, WriteCtx},
         ReplicationFns,
     },
     replicon_channels::{ReplicationChannel, RepliconChannels},
@@ -396,7 +396,7 @@ fn apply_init_components(
             let (component_fns, rule_fns) = replication_fns.get(fns_id);
             match components_kind {
                 ComponentsKind::Insert => {
-                    let mut ctx = WriteDeserializeCtx {
+                    let mut ctx = WriteCtx {
                         commands: &mut commands,
                         entity_map,
                         message_tick,
@@ -414,7 +414,7 @@ fn apply_init_components(
                     }
                 }
                 ComponentsKind::Removal => component_fns.remove(
-                    &RemoveDespawnCtx { message_tick },
+                    &DeleteCtx { message_tick },
                     &entity_markers,
                     commands.entity(client_entity.id()),
                 ),
@@ -458,7 +458,7 @@ fn apply_despawns(
             .and_then(|entity| world.get_entity_mut(entity))
         {
             entity_ticks.remove(&client_entity.id());
-            (replication_fns.despawn)(&RemoveDespawnCtx { message_tick }, client_entity);
+            (replication_fns.despawn)(&DeleteCtx { message_tick }, client_entity);
         }
     }
 
@@ -511,7 +511,7 @@ fn apply_update_components(
         while cursor.position() < end_pos {
             let fns_id = DefaultOptions::new().deserialize_from(&mut *cursor)?;
             let (component_fns, rule_fns) = replication_fns.get(fns_id);
-            let mut ctx = WriteDeserializeCtx {
+            let mut ctx = WriteCtx {
                 commands: &mut commands,
                 entity_map,
                 message_tick,

--- a/src/client.rs
+++ b/src/client.rs
@@ -413,11 +413,14 @@ fn apply_init_components(
                         )?;
                     }
                 }
-                ComponentsKind::Removal => component_fns.remove(
-                    &DeleteCtx { message_tick },
-                    &entity_markers,
-                    commands.entity(client_entity.id()),
-                ),
+                ComponentsKind::Removal => {
+                    let ctx = DeleteCtx { message_tick };
+                    component_fns.remove(
+                        &ctx,
+                        &entity_markers,
+                        commands.entity(client_entity.id()),
+                    );
+                }
             }
             components_len += 1;
         }
@@ -458,7 +461,8 @@ fn apply_despawns(
             .and_then(|entity| world.get_entity_mut(entity))
         {
             entity_ticks.remove(&client_entity.id());
-            (replication_fns.despawn)(&DeleteCtx { message_tick }, client_entity);
+            let ctx = DeleteCtx { message_tick };
+            (replication_fns.despawn)(&ctx, client_entity);
         }
     }
 

--- a/src/client/server_entity_map.rs
+++ b/src/client/server_entity_map.rs
@@ -1,5 +1,7 @@
 use bevy::{ecs::entity::EntityHashMap, prelude::*, utils::hashbrown::hash_map::Entry};
 
+use crate::Replicated;
+
 /// Maps server entities to client entities and vice versa.
 ///
 /// If [`ClientSet::Reset`](crate::client::ClientSet) is disabled, then this needs to be cleaned up manually
@@ -95,5 +97,118 @@ impl ServerEntityMap {
     pub fn clear(&mut self) {
         self.client_to_server.clear();
         self.server_to_client.clear();
+    }
+}
+
+/// Maps server entities into client entities inside components.
+///
+/// Spawns new client entity using [`Commands`] if a mapping doesn't exists.
+/// See also [`ComponentWorldMapper`].
+pub struct ComponentMapper<'a, 'w, 's> {
+    pub commands: &'a mut Commands<'w, 's>,
+    pub entity_map: &'a mut ServerEntityMap,
+}
+
+impl EntityMapper for ComponentMapper<'_, '_, '_> {
+    fn map_entity(&mut self, entity: Entity) -> Entity {
+        self.entity_map
+            .get_by_server_or_insert(entity, || self.commands.spawn(Replicated).id())
+    }
+}
+
+/// Maps server entities into client entities inside components.
+///
+/// Spawns new client entity if a mapping doesn't exists.
+/// See also [`ComponentMapper`].
+pub struct ComponentWorldMapper<'a> {
+    pub world: &'a mut World,
+    pub entity_map: &'a mut ServerEntityMap,
+}
+
+impl EntityMapper for ComponentWorldMapper<'_> {
+    fn map_entity(&mut self, entity: Entity) -> Entity {
+        self.entity_map
+            .get_by_server_or_insert(entity, || self.world.spawn(Replicated).id())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::ecs::system::CommandQueue;
+
+    use super::*;
+
+    #[test]
+    fn component_mapper_spawn() {
+        let mut world = World::default();
+        let mut entity_map = ServerEntityMap::default();
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+        let mut mapper = ComponentMapper {
+            commands: &mut commands,
+            entity_map: &mut entity_map,
+        };
+
+        let client_entity = mapper.map_entity(Entity::PLACEHOLDER);
+        queue.apply(&mut world);
+
+        assert!(world.get_entity(client_entity).is_some());
+        assert!(entity_map.to_server().contains_key(&client_entity));
+    }
+
+    #[test]
+    fn component_mapper_existing() {
+        let mut world = World::default();
+        let server_entity = world.spawn_empty().id();
+        let client_entity = world.spawn_empty().id();
+        let mut entity_map = ServerEntityMap::default();
+        entity_map.insert(server_entity, client_entity);
+
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+        let mut mapper = ComponentMapper {
+            commands: &mut commands,
+            entity_map: &mut entity_map,
+        };
+
+        assert_eq!(mapper.map_entity(server_entity), client_entity);
+        queue.apply(&mut world);
+
+        assert!(entity_map.to_server().contains_key(&client_entity));
+        assert!(entity_map.to_client().contains_key(&server_entity));
+        assert_eq!(world.entities().len(), 2);
+    }
+
+    #[test]
+    fn component_world_mapper_spawn() {
+        let mut world = World::default();
+        let mut entity_map = ServerEntityMap::default();
+        let mut mapper = ComponentWorldMapper {
+            world: &mut world,
+            entity_map: &mut entity_map,
+        };
+
+        let client_entity = mapper.map_entity(Entity::PLACEHOLDER);
+        assert!(world.get_entity(client_entity).is_some());
+        assert!(entity_map.to_server().contains_key(&client_entity));
+    }
+
+    #[test]
+    fn component_world_mapper_existing() {
+        let mut world = World::default();
+        let server_entity = world.spawn_empty().id();
+        let client_entity = world.spawn_empty().id();
+        let mut entity_map = ServerEntityMap::default();
+        entity_map.insert(server_entity, client_entity);
+
+        let mut mapper = ComponentWorldMapper {
+            world: &mut world,
+            entity_map: &mut entity_map,
+        };
+
+        assert_eq!(mapper.map_entity(server_entity), client_entity);
+        assert!(entity_map.to_server().contains_key(&client_entity));
+        assert!(entity_map.to_client().contains_key(&server_entity));
+        assert_eq!(world.entities().len(), 2);
     }
 }

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -201,8 +201,9 @@ impl CommandMarkers {
     /// Returns an iterator over markers presence for an entity.
     pub(crate) fn iter_contains<'a>(
         &'a self,
-        entity: &'a EntityMut,
+        entity: impl Into<EntityRef<'a>>,
     ) -> impl Iterator<Item = bool> + 'a {
+        let entity = entity.into();
         self.0
             .iter()
             .map(move |marker| entity.contains_id(marker.component_id))

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -51,7 +51,7 @@ pub trait AppMarkerExt {
     use bevy::{ecs::system::EntityCommands, prelude::*};
     use bevy_replicon::{
         core::replication_fns::{
-            ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+            ctx::{DeleteCtx, WriteCtx},
             rule_fns::RuleFns,
         },
         prelude::*,
@@ -67,7 +67,7 @@ pub trait AppMarkerExt {
 
     /// Instead of writing into a component directly, it writes data into [`ComponentHistory<C>`].
     fn write_history<C: Component>(
-        ctx: &mut WriteDeserializeCtx,
+        ctx: &mut WriteCtx,
         rule_fns: &RuleFns<C>,
         entity: &mut EntityMut,
         cursor: &mut Cursor<&[u8]>,
@@ -86,7 +86,7 @@ pub trait AppMarkerExt {
 
     /// Removes component `C` and its history.
     fn remove_history<C: Component>(
-        _ctx: &RemoveDespawnCtx,
+        _ctx: &DeleteCtx,
         mut entity_commands: EntityCommands,
     ) {
         entity_commands.remove::<History<C>>().remove::<C>();

--- a/src/core/replication_fns.rs
+++ b/src/core/replication_fns.rs
@@ -2,6 +2,7 @@ pub mod command_fns;
 pub mod component_fns;
 pub mod ctx;
 pub mod rule_fns;
+pub mod test_fns;
 
 use bevy::{ecs::component::ComponentId, prelude::*};
 use serde::{Deserialize, Serialize};
@@ -137,7 +138,7 @@ impl ReplicationFns {
     /// Returns associates functions.
     ///
     /// See also [`Self::register_rule_fns`].
-    pub fn get(&self, fns_id: FnsId) -> (&ComponentFns, &UntypedRuleFns) {
+    pub(crate) fn get(&self, fns_id: FnsId) -> (&ComponentFns, &UntypedRuleFns) {
         let (rule_fns, index) = self
             .rules
             .get(fns_id.0)
@@ -199,74 +200,6 @@ mod tests {
     use bevy::ecs::entity::MapEntities;
 
     use super::*;
-    use crate::core::command_markers::{CommandMarker, CommandMarkers};
-
-    #[test]
-    fn marker() {
-        let mut world = World::new();
-        let mut replication_fns = ReplicationFns::default();
-        let mut command_markers = CommandMarkers::default();
-
-        let marker_a = command_markers.insert(CommandMarker {
-            component_id: world.init_component::<MarkerA>(),
-            priority: 0,
-        });
-        replication_fns.register_marker(marker_a);
-        replication_fns.set_marker_fns(
-            &mut world,
-            marker_a,
-            command_fns::default_write::<ComponentA>,
-            command_fns::default_remove::<ComponentA>,
-        );
-
-        let (command_fns_a, _) = &replication_fns.components[0];
-        assert!(command_fns_a.marker_fns(&[false]).is_none());
-        assert!(command_fns_a.marker_fns(&[true]).is_some());
-    }
-
-    #[test]
-    fn multiple_markers() {
-        let mut world = World::new();
-        let mut replication_fns = ReplicationFns::default();
-        let mut command_markers = CommandMarkers::default();
-
-        let marker_a = command_markers.insert(CommandMarker {
-            component_id: world.init_component::<MarkerA>(),
-            priority: 1,
-        });
-        replication_fns.register_marker(marker_a);
-
-        let marker_b = command_markers.insert(CommandMarker {
-            component_id: world.init_component::<MarkerB>(),
-            priority: 0,
-        });
-        replication_fns.register_marker(marker_b);
-
-        replication_fns.set_marker_fns(
-            &mut world,
-            marker_a,
-            command_fns::default_write::<ComponentA>,
-            command_fns::default_remove::<ComponentA>,
-        );
-        replication_fns.set_marker_fns(
-            &mut world,
-            marker_b,
-            command_fns::default_write::<ComponentB>,
-            command_fns::default_remove::<ComponentB>,
-        );
-
-        let (command_fns_a, _) = &replication_fns.components[0];
-        assert!(command_fns_a.marker_fns(&[false, false]).is_none());
-        assert!(command_fns_a.marker_fns(&[true, false]).is_some());
-        assert!(command_fns_a.marker_fns(&[false, true]).is_none());
-        assert!(command_fns_a.marker_fns(&[true, true]).is_some());
-
-        let (command_fns_b, _) = &replication_fns.components[1];
-        assert!(command_fns_b.marker_fns(&[false, false]).is_none());
-        assert!(command_fns_b.marker_fns(&[true, false]).is_none());
-        assert!(command_fns_b.marker_fns(&[false, true]).is_some());
-        assert!(command_fns_b.marker_fns(&[true, true]).is_some());
-    }
 
     #[test]
     fn rule_fns() {
@@ -312,10 +245,4 @@ mod tests {
     impl MapEntities for ComponentB {
         fn map_entities<M: EntityMapper>(&mut self, _entity_mapper: &mut M) {}
     }
-
-    #[derive(Component)]
-    struct MarkerA;
-
-    #[derive(Component)]
-    struct MarkerB;
 }

--- a/src/core/replication_fns.rs
+++ b/src/core/replication_fns.rs
@@ -7,7 +7,7 @@ pub mod test_fns;
 use bevy::{ecs::component::ComponentId, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use self::ctx::RemoveDespawnCtx;
+use self::ctx::DeleteCtx;
 
 use super::command_markers::CommandMarkerIndex;
 use command_fns::{RemoveFn, UntypedCommandFns, WriteFn};
@@ -188,10 +188,10 @@ impl FnsInfo {
 pub struct FnsId(usize);
 
 /// Signature of the entity despawn function.
-pub type DespawnFn = fn(&RemoveDespawnCtx, EntityWorldMut);
+pub type DespawnFn = fn(&DeleteCtx, EntityWorldMut);
 
 /// Default entity despawn function.
-pub fn despawn_recursive(_ctx: &RemoveDespawnCtx, entity: EntityWorldMut) {
+pub fn despawn_recursive(_ctx: &DeleteCtx, entity: EntityWorldMut) {
     entity.despawn_recursive();
 }
 

--- a/src/core/replication_fns.rs
+++ b/src/core/replication_fns.rs
@@ -1,11 +1,14 @@
 pub mod command_fns;
 pub mod component_fns;
+pub mod ctx;
 pub mod rule_fns;
 
 use bevy::{ecs::component::ComponentId, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use super::{command_markers::CommandMarkerIndex, replicon_tick::RepliconTick};
+use self::ctx::RemoveDespawnCtx;
+
+use super::command_markers::CommandMarkerIndex;
 use command_fns::{RemoveFn, UntypedCommandFns, WriteFn};
 use component_fns::ComponentFns;
 use rule_fns::{RuleFns, UntypedRuleFns};
@@ -184,10 +187,10 @@ impl FnsInfo {
 pub struct FnsId(usize);
 
 /// Signature of the entity despawn function.
-pub type DespawnFn = fn(EntityWorldMut, RepliconTick);
+pub type DespawnFn = fn(&RemoveDespawnCtx, EntityWorldMut);
 
 /// Default entity despawn function.
-pub fn despawn_recursive(entity: EntityWorldMut, _replicon_tick: RepliconTick) {
+pub fn despawn_recursive(_ctx: &RemoveDespawnCtx, entity: EntityWorldMut) {
     entity.despawn_recursive();
 }
 

--- a/src/core/replication_fns/command_fns.rs
+++ b/src/core/replication_fns/command_fns.rs
@@ -7,7 +7,7 @@ use std::{
 use bevy::{ecs::system::EntityCommands, prelude::*};
 
 use super::{
-    ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+    ctx::{DeleteCtx, WriteCtx},
     rule_fns::RuleFns,
 };
 
@@ -45,7 +45,7 @@ impl UntypedCommandFns {
     /// The caller must ensure that the function is called with the same `C` with which this instance was created.
     pub(super) unsafe fn write<C: Component>(
         &self,
-        ctx: &mut WriteDeserializeCtx,
+        ctx: &mut WriteCtx,
         rule_fns: &RuleFns<C>,
         entity: &mut EntityMut,
         cursor: &mut Cursor<&[u8]>,
@@ -63,28 +63,28 @@ impl UntypedCommandFns {
     }
 
     /// Calls the assigned removal function.
-    pub(super) fn remove(&self, ctx: &RemoveDespawnCtx, commands: EntityCommands) {
+    pub(super) fn remove(&self, ctx: &DeleteCtx, commands: EntityCommands) {
         (self.remove)(ctx, commands);
     }
 }
 
 /// Signature of component writing function.
 pub type WriteFn<C> = fn(
-    &mut WriteDeserializeCtx,
+    &mut WriteCtx,
     &RuleFns<C>,
     &mut EntityMut,
     &mut Cursor<&[u8]>,
 ) -> bincode::Result<()>;
 
 /// Signature of component removal functions.
-pub type RemoveFn = fn(&RemoveDespawnCtx, EntityCommands);
+pub type RemoveFn = fn(&DeleteCtx, EntityCommands);
 
 /// Default component writing function.
 ///
 /// If the component does not exist on the entity, it will be deserialized with [`RuleFns::deserialize`] and inserted via [`Commands`].
 /// If the component exists on the entity, [`RuleFns::deserialize_in_place`] will be used directly on the entity's component.
 pub fn default_write<C: Component>(
-    ctx: &mut WriteDeserializeCtx,
+    ctx: &mut WriteCtx,
     rule_fns: &RuleFns<C>,
     entity: &mut EntityMut,
     cursor: &mut Cursor<&[u8]>,
@@ -100,6 +100,6 @@ pub fn default_write<C: Component>(
 }
 
 /// Default component removal function.
-pub fn default_remove<C: Component>(_ctx: &RemoveDespawnCtx, mut entity_commands: EntityCommands) {
+pub fn default_remove<C: Component>(_ctx: &DeleteCtx, mut entity_commands: EntityCommands) {
     entity_commands.remove::<C>();
 }

--- a/src/core/replication_fns/command_fns.rs
+++ b/src/core/replication_fns/command_fns.rs
@@ -69,12 +69,8 @@ impl UntypedCommandFns {
 }
 
 /// Signature of component writing function.
-pub type WriteFn<C> = fn(
-    &mut WriteCtx,
-    &RuleFns<C>,
-    &mut EntityMut,
-    &mut Cursor<&[u8]>,
-) -> bincode::Result<()>;
+pub type WriteFn<C> =
+    fn(&mut WriteCtx, &RuleFns<C>, &mut EntityMut, &mut Cursor<&[u8]>) -> bincode::Result<()>;
 
 /// Signature of component removal functions.
 pub type RemoveFn = fn(&DeleteCtx, EntityCommands);

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -4,7 +4,7 @@ use bevy::{ecs::system::EntityCommands, prelude::*, ptr::Ptr};
 
 use super::{
     command_fns::UntypedCommandFns,
-    ctx::{RemoveDespawnCtx, SerializeCtx, WriteDeserializeCtx},
+    ctx::{DeleteCtx, SerializeCtx, WriteCtx},
     rule_fns::UntypedRuleFns,
 };
 use crate::core::command_markers::CommandMarkerIndex;
@@ -104,7 +104,7 @@ impl ComponentFns {
     /// Panics if `debug_assertions` is enabled and `entity_markers` has a different length than the number of marker slots.
     pub(crate) unsafe fn write(
         &self,
-        ctx: &mut WriteDeserializeCtx,
+        ctx: &mut WriteCtx,
         rule_fns: &UntypedRuleFns,
         entity_markers: &[bool],
         entity: &mut EntityMut,
@@ -117,7 +117,7 @@ impl ComponentFns {
     /// Same as [`Self::write`], but calls the assigned remove function.
     pub(crate) fn remove(
         &self,
-        ctx: &RemoveDespawnCtx,
+        ctx: &DeleteCtx,
         entity_markers: &[bool],
         entity_commands: EntityCommands,
     ) {
@@ -146,7 +146,7 @@ type UntypedSerializeFn =
 
 /// Signature of component writing functions that restore the original type.
 type UntypedWriteFn = unsafe fn(
-    &mut WriteDeserializeCtx,
+    &mut WriteCtx,
     &UntypedCommandFns,
     &UntypedRuleFns,
     &mut EntityMut,
@@ -174,7 +174,7 @@ unsafe fn untyped_serialize<C: Component>(
 ///
 /// The caller must ensure that `rule_fns` was created for `C`.
 unsafe fn untyped_write<C: Component>(
-    ctx: &mut WriteDeserializeCtx,
+    ctx: &mut WriteCtx,
     command_fns: &UntypedCommandFns,
     rule_fns: &UntypedRuleFns,
     entity: &mut EntityMut,

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -12,7 +12,7 @@ use crate::core::command_markers::CommandMarkerIndex;
 /// Type-erased functions for a component.
 ///
 /// Stores type-erased command functions and functions that will restore original types.
-pub struct ComponentFns {
+pub(crate) struct ComponentFns {
     serialize: UntypedSerializeFn,
     write: UntypedWriteFn,
     commands: UntypedCommandFns,
@@ -78,7 +78,7 @@ impl ComponentFns {
     /// # Safety
     ///
     /// The caller must ensure that `ptr` and `rule_fns` were created for the same type as this instance.
-    pub unsafe fn serialize(
+    pub(crate) unsafe fn serialize(
         &self,
         ctx: &SerializeCtx,
         rule_fns: &UntypedRuleFns,
@@ -102,7 +102,7 @@ impl ComponentFns {
     /// # Panics
     ///
     /// Panics if `debug_assertions` is enabled and `entity_markers` has a different length than the number of marker slots.
-    pub unsafe fn write(
+    pub(crate) unsafe fn write(
         &self,
         ctx: &mut WriteDeserializeCtx,
         rule_fns: &UntypedRuleFns,
@@ -115,7 +115,7 @@ impl ComponentFns {
     }
 
     /// Same as [`Self::write`], but calls the assigned remove function.
-    pub fn remove(
+    pub(crate) fn remove(
         &self,
         ctx: &RemoveDespawnCtx,
         entity_markers: &[bool],
@@ -126,7 +126,7 @@ impl ComponentFns {
     }
 
     /// Picks assigned functions based on markers present on an entity.
-    pub(super) fn marker_fns(&self, entity_markers: &[bool]) -> Option<UntypedCommandFns> {
+    fn marker_fns(&self, entity_markers: &[bool]) -> Option<UntypedCommandFns> {
         debug_assert_eq!(
             entity_markers.len(),
             self.markers.len(),

--- a/src/core/replication_fns/ctx.rs
+++ b/src/core/replication_fns/ctx.rs
@@ -13,7 +13,7 @@ pub struct SerializeCtx {
 
 /// Replication context for writing and deserialization.
 #[non_exhaustive]
-pub struct WriteDeserializeCtx<'a, 'w, 's> {
+pub struct WriteCtx<'a, 'w, 's> {
     /// A queue to perform structural changes to the [`World`].
     pub commands: &'a mut Commands<'w, 's>,
 
@@ -24,7 +24,7 @@ pub struct WriteDeserializeCtx<'a, 'w, 's> {
     pub message_tick: RepliconTick,
 }
 
-impl EntityMapper for WriteDeserializeCtx<'_, '_, '_> {
+impl EntityMapper for WriteCtx<'_, '_, '_> {
     fn map_entity(&mut self, entity: Entity) -> Entity {
         self.entity_map
             .get_by_server_or_insert(entity, || self.commands.spawn(Replicated).id())
@@ -33,7 +33,7 @@ impl EntityMapper for WriteDeserializeCtx<'_, '_, '_> {
 
 /// Replication context for removal and despawn functions.
 #[non_exhaustive]
-pub struct RemoveDespawnCtx {
+pub struct DeleteCtx {
     /// Tick for the currently processing message.
     pub message_tick: RepliconTick,
 }

--- a/src/core/replication_fns/ctx.rs
+++ b/src/core/replication_fns/ctx.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::*;
+
+use crate::{
+    client::server_entity_map::ServerEntityMap, core::replicon_tick::RepliconTick, Replicated,
+};
+
+/// Replication context for serialization function.
+#[non_exhaustive]
+pub struct SerializeCtx {
+    /// Current tick.
+    pub replicon_tick: RepliconTick,
+}
+
+/// Replication context for writing and deserialization.
+#[non_exhaustive]
+pub struct WriteDeserializeCtx<'a, 'w, 's> {
+    /// A queue to perform structural changes to the [`World`].
+    pub commands: &'a mut Commands<'w, 's>,
+
+    /// Maps server entities to client entities and vice versa.
+    pub entity_map: &'a mut ServerEntityMap,
+
+    /// Tick for the currently processing message.
+    pub message_tick: RepliconTick,
+}
+
+impl EntityMapper for WriteDeserializeCtx<'_, '_, '_> {
+    fn map_entity(&mut self, entity: Entity) -> Entity {
+        self.entity_map
+            .get_by_server_or_insert(entity, || self.commands.spawn(Replicated).id())
+    }
+}
+
+/// Replication context for removal and despawn functions.
+#[non_exhaustive]
+pub struct RemoveDespawnCtx {
+    /// Tick for the currently processing message.
+    pub message_tick: RepliconTick,
+}

--- a/src/core/replication_fns/rule_fns.rs
+++ b/src/core/replication_fns/rule_fns.rs
@@ -150,12 +150,8 @@ pub type SerializeFn<C> = fn(&SerializeCtx, &C, &mut Cursor<Vec<u8>>) -> bincode
 pub type DeserializeFn<C> = fn(&mut WriteCtx, &mut Cursor<&[u8]>) -> bincode::Result<C>;
 
 /// Signature of in-place component deserialization functions.
-pub type DeserializeInPlaceFn<C> = fn(
-    DeserializeFn<C>,
-    &mut WriteCtx,
-    &mut C,
-    &mut Cursor<&[u8]>,
-) -> bincode::Result<()>;
+pub type DeserializeInPlaceFn<C> =
+    fn(DeserializeFn<C>, &mut WriteCtx, &mut C, &mut Cursor<&[u8]>) -> bincode::Result<()>;
 
 /// Default component serialization function.
 pub fn default_serialize<C: Component + Serialize>(

--- a/src/core/replication_fns/rule_fns.rs
+++ b/src/core/replication_fns/rule_fns.rs
@@ -13,7 +13,7 @@ use super::ctx::{SerializeCtx, WriteDeserializeCtx};
 /// Type-erased version of [`RuleFns`].
 ///
 /// Stored inside [`ReplicationFns`](super::ReplicationFns) after registration.
-pub struct UntypedRuleFns {
+pub(crate) struct UntypedRuleFns {
     type_id: TypeId,
     type_name: &'static str,
 

--- a/src/core/replication_fns/test_fns.rs
+++ b/src/core/replication_fns/test_fns.rs
@@ -71,6 +71,7 @@ pub trait TestFnsEntityExt {
     /// Returns a component serialized using a registered function for it.
     ///
     /// See also [`ReplicationFns::register_rule_fns`].
+    #[must_use]
     fn serialize(&mut self, fns_info: FnsInfo) -> Vec<u8>;
 
     /// Deserializes a component using a registered function for it and

--- a/src/core/replication_fns/test_fns.rs
+++ b/src/core/replication_fns/test_fns.rs
@@ -1,0 +1,192 @@
+use std::io::Cursor;
+
+use bevy::{
+    ecs::system::{CommandQueue, SystemState},
+    prelude::*,
+};
+
+use super::{
+    ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+    FnsInfo,
+};
+use crate::{
+    client::server_entity_map::ServerEntityMap,
+    core::{
+        command_markers::CommandMarkers,
+        replication_fns::{ctx::SerializeCtx, ReplicationFns},
+        replicon_tick::RepliconTick,
+    },
+};
+
+/**
+Extension for [`EntityWorldMut`] to call registered replication functions for [`FnsInfo`].
+
+See also [`ReplicationFns::register_rule_fns`].
+
+# Example
+
+This example shows how to call registered functions on an entity:
+
+```
+use bevy::prelude::*;
+use bevy_replicon::{
+    core::{
+        replication_fns::{rule_fns::RuleFns, test_fns::TestFnsEntityExt, ReplicationFns},
+        replicon_tick::RepliconTick,
+    },
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+
+let mut app = App::new();
+app.add_plugins((MinimalPlugins, RepliconPlugins));
+
+let replicon_tick = *app.world.resource::<RepliconTick>();
+
+// Register rule functions manually to obtain `FnsInfo`.
+let fns_info = app
+    .world
+    .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+        replication_fns.register_rule_fns(world, RuleFns::<DummyComponent>::default())
+    });
+
+let mut entity = app.world.spawn(DummyComponent);
+let data = entity.serialize(fns_info);
+entity.remove::<DummyComponent>();
+
+entity.apply_write(&data, fns_info, replicon_tick);
+assert!(entity.contains::<DummyComponent>());
+
+entity.apply_remove(fns_info, replicon_tick);
+assert!(!entity.contains::<DummyComponent>());
+
+entity.apply_despawn(replicon_tick);
+assert!(app.world.entities().is_empty());
+
+#[derive(Component, Serialize, Deserialize)]
+struct DummyComponent;
+```
+**/
+pub trait TestFnsEntityExt {
+    /// Returns a component serialized using a registered function for it.
+    ///
+    /// See also [`ReplicationFns::register_rule_fns`].
+    fn serialize(&mut self, fns_info: FnsInfo) -> Vec<u8>;
+
+    /// Deserializes a component using a registered function for it and
+    /// writes it into an entity using a write function based on markers.
+    ///
+    /// See also [`AppMarkerExt`](crate::core::command_markers::AppMarkerExt).
+    fn apply_write(
+        &mut self,
+        data: &[u8],
+        fns_info: FnsInfo,
+        message_tick: RepliconTick,
+    ) -> &mut Self;
+
+    /// Remvoes a component using a registered function for it.
+    ///
+    /// See also [`AppMarkerExt`](crate::core::command_markers::AppMarkerExt).
+    fn apply_remove(&mut self, fns_info: FnsInfo, message_tick: RepliconTick) -> &mut Self;
+
+    /// Despawns an entity using [`ReplicationFns::despawn`].
+    fn apply_despawn(self, message_tick: RepliconTick);
+}
+
+impl TestFnsEntityExt for EntityWorldMut<'_> {
+    fn serialize(&mut self, fns_info: FnsInfo) -> Vec<u8> {
+        let replication_fns = self.world().resource::<ReplicationFns>();
+        let (component_fns, rule_fns) = replication_fns.get(fns_info.fns_id());
+        let replicon_tick = *self.world().resource::<RepliconTick>();
+        let mut cursor = Cursor::default();
+        let ctx = SerializeCtx { replicon_tick };
+        let ptr = self.get_by_id(fns_info.component_id()).unwrap_or_else(|| {
+            let components = self.world().components();
+            let component_name = components
+                .get_name(fns_info.component_id())
+                .expect("function should require valid component ID");
+            panic!("serialization function require entity to have {component_name}");
+        });
+
+        unsafe {
+            component_fns
+                .serialize(&ctx, rule_fns, ptr, &mut cursor)
+                .expect("serialization into memory should never fail");
+        }
+
+        cursor.into_inner()
+    }
+
+    fn apply_write(
+        &mut self,
+        data: &[u8],
+        fns_info: FnsInfo,
+        message_tick: RepliconTick,
+    ) -> &mut Self {
+        let entity = self.id();
+        self.world_scope(|world| {
+            world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
+                world.resource_scope(|world, command_markers: Mut<CommandMarkers>| {
+                    world.resource_scope(|world, replication_fns: Mut<ReplicationFns>| {
+                        let mut state = SystemState::<(Commands, Query<EntityMut>)>::new(world);
+                        let (mut commands, mut query) = state.get_mut(world);
+                        let mut entity = query.get_mut(entity).unwrap();
+                        let entity_markers: Vec<_> =
+                            command_markers.iter_contains(&entity).collect();
+
+                        let (component_fns, rule_fns) = replication_fns.get(fns_info.fns_id());
+                        let mut cursor = Cursor::new(data);
+                        let mut ctx = WriteDeserializeCtx {
+                            commands: &mut commands,
+                            entity_map: &mut entity_map,
+                            message_tick,
+                        };
+
+                        unsafe {
+                            component_fns
+                                .write(
+                                    &mut ctx,
+                                    rule_fns,
+                                    &entity_markers,
+                                    &mut entity,
+                                    &mut cursor,
+                                )
+                                .expect("writing data into an entity shouldn't fail");
+                        }
+
+                        state.apply(world);
+                    })
+                })
+            })
+        });
+
+        self
+    }
+
+    fn apply_remove(&mut self, fns_info: FnsInfo, message_tick: RepliconTick) -> &mut Self {
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, self.world());
+        let entity = commands.entity(self.id());
+
+        let command_markers = self.world().resource::<CommandMarkers>();
+        let entity_markers: Vec<_> = command_markers.iter_contains(&*self).collect();
+
+        let replication_fns = self.world().resource::<ReplicationFns>();
+        let (component_fns, _) = replication_fns.get(fns_info.fns_id());
+        let ctx = RemoveDespawnCtx { message_tick };
+
+        component_fns.remove(&ctx, &entity_markers, entity);
+
+        self.world_scope(|world| {
+            queue.apply(world);
+        });
+
+        self
+    }
+
+    fn apply_despawn(self, message_tick: RepliconTick) {
+        let replication_fns = self.world().resource::<ReplicationFns>();
+        let ctx = RemoveDespawnCtx { message_tick };
+        (replication_fns.despawn)(&ctx, self);
+    }
+}

--- a/src/core/replication_fns/test_fns.rs
+++ b/src/core/replication_fns/test_fns.rs
@@ -6,7 +6,7 @@ use bevy::{
 };
 
 use super::{
-    ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+    ctx::{DeleteCtx, WriteCtx},
     FnsInfo,
 };
 use crate::{
@@ -136,7 +136,7 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
 
                         let (component_fns, rule_fns) = replication_fns.get(fns_info.fns_id());
                         let mut cursor = Cursor::new(data);
-                        let mut ctx = WriteDeserializeCtx {
+                        let mut ctx = WriteCtx {
                             commands: &mut commands,
                             entity_map: &mut entity_map,
                             message_tick,
@@ -173,7 +173,7 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
 
         let replication_fns = self.world().resource::<ReplicationFns>();
         let (component_fns, _) = replication_fns.get(fns_info.fns_id());
-        let ctx = RemoveDespawnCtx { message_tick };
+        let ctx = DeleteCtx { message_tick };
 
         component_fns.remove(&ctx, &entity_markers, entity);
 
@@ -186,7 +186,7 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
 
     fn apply_despawn(self, message_tick: RepliconTick) {
         let replication_fns = self.world().resource::<ReplicationFns>();
-        let ctx = RemoveDespawnCtx { message_tick };
+        let ctx = DeleteCtx { message_tick };
         (replication_fns.despawn)(&ctx, self);
     }
 }

--- a/src/core/replication_rules.rs
+++ b/src/core/replication_rules.rs
@@ -58,7 +58,7 @@ pub trait AppRuleExt {
     use bevy::prelude::*;
     use bevy_replicon::{
         core::replication_fns::{
-            ctx::{SerializeCtx, WriteDeserializeCtx},
+            ctx::{SerializeCtx, WriteCtx},
             rule_fns::RuleFns,
         },
         prelude::*,
@@ -82,7 +82,7 @@ pub trait AppRuleExt {
 
     /// Deserializes `translation` and creates [`Transform`] from it.
     fn deserialize_translation(
-        _ctx: &mut WriteDeserializeCtx,
+        _ctx: &mut WriteCtx,
         cursor: &mut Cursor<&[u8]>,
     ) -> bincode::Result<Transform> {
         let translation: Vec3 = bincode::deserialize_from(cursor)?;
@@ -245,7 +245,7 @@ use bevy::prelude::*;
 use bevy_replicon::{
     core::{
         replication_fns::{
-            ctx::{SerializeCtx, WriteDeserializeCtx},
+            ctx::{SerializeCtx, WriteCtx},
             rule_fns::RuleFns,
             ReplicationFns,
         },
@@ -289,7 +289,7 @@ impl GroupReplication for PlayerBundle {
 }
 
 # fn serialize_translation(_: &SerializeCtx, _: &Transform, _: &mut Cursor<Vec<u8>>) -> bincode::Result<()> { unimplemented!() }
-# fn deserialize_translation(_: &mut WriteDeserializeCtx, _: &mut Cursor<&[u8]>) -> bincode::Result<Transform> { unimplemented!() }
+# fn deserialize_translation(_: &mut WriteCtx, _: &mut Cursor<&[u8]>) -> bincode::Result<Transform> { unimplemented!() }
 ```
 **/
 pub trait GroupReplication {

--- a/src/core/replication_rules.rs
+++ b/src/core/replication_rules.rs
@@ -57,7 +57,11 @@ pub trait AppRuleExt {
 
     use bevy::prelude::*;
     use bevy_replicon::{
-        client::client_mapper::ClientMapper, core::replication_fns::rule_fns::RuleFns, prelude::*,
+        core::replication_fns::{
+            ctx::{SerializeCtx, WriteDeserializeCtx},
+            rule_fns::RuleFns,
+        },
+        prelude::*,
     };
 
     # let mut app = App::new();
@@ -69,6 +73,7 @@ pub trait AppRuleExt {
 
     /// Serializes only `translation` from [`Transform`].
     fn serialize_translation(
+        _ctx: &SerializeCtx,
         transform: &Transform,
         cursor: &mut Cursor<Vec<u8>>,
     ) -> bincode::Result<()> {
@@ -77,8 +82,8 @@ pub trait AppRuleExt {
 
     /// Deserializes `translation` and creates [`Transform`] from it.
     fn deserialize_translation(
+        _ctx: &mut WriteDeserializeCtx,
         cursor: &mut Cursor<&[u8]>,
-        _mapper: &mut ClientMapper,
     ) -> bincode::Result<Transform> {
         let translation: Vec3 = bincode::deserialize_from(cursor)?;
         Ok(Transform::from_translation(translation))
@@ -238,9 +243,12 @@ use std::io::Cursor;
 
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::client_mapper::ClientMapper,
     core::{
-        replication_fns::{rule_fns::RuleFns, ReplicationFns},
+        replication_fns::{
+            ctx::{SerializeCtx, WriteDeserializeCtx},
+            rule_fns::RuleFns,
+            ReplicationFns,
+        },
         replication_rules::{GroupReplication, ReplicationRule},
     },
     prelude::*,
@@ -280,8 +288,8 @@ impl GroupReplication for PlayerBundle {
     }
 }
 
-# fn serialize_translation(_: &Transform, _: &mut Cursor<Vec<u8>>) -> bincode::Result<()> { unimplemented!() }
-# fn deserialize_translation(_: &mut Cursor<&[u8]>, _: &mut ClientMapper) -> bincode::Result<Transform> { unimplemented!() }
+# fn serialize_translation(_: &SerializeCtx, _: &Transform, _: &mut Cursor<Vec<u8>>) -> bincode::Result<()> { unimplemented!() }
+# fn deserialize_translation(_: &mut WriteDeserializeCtx, _: &mut Cursor<&[u8]>) -> bincode::Result<Transform> { unimplemented!() }
 ```
 **/
 pub trait GroupReplication {

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -9,7 +9,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::EventMapper;
 use crate::{
-    client::{client_mapper::ServerEntityMap, replicon_client::RepliconClient, ClientSet},
+    client::{replicon_client::RepliconClient, server_entity_map::ServerEntityMap, ClientSet},
     core::{
         common_conditions::{client_connected, has_authority, server_running},
         replicon_channels::{RepliconChannel, RepliconChannels},

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::EventMapper;
 use crate::{
-    client::{client_mapper::ServerEntityMap, replicon_client::RepliconClient, ClientSet},
+    client::{replicon_client::RepliconClient, server_entity_map::ServerEntityMap, ClientSet},
     core::{
         common_conditions::{client_connected, has_authority, server_running},
         replicon_channels::{RepliconChannel, RepliconChannels},

--- a/src/server.rs
+++ b/src/server.rs
@@ -583,7 +583,7 @@ pub enum ServerEvent {
 /**
 A resource that exists on the server for mapping server entities to
 entities that clients have already spawned. The mappings are sent to clients as part of replication
-and injected into the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap).
+and injected into the client's [`ServerEntityMap`](crate::client::server_entity_map::ServerEntityMap).
 
 Sometimes you don't want to wait for the server to spawn something before it appears on the
 client – when a client performs an action, they can immediately simulate it on the client,
@@ -594,9 +594,9 @@ In this situation, the client can send the server its pre-spawned entity id, the
 and inject the [`ClientMapping`] into its [`ClientEntityMap`].
 
 Replication packets will send a list of such mappings to clients, which will
-be inserted into the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap). Using replication
+be inserted into the client's [`ServerEntityMap`](crate::client::server_entity_map::ServerEntityMap). Using replication
 to propagate the mappings ensures any replication messages related to the pre-mapped
-server entities will synchronize with updating the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap).
+server entities will synchronize with updating the client's [`ServerEntityMap`](crate::client::server_entity_map::ServerEntityMap).
 
 ### Example:
 
@@ -653,7 +653,8 @@ pub struct ClientEntityMap(HashMap<ClientId, Vec<ClientMapping>>);
 impl ClientEntityMap {
     /// Registers `mapping` for a client entity pre-spawned by the specified client.
     ///
-    /// This will be sent as part of replication data and added to the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap).
+    /// This will be sent as part of replication data and added to the client's
+    /// [`ServerEntityMap`](crate::client::server_entity_map::ServerEntityMap).
     pub fn insert(&mut self, client_id: ClientId, mapping: ClientMapping) {
         self.0.entry(client_id).or_default().push(mapping);
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,7 +22,7 @@ use bevy::{
 
 use crate::core::{
     common_conditions::{server_just_stopped, server_running},
-    replication_fns::ReplicationFns,
+    replication_fns::{ctx::SerializeCtx, ReplicationFns},
     replication_rules::ReplicationRules,
     replicon_channels::{ReplicationChannel, RepliconChannels},
     replicon_tick::RepliconTick,
@@ -229,6 +229,7 @@ impl ServerPlugin {
             &replication_fns,
             set.p0(),
             &change_tick,
+            *replicon_tick,
         )?;
 
         let mut client_buffers = mem::take(&mut *set.p5());
@@ -288,6 +289,7 @@ fn collect_changes(
     replication_fns: &ReplicationFns,
     world: &World,
     change_tick: &SystemChangeTick,
+    replicon_tick: RepliconTick,
 ) -> bincode::Result<()> {
     for (init_message, _) in messages.iter_mut() {
         init_message.start_array();
@@ -360,6 +362,7 @@ fn collect_changes(
                             &mut shared_bytes,
                             rule_fns,
                             component_fns,
+                            &SerializeCtx { replicon_tick },
                             replicated_component.fns_id,
                             component,
                         )?;
@@ -372,6 +375,7 @@ fn collect_changes(
                                 &mut shared_bytes,
                                 rule_fns,
                                 component_fns,
+                                &SerializeCtx { replicon_tick },
                                 replicated_component.fns_id,
                                 component,
                             )?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -348,6 +348,7 @@ fn collect_changes(
                 };
 
                 let (component_fns, rule_fns) = replication_fns.get(replicated_component.fns_id);
+                let ctx = SerializeCtx { replicon_tick };
                 let mut shared_bytes = None;
                 for (init_message, update_message, client) in messages.iter_mut_with_clients() {
                     let visibility = client.visibility().cached_visibility();
@@ -362,7 +363,7 @@ fn collect_changes(
                             &mut shared_bytes,
                             rule_fns,
                             component_fns,
-                            &SerializeCtx { replicon_tick },
+                            &ctx,
                             replicated_component.fns_id,
                             component,
                         )?;
@@ -375,7 +376,7 @@ fn collect_changes(
                                 &mut shared_bytes,
                                 rule_fns,
                                 component_fns,
-                                &SerializeCtx { replicon_tick },
+                                &ctx,
                                 replicated_component.fns_id,
                                 component,
                             )?;

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -15,7 +15,9 @@ use super::{
     ClientMapping, ConnectedClient,
 };
 use crate::core::{
-    replication_fns::{component_fns::ComponentFns, rule_fns::UntypedRuleFns, FnsId},
+    replication_fns::{
+        component_fns::ComponentFns, ctx::SerializeCtx, rule_fns::UntypedRuleFns, FnsId,
+    },
     replicon_channels::ReplicationChannel,
     replicon_tick::RepliconTick,
 };
@@ -291,6 +293,7 @@ impl InitMessage {
         shared_bytes: &mut Option<&'a [u8]>,
         rule_fns: &UntypedRuleFns,
         component_fns: &ComponentFns,
+        ctx: &SerializeCtx,
         fns_id: FnsId,
         ptr: Ptr,
     ) -> bincode::Result<()> {
@@ -301,7 +304,7 @@ impl InitMessage {
         let size = write_with(shared_bytes, &mut self.cursor, |cursor| {
             DefaultOptions::new().serialize_into(&mut *cursor, &fns_id)?;
             // SAFETY: `component_fns`, `ptr` and `rule_fns` were created for the same component type.
-            unsafe { component_fns.serialize(rule_fns, ptr, cursor) }
+            unsafe { component_fns.serialize(ctx, rule_fns, ptr, cursor) }
         })?;
 
         self.entity_data_size = self
@@ -519,6 +522,7 @@ impl UpdateMessage {
         shared_bytes: &mut Option<&'a [u8]>,
         rule_fns: &UntypedRuleFns,
         component_fns: &ComponentFns,
+        ctx: &SerializeCtx,
         fns_id: FnsId,
         ptr: Ptr,
     ) -> bincode::Result<()> {
@@ -529,7 +533,7 @@ impl UpdateMessage {
         let size = write_with(shared_bytes, &mut self.cursor, |cursor| {
             DefaultOptions::new().serialize_into(&mut *cursor, &fns_id)?;
             // SAFETY: `component_fns`, `ptr` and `rule_fns` were created for the same component type.
-            unsafe { component_fns.serialize(rule_fns, ptr, cursor) }
+            unsafe { component_fns.serialize(ctx, rule_fns, ptr, cursor) }
         })?;
 
         self.entity_data_size = self

--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, utils::Duration};
 use bevy_replicon::{
     client::server_entity_map::ServerEntityMap,
     core::{
-        replication_fns::{command_fns, ctx::WriteDeserializeCtx, rule_fns::RuleFns},
+        replication_fns::{command_fns, ctx::WriteCtx, rule_fns::RuleFns},
         replicon_tick::RepliconTick,
     },
     prelude::*,
@@ -528,7 +528,7 @@ struct ReplacedComponent(bool);
 
 /// Deserializes [`OriginalComponent`], but inserts it as [`ReplacedComponent`].
 fn replace(
-    ctx: &mut WriteDeserializeCtx,
+    ctx: &mut WriteCtx,
     rule_fns: &RuleFns<OriginalComponent>,
     entity: &mut EntityMut,
     cursor: &mut Cursor<&[u8]>,

--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -2,9 +2,9 @@ use std::io::Cursor;
 
 use bevy::{prelude::*, utils::Duration};
 use bevy_replicon::{
-    client::client_mapper::{ClientMapper, ServerEntityMap},
+    client::server_entity_map::ServerEntityMap,
     core::{
-        replication_fns::{command_fns, rule_fns::RuleFns},
+        replication_fns::{command_fns, ctx::WriteDeserializeCtx, rule_fns::RuleFns},
         replicon_tick::RepliconTick,
     },
     prelude::*,
@@ -528,20 +528,13 @@ struct ReplacedComponent(bool);
 
 /// Deserializes [`OriginalComponent`], but inserts it as [`ReplacedComponent`].
 fn replace(
+    ctx: &mut WriteDeserializeCtx,
     rule_fns: &RuleFns<OriginalComponent>,
-    commands: &mut Commands,
     entity: &mut EntityMut,
     cursor: &mut Cursor<&[u8]>,
-    entity_map: &mut ServerEntityMap,
-    _replicon_tick: RepliconTick,
 ) -> bincode::Result<()> {
-    let mut mapper = ClientMapper {
-        commands,
-        entity_map,
-    };
-
-    let component = rule_fns.deserialize(cursor, &mut mapper)?;
-    commands
+    let component = rule_fns.deserialize(ctx, cursor)?;
+    ctx.commands
         .entity(entity.id())
         .insert(ReplacedComponent(component.0));
 

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -4,7 +4,7 @@ use bevy::{
     time::TimePlugin,
 };
 use bevy_replicon::{
-    client::client_mapper::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
+    client::server_entity_map::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
 

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::client_mapper::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
+    client::server_entity_map::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
 

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -5,7 +5,7 @@ use bevy_replicon::{
     core::{
         replication_fns::{
             command_fns,
-            ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+            ctx::{DeleteCtx, WriteCtx},
             rule_fns::RuleFns,
             test_fns::TestFnsEntityExt,
             ReplicationFns,
@@ -300,7 +300,7 @@ struct DummyMarker;
 
 /// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
 fn replace(
-    ctx: &mut WriteDeserializeCtx,
+    ctx: &mut WriteCtx,
     rule_fns: &RuleFns<OriginalComponent>,
     entity: &mut EntityMut,
     cursor: &mut Cursor<&[u8]>,
@@ -312,6 +312,6 @@ fn replace(
 }
 
 /// Adds special [`Despawned`] marker instead of despawning an entity.
-fn mark_despawned(_ctx: &RemoveDespawnCtx, mut entity: EntityWorldMut) {
+fn mark_despawned(_ctx: &DeleteCtx, mut entity: EntityWorldMut) {
     entity.insert(Despawned);
 }

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -1,0 +1,317 @@
+use std::io::Cursor;
+
+use bevy::prelude::*;
+use bevy_replicon::{
+    core::{
+        replication_fns::{
+            command_fns,
+            ctx::{RemoveDespawnCtx, WriteDeserializeCtx},
+            rule_fns::RuleFns,
+            test_fns::TestFnsEntityExt,
+            ReplicationFns,
+        },
+        replicon_tick::RepliconTick,
+    },
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn write() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app.world.spawn(OriginalComponent);
+    let data = entity.serialize(fns_info);
+    entity.apply_write(&data, fns_info, replicon_tick);
+    assert!(entity.contains::<ReplacedComponent>());
+}
+
+#[test]
+fn remove() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app.world.spawn(ReplacedComponent);
+    entity.apply_remove(fns_info, replicon_tick);
+    assert!(!entity.contains::<ReplacedComponent>());
+}
+
+#[test]
+fn write_without_marker() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker::<ReplaceMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app.world.spawn(OriginalComponent);
+    let data = entity.serialize(fns_info);
+    entity.remove::<OriginalComponent>();
+    entity.apply_write(&data, fns_info, replicon_tick);
+    assert!(entity.contains::<OriginalComponent>());
+}
+
+#[test]
+fn remove_without_marker() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker::<ReplaceMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app.world.spawn(OriginalComponent);
+    entity.apply_remove(fns_info, replicon_tick);
+    assert!(!entity.contains::<OriginalComponent>());
+}
+
+#[test]
+fn write_with_marker() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker::<ReplaceMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app.world.spawn((OriginalComponent, ReplaceMarker));
+    let data = entity.serialize(fns_info);
+    entity.apply_write(&data, fns_info, replicon_tick);
+    assert!(entity.contains::<ReplacedComponent>());
+}
+
+#[test]
+fn remove_with_marker() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker::<ReplaceMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app.world.spawn((ReplacedComponent, ReplaceMarker));
+    entity.apply_remove(fns_info, replicon_tick);
+    assert!(!entity.contains::<ReplacedComponent>());
+}
+
+#[test]
+fn write_with_multiple_markers() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker::<DummyMarker>()
+        .register_marker::<ReplaceMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        )
+        .set_marker_fns::<DummyMarker, _>(
+            command_fns::default_write::<OriginalComponent>,
+            command_fns::default_remove::<OriginalComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app
+        .world
+        .spawn((OriginalComponent, ReplaceMarker, DummyMarker));
+    let data = entity.serialize(fns_info);
+    entity.apply_write(&data, fns_info, replicon_tick);
+    assert!(
+        entity.contains::<ReplacedComponent>(),
+        "last marker should take priority"
+    );
+}
+
+#[test]
+fn remove_with_mutltiple_markers() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker::<DummyMarker>()
+        .register_marker::<ReplaceMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        )
+        .set_marker_fns::<DummyMarker, _>(
+            command_fns::default_write::<OriginalComponent>,
+            command_fns::default_remove::<OriginalComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app
+        .world
+        .spawn((ReplacedComponent, ReplaceMarker, DummyMarker));
+    entity.apply_remove(fns_info, replicon_tick);
+    assert!(
+        !entity.contains::<ReplacedComponent>(),
+        "last marker should take priority"
+    );
+}
+
+#[test]
+fn write_with_priority_marker() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker_with_priority::<ReplaceMarker>(1)
+        .register_marker::<DummyMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        )
+        .set_marker_fns::<DummyMarker, _>(
+            command_fns::default_write::<OriginalComponent>,
+            command_fns::default_remove::<OriginalComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app
+        .world
+        .spawn((OriginalComponent, ReplaceMarker, DummyMarker));
+    let data = entity.serialize(fns_info);
+    entity.apply_write(&data, fns_info, replicon_tick);
+    assert!(entity.contains::<ReplacedComponent>());
+}
+
+#[test]
+fn remove_with_priority_marker() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins))
+        .register_marker_with_priority::<ReplaceMarker>(1)
+        .register_marker::<DummyMarker>()
+        .set_marker_fns::<ReplaceMarker, _>(
+            replace,
+            command_fns::default_remove::<ReplacedComponent>,
+        )
+        .set_marker_fns::<DummyMarker, _>(
+            command_fns::default_write::<OriginalComponent>,
+            command_fns::default_remove::<OriginalComponent>,
+        );
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let fns_info = app
+        .world
+        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+        });
+
+    let mut entity = app
+        .world
+        .spawn((ReplacedComponent, ReplaceMarker, DummyMarker));
+    entity.apply_remove(fns_info, replicon_tick);
+    assert!(!entity.contains::<ReplacedComponent>());
+}
+
+#[test]
+fn despawn() {
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins));
+
+    let mut replication_fns = app.world.resource_mut::<ReplicationFns>();
+    replication_fns.despawn = mark_despawned;
+
+    let replicon_tick = *app.world.resource::<RepliconTick>();
+    let entity = app.world.spawn_empty();
+    let id = entity.id(); // Take ID since despawn function consumes entity.
+    entity.apply_despawn(replicon_tick);
+    assert!(app.world.get::<Despawned>(id).is_some());
+}
+
+#[derive(Component, Deserialize, Serialize)]
+struct OriginalComponent;
+
+#[derive(Component, Deserialize, Serialize)]
+struct ReplacedComponent;
+
+#[derive(Component)]
+struct Despawned;
+
+#[derive(Component, Deserialize, Serialize)]
+struct ReplaceMarker;
+
+#[derive(Component, Deserialize, Serialize)]
+struct DummyMarker;
+
+/// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
+fn replace(
+    ctx: &mut WriteDeserializeCtx,
+    rule_fns: &RuleFns<OriginalComponent>,
+    entity: &mut EntityMut,
+    cursor: &mut Cursor<&[u8]>,
+) -> bincode::Result<()> {
+    rule_fns.deserialize(ctx, cursor)?;
+    ctx.commands.entity(entity.id()).insert(ReplacedComponent);
+
+    Ok(())
+}
+
+/// Adds special [`Despawned`] marker instead of despawning an entity.
+fn mark_despawned(_ctx: &RemoveDespawnCtx, mut entity: EntityWorldMut) {
+    entity.insert(Despawned);
+}

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use bevy::{ecs::entity::MapEntities, prelude::*};
 use bevy_replicon::{
     client::server_entity_map::ServerEntityMap,
-    core::replication_fns::{command_fns, ctx::WriteDeserializeCtx, rule_fns::RuleFns},
+    core::replication_fns::{command_fns, ctx::WriteCtx, rule_fns::RuleFns},
     prelude::*,
     test_app::ServerTestAppExt,
 };
@@ -432,7 +432,7 @@ struct ReplacedComponent;
 
 /// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
 fn replace(
-    ctx: &mut WriteDeserializeCtx,
+    ctx: &mut WriteCtx,
     rule_fns: &RuleFns<OriginalComponent>,
     entity: &mut EntityMut,
     cursor: &mut Cursor<&[u8]>,

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::client_mapper::ServerEntityMap, core::replication_fns::command_fns, prelude::*,
+    client::server_entity_map::ServerEntityMap, core::replication_fns::command_fns, prelude::*,
     test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -4,7 +4,7 @@ use bevy::{
     time::TimePlugin,
 };
 use bevy_replicon::{
-    client::client_mapper::ServerEntityMap, core::replicon_tick::RepliconTick, prelude::*,
+    client::server_entity_map::ServerEntityMap, core::replicon_tick::RepliconTick, prelude::*,
     test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::client_mapper::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
+    client::server_entity_map::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Writing shares context with deserialize since deserialization also need access to commands for in-place deserialization for components with entities.
Removal and despawn functions also share context due to their nature.
But it makes sense to keep serialization context different since the tick is also different and different kind of data can be passed in the future.

This change have the following benefits:
- We can add more context-related data without breaking changes.
- Reduces the number of arguments in the writing signature.
- More flexible, now serialization logic can depend on tick.
- Removes the need of ugly creation of `ClientMapper` in writing
  functions, now writing context implement `MapEntities`.

Was suggested by @NiseVoid.

I also used more specific naming in `client` module to disambiguate between the current tick and message tick.

Update: Since all contexts have `non_exhaustive`, users no longer can manually call functions for their tests. To solve this, I provided a convenient extension trait on an entity for users to quickly call the registered functions and hidden the related internals from the public API. I also refactored our tests into this new API.

Update2: Since I moved mapping into context for convenience, there is no convenient way for users to map entities outside of writing. I added 2 kind of mappers for it.