### PR TITLE
Use separate resource on client to track last received init tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AppRuleExt::replicate_with` now additionally accepts `in_place_as_deserialize`. You can use it to customize deserialization if a component is already present or just pass `command_fns::deserialize_in_place` to make it fallback to the passed `deserialize`.
 - Writing to entities on client now done via `EntityMut` and `Commands` instead of `EntityWorldMut`. It was needed to support the mentioned in-place deserialization and will possibly allow batching insertions in the future (for details see https://github.com/bevyengine/bevy/issues/10154).
 - Return iterator from `RepliconClient::receive` instead of popping the last message. If you used `while` loop for it before, replace it with `for`.
+- Use new `ServerInitTick` resource on client instead of `RepliconTick`. If you used `ServerEventAppExt::add_server_event_with`, use `ServerInitTick` instead of `RepliconTick` in your receive function.
+- Move `replicon_tick` module under `server` module since now it's used only on server.
 - Move `Replication` to `core` module.
 - Move all functions-related logic from `ReplicationRules` into a new `ReplicationFns` and hide `ReplicationRules` from public API.
 - Rename `serialize_component` into `default_serialize` and move into `rule_fns` module.

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,7 +3,6 @@ pub mod common_conditions;
 pub mod replication_fns;
 pub mod replication_rules;
 pub mod replicon_channels;
-pub mod replicon_tick;
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -12,14 +11,12 @@ use command_markers::CommandMarkers;
 use replication_fns::ReplicationFns;
 use replication_rules::ReplicationRules;
 use replicon_channels::RepliconChannels;
-use replicon_tick::RepliconTick;
 
 pub struct RepliconCorePlugin;
 
 impl Plugin for RepliconCorePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Replicated>()
-            .init_resource::<RepliconTick>()
             .init_resource::<RepliconChannels>()
             .init_resource::<ReplicationFns>()
             .init_resource::<ReplicationRules>()

--- a/src/core/replication_fns/ctx.rs
+++ b/src/core/replication_fns/ctx.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::{
-    client::server_entity_map::ServerEntityMap, core::replicon_tick::RepliconTick, Replicated,
+    client::server_entity_map::ServerEntityMap, server::replicon_tick::RepliconTick, Replicated,
 };
 
 /// Replication context for serialization function.

--- a/src/core/replication_fns/test_fns.rs
+++ b/src/core/replication_fns/test_fns.rs
@@ -14,8 +14,8 @@ use crate::{
     core::{
         command_markers::CommandMarkers,
         replication_fns::{ctx::SerializeCtx, ReplicationFns},
-        replicon_tick::RepliconTick,
     },
+    server::replicon_tick::RepliconTick,
 };
 
 /**
@@ -30,11 +30,9 @@ This example shows how to call registered functions on an entity:
 ```
 use bevy::prelude::*;
 use bevy_replicon::{
-    core::{
-        replication_fns::{rule_fns::RuleFns, test_fns::TestFnsEntityExt, ReplicationFns},
-        replicon_tick::RepliconTick,
-    },
+    core::replication_fns::{rule_fns::RuleFns, test_fns::TestFnsEntityExt, ReplicationFns},
     prelude::*,
+    server::replicon_tick::RepliconTick,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,10 @@ In order to serialize Bevy components you need to enable the `serialize` feature
 ### Tick and fixed timestep games
 
 The [`ServerPlugin`] sends replication data in [`PostUpdate`] any time the
-[`RepliconTick`](core::replicon_tick::RepliconTick) resource changes.
+[`RepliconTick`](server::replicon_tick::RepliconTick) resource changes.
 By default, its incremented in [`PostUpdate`] per the [`TickPolicy`].
 
-If you set [`TickPolicy::Manual`], you can increment [`RepliconTick`](core::replicon_tick::RepliconTick)
+If you set [`TickPolicy::Manual`], you can increment [`RepliconTick`](server::replicon_tick::RepliconTick)
 at the start of your game loop inside [`FixedMain`](bevy::app::FixedMain).
 This value can represent your simulation step, and is made available to the client in the custom
 deserialization, despawn and component removal functions.

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,7 @@ pub(super) mod removal_buffer;
 pub(super) mod replicated_archetypes;
 pub(super) mod replication_messages;
 pub mod replicon_server;
+pub mod replicon_tick;
 
 use std::{io::Cursor, mem, time::Duration};
 
@@ -25,7 +26,6 @@ use crate::core::{
     replication_fns::{ctx::SerializeCtx, ReplicationFns},
     replication_rules::ReplicationRules,
     replicon_channels::{ReplicationChannel, RepliconChannels},
-    replicon_tick::RepliconTick,
     ClientId,
 };
 use connected_clients::{
@@ -36,6 +36,7 @@ use removal_buffer::{RemovalBuffer, RemovalBufferPlugin};
 use replicated_archetypes::ReplicatedArchetypes;
 use replication_messages::ReplicationMessages;
 use replicon_server::RepliconServer;
+use replicon_tick::RepliconTick;
 
 pub struct ServerPlugin {
     /// Tick configuration.
@@ -64,6 +65,7 @@ impl Plugin for ServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((DespawnBufferPlugin, RemovalBufferPlugin))
             .init_resource::<RepliconServer>()
+            .init_resource::<RepliconTick>()
             .init_resource::<ClientBuffers>()
             .init_resource::<ClientEntityMap>()
             .insert_resource(ConnectedClients::new(self.visibility_policy))

--- a/src/server/connected_clients.rs
+++ b/src/server/connected_clients.rs
@@ -9,8 +9,8 @@ use bevy::{
 };
 
 use crate::{
-    core::{replicon_tick::RepliconTick, ClientId},
-    server::VisibilityPolicy,
+    core::ClientId,
+    server::{replicon_tick::RepliconTick, VisibilityPolicy},
 };
 use client_visibility::ClientVisibility;
 

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -12,6 +12,7 @@ use varint_rs::VarintWriter;
 use super::{
     connected_clients::{ClientBuffers, ConnectedClients},
     replicon_server::RepliconServer,
+    replicon_tick::RepliconTick,
     ClientMapping, ConnectedClient,
 };
 use crate::core::{
@@ -19,7 +20,6 @@ use crate::core::{
         component_fns::ComponentFns, ctx::SerializeCtx, rule_fns::UntypedRuleFns, FnsId,
     },
     replicon_channels::ReplicationChannel,
-    replicon_tick::RepliconTick,
 };
 
 /// Accumulates replication messages and sends them to clients.

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// A tick that increments each time we need the server to compute and send an update.
 ///
-/// Updated on clients every time they receive replication from the server.
+/// Used only on server.
 /// See also [`TickPolicy`](crate::server::TickPolicy).
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Resource, Serialize)]
 pub struct RepliconTick(pub(crate) u32);

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 
 /// A tick that increments each time we need the server to compute and send an update.
 ///
-/// Used only on server. See [`ServerInitTick`] for tick tracking on the client.
+/// Used only on server.
+/// See [`ServerInitTick`](crate::client::ServerInitTick) for tick tracking on the client.
 /// See also [`TickPolicy`](crate::server::TickPolicy).
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Resource, Serialize)]
 pub struct RepliconTick(pub(crate) u32);

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// A tick that increments each time we need the server to compute and send an update.
 ///
