### PR TITLE
Implement history switch for markers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -158,7 +158,8 @@ fn apply_replication(
     // Unlike init messages, we read all updates first, sort them by tick
     // in descending order to ensure that the last update will be applied first.
     // Since update messages manually split by packet size, we apply all messages,
-    // but skip outdated data per-entity by checking last received tick for it.
+    // but skip outdated data per-entity by checking last received tick for it
+    // (unless user requested history via marker).
     let init_tick = *world.resource::<ServerInitTick>();
     let acks_size = mem::size_of::<u16>() * client.received_count(ReplicationChannel::Update);
     let mut acks = Vec::with_capacity(acks_size);

--- a/src/client.rs
+++ b/src/client.rs
@@ -98,29 +98,34 @@ impl ClientPlugin {
                     world.resource_scope(|world, mut buffered_updates: Mut<BufferedUpdates>| {
                         world.resource_scope(|world, command_markers: Mut<CommandMarkers>| {
                             world.resource_scope(|world, replication_fns: Mut<ReplicationFns>| {
-                                let mut stats = world.remove_resource::<ClientStats>();
-                                let mut params = ReceiveParams {
-                                    queue: &mut queue,
-                                    entity_markers: &mut entity_markers,
-                                    entity_map: &mut entity_map,
-                                    entity_ticks: &mut entity_ticks,
-                                    stats: stats.as_mut(),
-                                    command_markers: &command_markers,
-                                    replication_fns: &replication_fns,
-                                };
+                                world.resource_scope(
+                                    |world, mut tick_events: Mut<Events<TickConfirmed>>| {
+                                        let mut stats = world.remove_resource::<ClientStats>();
+                                        let mut params = ReceiveParams {
+                                            queue: &mut queue,
+                                            tick_events: &mut tick_events,
+                                            entity_markers: &mut entity_markers,
+                                            entity_map: &mut entity_map,
+                                            entity_ticks: &mut entity_ticks,
+                                            stats: stats.as_mut(),
+                                            command_markers: &command_markers,
+                                            replication_fns: &replication_fns,
+                                        };
 
-                                apply_replication(
-                                    world,
-                                    &mut params,
-                                    &mut client,
-                                    &mut buffered_updates,
-                                )?;
+                                        apply_replication(
+                                            world,
+                                            &mut params,
+                                            &mut client,
+                                            &mut buffered_updates,
+                                        )?;
 
-                                if let Some(stats) = stats {
-                                    world.insert_resource(stats);
-                                }
+                                        if let Some(stats) = stats {
+                                            world.insert_resource(stats);
+                                        }
 
-                                Ok(())
+                                        Ok(())
+                                    },
+                                )
                             })
                         })
                     })
@@ -450,6 +455,12 @@ fn apply_update_components(
             continue;
         }
         *entity_tick = message_tick;
+        if params.entity_markers.need_history() {
+            params.tick_events.send(TickConfirmed {
+                entity: client_entity.id(),
+                tick: message_tick,
+            });
+        }
 
         let end_pos = cursor.position() + data_size as u64;
         let mut components_count = 0u32;
@@ -517,6 +528,7 @@ fn deserialize_entity(cursor: &mut Cursor<&[u8]>) -> bincode::Result<Entity> {
 /// To avoid passing a lot of arguments into all receive functions.
 struct ReceiveParams<'a> {
     queue: &'a mut CommandQueue,
+    tick_events: &'a mut Events<TickConfirmed>,
     entity_markers: &'a mut EntityMarkers,
     entity_map: &'a mut ServerEntityMap,
     entity_ticks: &'a mut ServerEntityTicks,
@@ -580,6 +592,12 @@ pub enum ClientSet {
     /// If this set is disabled and you don't want to repair client state, then you need to manually clean up
     /// the client after a disconnect or when reconnecting.
     Reset,
+}
+
+#[derive(Event)]
+pub struct TickConfirmed {
+    pub entity: Entity,
+    pub tick: RepliconTick,
 }
 
 /// Last received tick for init message from server.

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use varint_rs::VarintReader;
 
 use crate::{
     core::{
-        command_markers::CommandMarkers,
+        command_markers::{CommandMarkers, EntityMarkers},
         common_conditions::{client_connected, client_just_connected, client_just_disconnected},
         replication_fns::{
             ctx::{DeleteCtx, WriteCtx},
@@ -90,7 +90,7 @@ impl ClientPlugin {
     pub(super) fn receive_replication(
         world: &mut World,
         mut queue: Local<CommandQueue>,
-        mut entity_markers: Local<Vec<bool>>,
+        mut entity_markers: Local<EntityMarkers>,
     ) -> bincode::Result<()> {
         world.resource_scope(|world, mut client: Mut<RepliconClient>| {
             world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
@@ -330,7 +330,7 @@ fn apply_init_components(
         let mut commands = Commands::new_from_entities(params.queue, world_cell.entities());
         params
             .entity_markers
-            .extend(params.command_markers.iter_contains(&client_entity));
+            .read(params.command_markers, &client_entity);
 
         let end_pos = cursor.position() + data_size as u64;
         let mut components_len = 0u32;
@@ -339,11 +339,7 @@ fn apply_init_components(
             let (component_fns, rule_fns) = params.replication_fns.get(fns_id);
             match components_kind {
                 ComponentsKind::Insert => {
-                    let mut ctx = WriteCtx {
-                        commands: &mut commands,
-                        entity_map: params.entity_map,
-                        message_tick,
-                    };
+                    let mut ctx = WriteCtx::new(&mut commands, params.entity_map, message_tick);
 
                     // SAFETY: `rule_fns` and `component_fns` were created for the same type.
                     unsafe {
@@ -373,7 +369,6 @@ fn apply_init_components(
             stats.components_changed += components_len;
         }
 
-        params.entity_markers.clear();
         params.queue.apply(world);
     }
 
@@ -430,16 +425,6 @@ fn apply_update_components(
             cursor.set_position(cursor.position() + data_size as u64);
             continue;
         };
-        let entity_tick = params
-            .entity_ticks
-            .get_mut(&client_entity)
-            .expect("all entities from update should have assigned ticks");
-        if message_tick <= *entity_tick {
-            trace!("ignoring outdated update for client's {client_entity:?}");
-            cursor.set_position(cursor.position() + data_size as u64);
-            continue;
-        }
-        *entity_tick = message_tick;
 
         let world_cell = world.as_unsafe_world_cell();
         // SAFETY: access is unique and used to obtain `EntityMut`, which is just a wrapper over `UnsafeEntityCell`.
@@ -448,28 +433,50 @@ fn apply_update_components(
         let mut commands = Commands::new_from_entities(params.queue, world_cell.entities());
         params
             .entity_markers
-            .extend(params.command_markers.iter_contains(&client_entity));
+            .read(params.command_markers, &client_entity);
+
+        let entity_tick = params
+            .entity_ticks
+            .get_mut(&client_entity.id())
+            .expect("all entities from update should have assigned ticks");
+        let old_entity = message_tick <= *entity_tick;
+        if old_entity && !params.entity_markers.need_history() {
+            trace!(
+                "ignoring outdated update for client's {:?}",
+                client_entity.id()
+            );
+            cursor.set_position(cursor.position() + data_size as u64);
+            continue;
+        }
+        *entity_tick = message_tick;
 
         let end_pos = cursor.position() + data_size as u64;
         let mut components_count = 0u32;
         while cursor.position() < end_pos {
             let fns_id = DefaultOptions::new().deserialize_from(&mut *cursor)?;
             let (component_fns, rule_fns) = params.replication_fns.get(fns_id);
-            let mut ctx = WriteCtx {
-                commands: &mut commands,
-                entity_map: params.entity_map,
-                message_tick,
-            };
+            let mut ctx = WriteCtx::new(&mut commands, params.entity_map, message_tick);
 
             // SAFETY: `rule_fns` and `component_fns` were created for the same type.
             unsafe {
-                component_fns.write(
-                    &mut ctx,
-                    rule_fns,
-                    params.entity_markers,
-                    &mut client_entity,
-                    cursor,
-                )?;
+                if old_entity {
+                    component_fns.consume_or_write(
+                        &mut ctx,
+                        rule_fns,
+                        params.entity_markers,
+                        params.command_markers,
+                        &mut client_entity,
+                        cursor,
+                    )?;
+                } else {
+                    component_fns.write(
+                        &mut ctx,
+                        rule_fns,
+                        params.entity_markers,
+                        &mut client_entity,
+                        cursor,
+                    )?;
+                }
             }
 
             components_count += 1;
@@ -480,7 +487,6 @@ fn apply_update_components(
             stats.components_changed += components_count;
         }
 
-        params.entity_markers.clear();
         params.queue.apply(world);
     }
 
@@ -510,7 +516,7 @@ fn deserialize_entity(cursor: &mut Cursor<&[u8]>) -> bincode::Result<Entity> {
 /// To avoid passing a lot of arguments into all receive functions.
 struct ReceiveParams<'a> {
     queue: &'a mut CommandQueue,
-    entity_markers: &'a mut Vec<bool>,
+    entity_markers: &'a mut EntityMarkers,
     entity_map: &'a mut ServerEntityMap,
     entity_ticks: &'a mut ServerEntityTicks,
     stats: Option<&'a mut ClientStats>,

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -236,6 +236,7 @@ pub struct MarkerConfig {
     pub need_history: bool,
 }
 
+/// Stores which markers are present on an entity.
 pub(crate) struct EntityMarkers {
     markers: Vec<bool>,
     need_history: bool,
@@ -260,10 +261,14 @@ impl EntityMarkers {
         }
     }
 
+    /// Returns a slice of which markers are present on an entity.
+    ///
+    /// Indices corresponds markers in to [`CommandMarkers`].
     pub(super) fn markers(&self) -> &[bool] {
         &self.markers
     }
 
+    /// Returns `true` if an entity have at least one marker that needs history.
     pub(crate) fn need_history(&self) -> bool {
         self.need_history
     }

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -21,7 +21,7 @@ pub trait AppMarkerExt {
     /// For details see [`Self::set_marker_fns`].
     ///
     /// This function registers markers with priority equal to 0.
-    /// Use [`Self::register_marker_with_priority`] if you have multiple
+    /// Use [`Self::register_marker_with`] if you have multiple
     /// markers affecting the same component.
     fn register_marker<M: Component>(&mut self) -> &mut Self;
 

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -311,7 +311,7 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .register_marker::<DummyMarkerA>()
             .register_marker_with::<DummyMarkerB>(MarkerConfig {
-                priority: 1,
+                priority: 2,
                 ..Default::default()
             })
             .register_marker_with::<DummyMarkerC>(MarkerConfig {

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -226,12 +226,12 @@ pub struct MarkerConfig {
     /// By default set to `0`.
     pub priority: usize,
 
-    /// Represents whether a marker need to process old updates.
+    /// Represents whether a marker needs to process old updates.
     ///
     /// Since updates use [`ChannelKind::Unreliable`](crate::core::replicon_channels::ChannelKind),
-    /// client may receive an older update for an entity. By default these updates are discarded,
-    /// but some markers, may need them. If this field is set to `true`, old component updates will
-    /// be passed to writing function for this marker.
+    /// a client may receive an older update for an entity. By default these updates are discarded,
+    /// but some markers may need them. If this field is set to `true`, old component updates will
+    /// be passed to the writing function for this marker.
     ///
     /// By default set to `false`.
     pub need_history: bool,
@@ -269,7 +269,7 @@ impl EntityMarkers {
         &self.markers
     }
 
-    /// Returns `true` if an entity have at least one marker that needs history.
+    /// Returns `true` if an entity has at least one marker that needs history.
     pub(crate) fn need_history(&self) -> bool {
         self.need_history
     }

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -92,7 +92,6 @@ impl ComponentFns {
 
     /// Calls the assigned writing function based on entity markers.
     ///
-    /// Entity markers store information about which markers are present on an entity.
     /// The first-found write function whose marker is present on the entity will be selected
     /// (the functions are sorted by priority).
     /// If there is no such function, it will use the default function.
@@ -100,10 +99,6 @@ impl ComponentFns {
     /// # Safety
     ///
     /// The caller must ensure that `rule_fns` was created for the same type as this instance.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `debug_assertions` is enabled and `entity_markers` has a different length than the number of marker slots.
     pub(crate) unsafe fn write(
         &self,
         ctx: &mut WriteCtx,
@@ -123,6 +118,14 @@ impl ComponentFns {
         (self.write)(ctx, &command_fns, rule_fns, entity, cursor)
     }
 
+    /// Calls the assigned writing or consuming function based on entity markers.
+    ///
+    /// Selects first-found write function like [`Self::write`], but if its marker doesn't require history,
+    /// consume function will be used instead.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `rule_fns` was created for the same type as this instance.
     pub(crate) unsafe fn consume_or_write(
         &self,
         ctx: &mut WriteCtx,
@@ -212,6 +215,11 @@ unsafe fn untyped_write<C: Component>(
     command_fns.write::<C>(ctx, &rule_fns.typed::<C>(), entity, cursor)
 }
 
+/// Resolves `rule_fns` to `C` and calls [`RuleFns::consume`](super::rule_fns::RuleFns) for `C`.
+///
+/// # Safety
+///
+/// The caller must ensure that `rule_fns` was created for `C`.
 unsafe fn untyped_consume<C: Component>(
     ctx: &mut WriteCtx,
     rule_fns: &UntypedRuleFns,

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -182,6 +182,7 @@ type UntypedWriteFn = unsafe fn(
     &mut Cursor<&[u8]>,
 ) -> bincode::Result<()>;
 
+/// Signature of component consuming functions that restore the original type.
 type UntypedConsumeFn =
     unsafe fn(&mut WriteCtx, &UntypedRuleFns, &mut Cursor<&[u8]>) -> bincode::Result<()>;
 

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -116,7 +116,8 @@ impl ComponentFns {
             .markers
             .iter()
             .zip(entity_markers.markers())
-            .find_map(|(fns, &contains)| fns.filter(|_| contains))
+            .filter(|(_, &contains)| contains)
+            .find_map(|(&fns, _)| fns)
             .unwrap_or(self.commands);
 
         (self.write)(ctx, &command_fns, rule_fns, entity, cursor)
@@ -156,7 +157,8 @@ impl ComponentFns {
             .markers
             .iter()
             .zip(entity_markers.markers())
-            .find_map(|(fns, &contains)| fns.filter(|_| contains))
+            .filter(|(_, &contains)| contains)
+            .find_map(|(&fns, _)| fns)
             .unwrap_or(self.commands);
 
         command_fns.remove(ctx, entity_commands)

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -137,8 +137,9 @@ impl ComponentFns {
             .iter()
             .zip(entity_markers.markers())
             .zip(command_markers.iter_require_history())
-            .filter(|&((_, &contains), need_history)| contains && need_history)
-            .find_map(|((&fns, _), _)| fns)
+            .filter(|((_, &contains), _)| contains)
+            .find_map(|((&fns, _), need_history)| fns.map(|fns| (fns, need_history)))
+            .and_then(|(fns, need_history)| need_history.then_some(fns))
         {
             (self.write)(ctx, &command_fns, rule_fns, entity, cursor)
         } else {

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -120,8 +120,8 @@ impl ComponentFns {
 
     /// Calls the assigned writing or consuming function based on entity markers.
     ///
-    /// Selects first-found write function like [`Self::write`], but if its marker doesn't require history,
-    /// consume function will be used instead.
+    /// Selects the first-found write function like [`Self::write`], but if its marker doesn't require history,
+    /// the consume function will be used instead.
     ///
     /// # Safety
     ///
@@ -182,7 +182,7 @@ type UntypedWriteFn = unsafe fn(
     &mut Cursor<&[u8]>,
 ) -> bincode::Result<()>;
 
-/// Signature of component consuming functions that restore the original type.
+/// Signature of component consuming functions that restores the original type.
 type UntypedConsumeFn =
     unsafe fn(&mut WriteCtx, &UntypedRuleFns, &mut Cursor<&[u8]>) -> bincode::Result<()>;
 

--- a/src/core/replication_fns/ctx.rs
+++ b/src/core/replication_fns/ctx.rs
@@ -23,6 +23,7 @@ pub struct WriteCtx<'a, 'w, 's> {
     /// Tick for the currently processing message.
     pub message_tick: RepliconTick,
 
+    /// Disables mapping logic to avoid spawning entities for consume functions.
     pub(super) ignore_mapping: bool,
 }
 

--- a/src/core/replication_fns/ctx.rs
+++ b/src/core/replication_fns/ctx.rs
@@ -22,10 +22,31 @@ pub struct WriteCtx<'a, 'w, 's> {
 
     /// Tick for the currently processing message.
     pub message_tick: RepliconTick,
+
+    pub(super) ignore_mapping: bool,
+}
+
+impl<'a, 'w, 's> WriteCtx<'a, 'w, 's> {
+    pub(crate) fn new(
+        commands: &'a mut Commands<'w, 's>,
+        entity_map: &'a mut ServerEntityMap,
+        message_tick: RepliconTick,
+    ) -> Self {
+        Self {
+            commands,
+            entity_map,
+            message_tick,
+            ignore_mapping: false,
+        }
+    }
 }
 
 impl EntityMapper for WriteCtx<'_, '_, '_> {
     fn map_entity(&mut self, entity: Entity) -> Entity {
+        if self.ignore_mapping {
+            return entity;
+        }
+
         self.entity_map
             .get_by_server_or_insert(entity, || self.commands.spawn(Replicated).id())
     }

--- a/src/core/replication_fns/rule_fns.rs
+++ b/src/core/replication_fns/rule_fns.rs
@@ -94,9 +94,9 @@ impl<C: Component> RuleFns<C> {
         self
     }
 
-    /// Replaces default [`consume_as_deserialize`] with a custom function.
+    /// Replaces the default [`consume_as_deserialize`] with a custom function.
     ///
-    /// This function will be called if an entity have at least one marker
+    /// This function will be called if an entity has at least one marker
     /// that requires history for components that don't belong to that markers.
     ///
     /// If no markers require history, old entity updates will be skipped entirely

--- a/src/core/replication_fns/rule_fns.rs
+++ b/src/core/replication_fns/rule_fns.rs
@@ -88,6 +88,7 @@ impl<C: Component> RuleFns<C> {
     /// Replaces default [`in_place_as_deserialize`] with a custom function.
     ///
     /// This function will be called when a component is already present on an entity.
+    /// For insertion [`Self::deserialize`] will be called instead.
     pub fn with_in_place(mut self, deserialize_in_place: DeserializeInPlaceFn<C>) -> Self {
         self.deserialize_in_place = deserialize_in_place;
         self

--- a/src/core/replication_fns/rule_fns.rs
+++ b/src/core/replication_fns/rule_fns.rs
@@ -96,14 +96,14 @@ impl<C: Component> RuleFns<C> {
 
     /// Replaces the default [`consume_as_deserialize`] with a custom function.
     ///
-    /// For example, if you know the size of the serialized component,
-    /// you can just advance the cursor without its deserialization logic.
+    /// This function will be called to handle stale component updates for entities
+    /// with a marker that indicates the entity's history should be consumed instead of discarded.
     ///
-    /// This function will be called to skip components for entities
-    /// with a marker that require history.
-    ///
-    /// If no markers require history, old entity updates will be skipped entirely
+    /// If no markers on an entity request history, then stale updates will be skipped entirely
     /// by just advancing the cursor (without calling any consume functions).
+    ///
+    /// If you want to ignore a component, just use its expected size to advance the cursor
+    /// without deserializing (but be careful if the component is dynamically sized).
     ///
     /// See [`MarkerConfig::need_history`](crate::core::command_markers::MarkerConfig::need_history)
     /// for details.

--- a/src/core/replication_fns/rule_fns.rs
+++ b/src/core/replication_fns/rule_fns.rs
@@ -96,8 +96,11 @@ impl<C: Component> RuleFns<C> {
 
     /// Replaces the default [`consume_as_deserialize`] with a custom function.
     ///
-    /// This function will be called if an entity has at least one marker
-    /// that requires history for components that don't belong to that markers.
+    /// For example, if you know the size of the serialized component,
+    /// you can just advance the cursor without its deserialization logic.
+    ///
+    /// This function will be called to skip components for entities
+    /// with a marker that require history.
     ///
     /// If no markers require history, old entity updates will be skipped entirely
     /// by just advancing the cursor (without calling any consume functions).

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -2,12 +2,15 @@ use std::io::Cursor;
 
 use bevy::prelude::*;
 use bevy_replicon::{
-    core::replication_fns::{
-        command_fns,
-        ctx::{DeleteCtx, WriteCtx},
-        rule_fns::RuleFns,
-        test_fns::TestFnsEntityExt,
-        ReplicationFns,
+    core::{
+        command_markers::MarkerConfig,
+        replication_fns::{
+            command_fns,
+            ctx::{DeleteCtx, WriteCtx},
+            rule_fns::RuleFns,
+            test_fns::TestFnsEntityExt,
+            ReplicationFns,
+        },
     },
     prelude::*,
     server::replicon_tick::RepliconTick,
@@ -263,7 +266,10 @@ fn remove_with_mutltiple_markers() {
 fn write_with_priority_marker() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .register_marker_with::<ReplaceMarker>(1, false)
+        .register_marker_with::<ReplaceMarker>(MarkerConfig {
+            priority: 1,
+            ..Default::default()
+        })
         .register_marker::<DummyMarker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
@@ -293,7 +299,10 @@ fn write_with_priority_marker() {
 fn remove_with_priority_marker() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .register_marker_with::<ReplaceMarker>(1, false)
+        .register_marker_with::<ReplaceMarker>(MarkerConfig {
+            priority: 1,
+            ..Default::default()
+        })
         .register_marker::<DummyMarker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -263,7 +263,7 @@ fn remove_with_mutltiple_markers() {
 fn write_with_priority_marker() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .register_marker_with_priority::<ReplaceMarker>(1)
+        .register_marker_with::<ReplaceMarker>(1, false)
         .register_marker::<DummyMarker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
@@ -293,7 +293,7 @@ fn write_with_priority_marker() {
 fn remove_with_priority_marker() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .register_marker_with_priority::<ReplaceMarker>(1)
+        .register_marker_with::<ReplaceMarker>(1, false)
         .register_marker::<DummyMarker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,


### PR DESCRIPTION
We currently discard old updates. But when users implement interpolation, they need to store all intermediate values. This PR adds a special field for markers that disables the mentioned discard.

I considered making it a function property, but I think it's more ergonomic as a marker property and faster to calculate.

We replaced `AppMarkerExt::register_marker_with_priority` with `AppMarkerExt::register_marker_with` that also accepts `need_history` boolean. Not quite sure if it should be a bool, maybe use an enum?

Since some markers need history and some not, we introduced `consume` function that can be optionally overriden. By default it just disables mapping entities and calls `deserialize`, but user can optimize it.

Now internally used entity markers is not just a `Vec<bool>`, but a special struct that also pre-computes if an entity have any marker that requires history.

When we read updates, we calculate it first and then and if current entity have any marker that needs history, we don't discard it as before.

Then if an entity is old, we internally invoke newly added `consume_or_write` that calls `write` if history is required by its marker or `consume` if not.