### PR TITLE
Return iterator from `RepliconClient::receive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More tracing.
 - `Debug` impl for `RepliconClientStatus`.
 
+### Fixed
+
+- Reversed order of the received messages from `RepliconClient`.
+
 ### Changed
 
 - `SerializeFn` now accepts regular `C` instead of `Ptr`.
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AppRuleExt::replicate_with` now no longer accepts `RemoveComponentFn`. Use the mentioned marker-based API to customize it instead.
 - `AppRuleExt::replicate_with` now additionally accepts `in_place_as_deserialize`. You can use it to customize deserialization if a component is already present or just pass `command_fns::deserialize_in_place` to make it fallback to the passed `deserialize`.
 - Writing to entities on client now done via `EntityMut` and `Commands` instead of `EntityWorldMut`. It was needed to support the mentioned in-place deserialization and will possibly allow batching insertions in the future (for details see https://github.com/bevyengine/bevy/issues/10154).
+- Return iterator from `RepliconClient::receive` instead of popping the last message. If you used `while` loop for it before, replace it with `for`.
 - Move `Replication` to `core` module.
 - Move all functions-related logic from `ReplicationRules` into a new `ReplicationFns` and hide `ReplicationRules` from public API.
 - Rename `serialize_component` into `default_serialize` and move into `rule_fns` module.

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -103,7 +103,7 @@ pub trait ServerEventAppExt {
         registry: Res<AppTypeRegistry>,
     ) {
         let registry = registry.read();
-        while let Some(message) = client.receive(*channel) {
+        for message in client.receive(*channel) {
             let (tick, event) = server_event::deserialize_with(&message, |cursor| {
                 let mut deserializer =
                     bincode::Deserializer::with_reader(cursor, DefaultOptions::new());
@@ -211,7 +211,7 @@ fn receive<T: Event + DeserializeOwned>(
     replicon_tick: Res<RepliconTick>,
     channel: Res<ServerEventChannel<T>>,
 ) {
-    while let Some(message) = client.receive(*channel) {
+    for message in client.receive(*channel) {
         let (tick, event) = deserialize_with(&message, |cursor| {
             DefaultOptions::new().deserialize_from(cursor)
         })
@@ -235,7 +235,7 @@ fn receive_and_map<T: Event + MapEntities + DeserializeOwned>(
     entity_map: Res<ServerEntityMap>,
     channel: Res<ServerEventChannel<T>>,
 ) {
-    while let Some(message) = client.receive(*channel) {
+    for message in client.receive(*channel) {
         let (tick, mut event): (_, T) = deserialize_with(&message, |cursor| {
             DefaultOptions::new().deserialize_from(cursor)
         })

--- a/src/server/replicon_server.rs
+++ b/src/server/replicon_server.rs
@@ -43,7 +43,7 @@ impl RepliconServer {
             .retain(|&(sender_id, ..)| sender_id != client_id);
     }
 
-    /// Receives all available messages from over a channel.
+    /// Receives all available messages from clients over a channel.
     ///
     /// All messages will be drained.
     pub fn receive<I: Into<u8>>(


### PR DESCRIPTION
It fixes reversed order of the received messages from `RepliconClient`. I added two tests to demonstrate that it fixes the problem.

It's also more efficient to perform removals in bulk. But because of the borrow checker, we now send acks in bulk too.