-/// Used only on server.
+/// Used only on server. See [`ServerInitTick`] for tick tracking on the client.
 /// See also [`TickPolicy`](crate::server::TickPolicy).
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Resource, Serialize)]
 pub struct RepliconTick(pub(crate) u32);

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -2,17 +2,15 @@ use std::io::Cursor;
 
 use bevy::prelude::*;
 use bevy_replicon::{
-    core::{
-        replication_fns::{
-            command_fns,
-            ctx::{DeleteCtx, WriteCtx},
-            rule_fns::RuleFns,
-            test_fns::TestFnsEntityExt,
-            ReplicationFns,
-        },
-        replicon_tick::RepliconTick,
+    core::replication_fns::{
+        command_fns,
+        ctx::{DeleteCtx, WriteCtx},
+        rule_fns::RuleFns,
+        test_fns::TestFnsEntityExt,
+        ReplicationFns,
     },
     prelude::*,
+    server::replicon_tick::RepliconTick,
 };
 use serde::{Deserialize, Serialize};
 

--- a/tests/other.rs
+++ b/tests/other.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    core::{replicon_channels::ReplicationChannel, replicon_tick::RepliconTick},
-    prelude::*,
+    core::replicon_channels::ReplicationChannel, prelude::*, server::replicon_tick::RepliconTick,
     test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
@@ -121,8 +120,6 @@ fn client_cleanup_on_disconnect() {
     assert_eq!(client.receive(ReplicationChannel::Init).count(), 0);
 
     app.update();
-
-    assert_eq!(app.world.resource::<RepliconTick>().get(), 0);
 }
 
 #[test]
@@ -177,8 +174,6 @@ fn client_disconnected() {
     assert_eq!(client.receive(ReplicationChannel::Init).count(), 0);
 
     app.update();
-
-    assert_eq!(app.world.resource::<RepliconTick>().get(), 0);
 }
 
 #[test]


### PR DESCRIPTION
I noticed that people sometimes mess with
`RepliconTick` on client and it can result in broken updates. This is why I introduced `ServerInitTick` (similar to `ServerEntityTicks`). It wraps `RepliconTick` and forbids incrementing it. So users can now also have their own `RepliconTick` on the client for rollback scenarios where the client has its own tick that is ahead than the server's tick.