### PR TITLE
Replace `ServerEntityTicks` resource with `Confirmed` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Writing to entities on client now done via `EntityMut` and `Commands` instead of `EntityWorldMut`. It was needed to support the mentioned in-place deserialization and will possibly allow batching insertions in the future (for details see https://github.com/bevyengine/bevy/issues/10154).
 - Return iterator from `RepliconClient::receive` instead of popping the last message. If you used `while` loop for it before, replace it with `for`.
 - Use new `ServerInitTick` resource on client instead of `RepliconTick`. If you used `ServerEventAppExt::add_server_event_with`, use `ServerInitTick` instead of `RepliconTick` in your receive function.
+- Replace `ServerEntityTicks` with `Confirmed` component. The component now also stores whether the last 64 ticks were received.
 - Move `replicon_tick` module under `server` module since now it's used only on server.
 - Move `Replication` to `core` module.
 - Move all functions-related logic from `ReplicationRules` into a new `ReplicationFns` and hide `ReplicationRules` from public API.
@@ -80,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `RepliconChannels::set_client_max_bytes` and `RepliconChannels::set_server_max_bytes` with `RepliconChannels::server_channel_mut` and `RepliconChannels::client_channel_mut` respectively with more rich configuration.
 - Move `ClientEventChannel` to `client_event` module.
 - Move `ServerEventChannel` to `server_event` module.
-- `ClientMapper`, `ServerEntityMap`, `BufferedUpdates`, `ServerEntityTicks`, `ReplicationRules`, `ReplicationChannel`, `ClientEventChannel`, `ServerEventChannel`, `ServerEventQueue` and `EventMapper` are no longer in `prelude` module. Import them directly.
+- `ClientMapper`, `ServerEntityMap`, `BufferedUpdates`, `ReplicationRules`, `ReplicationChannel`, `ClientEventChannel`, `ServerEventChannel`, `ServerEventQueue` and `EventMapper` are no longer in `prelude` module. Import them directly.
 
 ## [0.23.0] - 2024-02-22
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -328,10 +328,11 @@ fn apply_init_components(
             .entity_markers
             .read(params.command_markers, &client_entity);
 
-        let mut confirmed = client_entity
-            .get_mut::<Confirmed>()
-            .expect("all init entities should have been spawned with confirmed ticks");
-        confirmed.resize_to(message_tick);
+        if let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() {
+            confirmed.resize_to(message_tick);
+        } else {
+            error!("entity without Confirmed: {:?}", client_entity.id());
+        }
 
         let end_pos = cursor.position() + data_size as u64;
         let mut components_len = 0u32;

--- a/src/client.rs
+++ b/src/client.rs
@@ -451,7 +451,7 @@ fn apply_update_components(
                 continue;
             }
 
-            let ago = confirmed.last_tick() - message_tick;
+            let ago = confirmed.last_tick().get().wrapping_sub(message_tick.get());
             if ago >= u64::BITS {
                 trace!(
                     "discarding update {ago} ticks old for client's {:?}",

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,13 +1,11 @@
+pub mod confirmed;
 pub mod diagnostics;
 pub mod replicon_client;
 pub mod server_entity_map;
 
 use std::{io::Cursor, mem};
 
-use bevy::{
-    ecs::{entity::EntityHashMap, system::CommandQueue},
-    prelude::*,
-};
+use bevy::{ecs::system::CommandQueue, prelude::*};
 use bincode::{DefaultOptions, Options};
 use bytes::Bytes;
 use varint_rs::VarintReader;
@@ -25,6 +23,7 @@ use crate::{
     },
     server::replicon_tick::RepliconTick,
 };
+use confirmed::Confirmed;
 use diagnostics::ClientStats;
 use replicon_client::RepliconClient;
 use server_entity_map::ServerEntityMap;
@@ -36,7 +35,6 @@ impl Plugin for ClientPlugin {
         app.init_resource::<RepliconClient>()
             .init_resource::<ServerEntityMap>()
             .init_resource::<ServerInitTick>()
-            .init_resource::<ServerEntityTicks>()
             .init_resource::<BufferedUpdates>()
             .configure_sets(
                 PreUpdate,
@@ -94,34 +92,31 @@ impl ClientPlugin {
     ) -> bincode::Result<()> {
         world.resource_scope(|world, mut client: Mut<RepliconClient>| {
             world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
-                world.resource_scope(|world, mut entity_ticks: Mut<ServerEntityTicks>| {
-                    world.resource_scope(|world, mut buffered_updates: Mut<BufferedUpdates>| {
-                        world.resource_scope(|world, command_markers: Mut<CommandMarkers>| {
-                            world.resource_scope(|world, replication_fns: Mut<ReplicationFns>| {
-                                let mut stats = world.remove_resource::<ClientStats>();
-                                let mut params = ReceiveParams {
-                                    queue: &mut queue,
-                                    entity_markers: &mut entity_markers,
-                                    entity_map: &mut entity_map,
-                                    entity_ticks: &mut entity_ticks,
-                                    stats: stats.as_mut(),
-                                    command_markers: &command_markers,
-                                    replication_fns: &replication_fns,
-                                };
+                world.resource_scope(|world, mut buffered_updates: Mut<BufferedUpdates>| {
+                    world.resource_scope(|world, command_markers: Mut<CommandMarkers>| {
+                        world.resource_scope(|world, replication_fns: Mut<ReplicationFns>| {
+                            let mut stats = world.remove_resource::<ClientStats>();
+                            let mut params = ReceiveParams {
+                                queue: &mut queue,
+                                entity_markers: &mut entity_markers,
+                                entity_map: &mut entity_map,
+                                stats: stats.as_mut(),
+                                command_markers: &command_markers,
+                                replication_fns: &replication_fns,
+                            };
 
-                                apply_replication(
-                                    world,
-                                    &mut params,
-                                    &mut client,
-                                    &mut buffered_updates,
-                                )?;
+                            apply_replication(
+                                world,
+                                &mut params,
+                                &mut client,
+                                &mut buffered_updates,
+                            )?;
 
-                                if let Some(stats) = stats {
-                                    world.insert_resource(stats);
-                                }
+                            if let Some(stats) = stats {
+                                world.insert_resource(stats);
+                            }
 
-                                Ok(())
-                            })
+                            Ok(())
                         })
                     })
                 })
@@ -132,12 +127,10 @@ impl ClientPlugin {
     fn reset(
         mut init_tick: ResMut<ServerInitTick>,
         mut entity_map: ResMut<ServerEntityMap>,
-        mut entity_ticks: ResMut<ServerEntityTicks>,
         mut buffered_updates: ResMut<BufferedUpdates>,
     ) {
         *init_tick = Default::default();
         entity_map.clear();
-        entity_ticks.clear();
         buffered_updates.clear();
     }
 }
@@ -190,7 +183,7 @@ fn apply_init_message(
     world.resource_mut::<ServerInitTick>().0 = message_tick;
     debug_assert!(cursor.position() < end_pos, "init message can't be empty");
 
-    apply_entity_mappings(world, params, &mut cursor)?;
+    apply_entity_mappings(world, params, &mut cursor, message_tick)?;
     if cursor.position() == end_pos {
         return Ok(());
     }
@@ -285,6 +278,7 @@ fn apply_entity_mappings(
     world: &mut World,
     params: &mut ReceiveParams,
     cursor: &mut Cursor<&[u8]>,
+    message_tick: RepliconTick,
 ) -> bincode::Result<()> {
     let mappings_len: u16 = bincode::deserialize_from(&mut *cursor)?;
     if let Some(stats) = &mut params.stats {
@@ -296,7 +290,7 @@ fn apply_entity_mappings(
 
         if let Some(mut entity) = world.get_entity_mut(client_entity) {
             debug!("received mapping from {server_entity:?} to {client_entity:?}");
-            entity.insert(Replicated);
+            entity.insert((Replicated, Confirmed::new(message_tick)));
             params.entity_map.insert(server_entity, client_entity);
         } else {
             // Entity could be despawned on client already.
@@ -321,13 +315,18 @@ fn apply_init_components(
 
         let client_entity = params
             .entity_map
-            .get_by_server_or_insert(server_entity, || world.spawn(Replicated).id());
-        params.entity_ticks.insert(client_entity, message_tick);
+            .get_by_server_or_insert(server_entity, || {
+                world.spawn((Replicated, Confirmed::new(message_tick))).id()
+            });
 
         let world_cell = world.as_unsafe_world_cell();
         // SAFETY: access is unique and used to obtain `EntityMut`, which is just a wrapper over `UnsafeEntityCell`.
         let mut client_entity: EntityMut =
             unsafe { world_cell.world_mut().entity_mut(client_entity).into() };
+        client_entity
+            .get_mut::<Confirmed>()
+            .unwrap()
+            .set(message_tick);
         let mut commands = Commands::new_from_entities(params.queue, world_cell.entities());
         params
             .entity_markers
@@ -397,7 +396,6 @@ fn apply_despawns(
             .remove_by_server(server_entity)
             .and_then(|entity| world.get_entity_mut(entity))
         {
-            params.entity_ticks.remove(&client_entity.id());
             let ctx = DeleteCtx { message_tick };
             (params.replication_fns.despawn)(&ctx, client_entity);
         }
@@ -436,11 +434,8 @@ fn apply_update_components(
             .entity_markers
             .read(params.command_markers, &client_entity);
 
-        let entity_tick = params
-            .entity_ticks
-            .get_mut(&client_entity.id())
-            .expect("all entities from update should have assigned ticks");
-        let old_entity = message_tick <= *entity_tick;
+        let mut confirmed = client_entity.get_mut::<Confirmed>().unwrap();
+        let old_entity = !confirmed.set(message_tick);
         if old_entity && !params.entity_markers.need_history() {
             trace!(
                 "ignoring outdated update for client's {:?}",
@@ -449,7 +444,6 @@ fn apply_update_components(
             cursor.set_position(cursor.position() + data_size as u64);
             continue;
         }
-        *entity_tick = message_tick;
 
         let end_pos = cursor.position() + data_size as u64;
         let mut components_count = 0u32;
@@ -519,7 +513,6 @@ struct ReceiveParams<'a> {
     queue: &'a mut CommandQueue,
     entity_markers: &'a mut EntityMarkers,
     entity_map: &'a mut ServerEntityMap,
-    entity_ticks: &'a mut ServerEntityTicks,
     stats: Option<&'a mut ClientStats>,
     command_markers: &'a CommandMarkers,
     replication_fns: &'a ReplicationFns,
@@ -588,14 +581,6 @@ pub enum ClientSet {
 /// When a component changes, this value is not updated.
 #[derive(Clone, Copy, Debug, Default, Deref, Resource)]
 pub struct ServerInitTick(RepliconTick);
-
-/// Last received tick for each entity.
-///
-/// Used to avoid applying old updates.
-///
-/// If [`ClientSet::Reset`] is disabled, then this needs to be cleaned up manually.
-#[derive(Default, Deref, DerefMut, Resource)]
-pub struct ServerEntityTicks(EntityHashMap<RepliconTick>);
 
 /// All cached buffered updates, used by the replicon client to align replication updates with initialization
 /// messages.

--- a/src/client.rs
+++ b/src/client.rs
@@ -326,7 +326,7 @@ fn apply_init_components(
             .read(params.command_markers, &client_entity);
 
         if let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() {
-            confirmed.resize_to(message_tick);
+            confirmed.set_last_tick(message_tick);
         } else {
             commands
                 .entity(client_entity.id())
@@ -440,7 +440,7 @@ fn apply_update_components(
             .expect("all entities from update should have confirmed ticks");
         let new_entity = message_tick > confirmed.last_tick();
         if new_entity {
-            confirmed.resize_to(message_tick);
+            confirmed.set_last_tick(message_tick);
         } else {
             if !params.entity_markers.need_history() {
                 trace!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -328,11 +328,10 @@ fn apply_init_components(
             .entity_markers
             .read(params.command_markers, &client_entity);
 
-        if let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() {
-            confirmed.resize_to(message_tick);
-        } else {
-            error!("entity without Confirmed: {:?}", client_entity.id());
-        }
+        let mut confirmed = client_entity
+            .get_mut::<Confirmed>()
+            .expect("all init entities should have been spawned with confirmed ticks");
+        confirmed.resize_to(message_tick);
 
         let end_pos = cursor.position() + data_size as u64;
         let mut components_len = 0u32;

--- a/src/client.rs
+++ b/src/client.rs
@@ -331,6 +331,7 @@ fn apply_init_components(
         if let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() {
             confirmed.resize_to(message_tick);
         } else {
+            commands.entity(client_entity.id()).log_components();
             error!("entity without Confirmed: {:?}", client_entity.id());
         }
 
@@ -436,9 +437,11 @@ fn apply_update_components(
             .entity_markers
             .read(params.command_markers, &client_entity);
 
-        let mut confirmed = client_entity
-            .get_mut::<Confirmed>()
-            .expect("all entities from update should have confirmed ticks");
+        let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() else {
+            commands.entity(client_entity.id()).log_components();
+            error!("entity without Confirmed: {:?}", client_entity.id());
+            continue;
+        };
         let new_entity = message_tick > confirmed.last_tick();
         if new_entity {
             confirmed.resize_to(message_tick);

--- a/src/client.rs
+++ b/src/client.rs
@@ -331,7 +331,6 @@ fn apply_init_components(
         if let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() {
             confirmed.resize_to(message_tick);
         } else {
-            commands.entity(client_entity.id()).log_components();
             error!("entity without Confirmed: {:?}", client_entity.id());
         }
 
@@ -437,11 +436,9 @@ fn apply_update_components(
             .entity_markers
             .read(params.command_markers, &client_entity);
 
-        let Some(mut confirmed) = client_entity.get_mut::<Confirmed>() else {
-            commands.entity(client_entity.id()).log_components();
-            error!("entity without Confirmed: {:?}", client_entity.id());
-            continue;
-        };
+        let mut confirmed = client_entity
+            .get_mut::<Confirmed>()
+            .expect("all entities from update should have confirmed ticks");
         let new_entity = message_tick > confirmed.last_tick();
         if new_entity {
             confirmed.resize_to(message_tick);

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -46,14 +46,15 @@ impl Confirmed {
         ago >= u64::BITS || (self.mask >> ago & 1) == 1
     }
 
-    /// Returns `true` if any tick in the given range confirmed for an entity.
+    /// Returns `true` if any tick in the given range was confirmed for the entity with
+    /// this component.
     ///
     /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
     ///
     /// # Panics
     ///
     /// Panics if `debug_assertions` are enabled and
-    /// `start_tick` is bigger then `end_tick`.
+    /// `start_tick` is greater then `end_tick`.
     pub fn contains_any(&self, start_tick: RepliconTick, end_tick: RepliconTick) -> bool {
         debug_assert!(start_tick <= end_tick);
 

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -24,7 +24,8 @@ impl Debug for Confirmed {
 }
 
 impl Confirmed {
-    pub(super) fn new(last_tick: RepliconTick) -> Self {
+    /// Creates a new instance with a single confirmed tick.
+    pub fn new(last_tick: RepliconTick) -> Self {
         Self { mask: 1, last_tick }
     }
 
@@ -45,14 +46,24 @@ impl Confirmed {
         ago >= u64::BITS || (self.mask >> ago & 1) == 1
     }
 
-    /// Marks specific tick as received.
-    pub(super) fn set(&mut self, ago: u32) {
+    /// Marks previous tick as received.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `debug_assertions` are enabled and
+    /// `ago` is bigger then [`u64::BITS`].
+    pub fn set(&mut self, ago: u32) {
         debug_assert!(ago < u64::BITS);
         self.mask |= 1 << ago;
     }
 
     /// Sets the last received tick and shifts the mask.
-    pub(super) fn resize_to(&mut self, tick: RepliconTick) {
+    ///
+    /// # Panics
+    ///
+    /// Panics if `debug_assertions` are enabled and
+    /// `tick` is less then the last tick.
+    pub fn resize_to(&mut self, tick: RepliconTick) {
         debug_assert!(tick >= self.last_tick);
         let diff = tick - self.last_tick;
         self.mask = self.mask.wrapping_shl(diff);

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -42,7 +42,7 @@ impl Confirmed {
             return false;
         }
 
-        let ago = self.last_tick - tick;
+        let ago = self.last_tick.get().wrapping_sub(tick.get());
         ago >= u64::BITS || (self.mask >> ago & 1) == 1
     }
 
@@ -68,9 +68,9 @@ impl Confirmed {
             return false;
         }
 
-        let ago = end_tick - start_tick;
+        let ago = end_tick.get().wrapping_sub(start_tick.get());
         let range = (1 << (ago + 1)) - 1; // Set bit to `ago + 1` and then decrement to get `ago` of 1's.
-        let offset = self.last_tick - end_tick;
+        let offset = self.last_tick.get().wrapping_sub(end_tick.get());
         let mask = range << offset;
 
         self.mask & mask != 0
@@ -83,7 +83,7 @@ impl Confirmed {
         if tick > self.last_tick {
             self.set_last_tick(tick);
         }
-        let ago = self.last_tick - tick;
+        let ago = self.last_tick.get().wrapping_sub(tick.get());
         if ago < u64::BITS {
             self.set(ago);
         }
@@ -108,7 +108,7 @@ impl Confirmed {
     /// `tick` is less then the last tick.
     pub(super) fn set_last_tick(&mut self, tick: RepliconTick) {
         debug_assert!(tick >= self.last_tick);
-        let diff = tick - self.last_tick;
+        let diff = tick.get().wrapping_sub(self.last_tick.get());
         self.mask = self.mask.wrapping_shl(diff);
         self.last_tick = tick;
         self.mask |= 1;

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -22,6 +22,11 @@ impl Confirmed {
         Self { mask: 1, last_tick }
     }
 
+    /// Returns last received tick for an entity.
+    pub fn last_tick(&self) -> RepliconTick {
+        self.last_tick
+    }
+
     /// Returns `true` if this tick is confirmed for an entity.
     pub fn get(&self, tick: RepliconTick) -> bool {
         if tick > self.last_tick {

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -81,7 +81,7 @@ impl Confirmed {
     /// Useful for unit tests.
     pub fn confirm(&mut self, tick: RepliconTick) {
         if tick > self.last_tick {
-            self.resize_to(tick);
+            self.set_last_tick(tick);
         }
         let ago = self.last_tick - tick;
         if ago < u64::BITS {
@@ -106,7 +106,7 @@ impl Confirmed {
     ///
     /// Panics if `debug_assertions` are enabled and
     /// `tick` is less then the last tick.
-    pub(super) fn resize_to(&mut self, tick: RepliconTick) {
+    pub(super) fn set_last_tick(&mut self, tick: RepliconTick) {
         debug_assert!(tick >= self.last_tick);
         let diff = tick - self.last_tick;
         self.mask = self.mask.wrapping_shl(diff);
@@ -172,7 +172,7 @@ mod tests {
     fn resize() {
         let mut confirmed = Confirmed::new(RepliconTick(1));
 
-        confirmed.resize_to(RepliconTick(2));
+        confirmed.set_last_tick(RepliconTick(2));
 
         assert!(!confirmed.contains(RepliconTick(0)));
         assert!(confirmed.contains(RepliconTick(1)));
@@ -183,7 +183,7 @@ mod tests {
     fn resize_to_same() {
         let mut confirmed = Confirmed::new(RepliconTick(1));
 
-        confirmed.resize_to(RepliconTick(1));
+        confirmed.set_last_tick(RepliconTick(1));
 
         assert!(!confirmed.contains(RepliconTick(0)));
         assert!(confirmed.contains(RepliconTick(1)));
@@ -194,7 +194,7 @@ mod tests {
     fn resize_with_wrapping() {
         let mut confirmed = Confirmed::new(RepliconTick(1));
 
-        confirmed.resize_to(RepliconTick(65));
+        confirmed.set_last_tick(RepliconTick(65));
 
         assert!(confirmed.contains(RepliconTick(0)));
         assert!(confirmed.contains(RepliconTick(1)));
@@ -208,7 +208,7 @@ mod tests {
     fn resize_with_overflow() {
         let mut confirmed = Confirmed::new(RepliconTick(u32::MAX));
 
-        confirmed.resize_to(RepliconTick(1));
+        confirmed.set_last_tick(RepliconTick(1));
 
         assert!(!confirmed.contains(RepliconTick(0)));
         assert!(confirmed.contains(RepliconTick(1)));

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -1,0 +1,115 @@
+use std::fmt::{self, Debug, Formatter};
+
+use bevy::prelude::*;
+
+use crate::server::replicon_tick::RepliconTick;
+
+/// Received tick from server for an entity.
+#[derive(Component)]
+pub struct Confirmed {
+    mask: u64,
+    last_tick: RepliconTick,
+}
+
+impl Debug for Confirmed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Confirmed [{:?} {:b}]", self.last_tick, self.mask)
+    }
+}
+
+impl Confirmed {
+    pub(super) fn new(last_tick: RepliconTick) -> Self {
+        Self { mask: 1, last_tick }
+    }
+
+    /// Returns `true` if this tick is confirmed for an entity.
+    pub fn get(&self, tick: RepliconTick) -> bool {
+        if tick > self.last_tick {
+            return false;
+        }
+
+        let ago = self.last_tick - tick;
+        ago >= u64::BITS || (self.mask >> ago & 1) == 1
+    }
+
+    pub(super) fn set(&mut self, tick: RepliconTick) -> bool {
+        let new = tick > self.last_tick;
+        if new {
+            self.resize_to(tick);
+        }
+
+        let ago = self.last_tick - tick;
+        self.mask |= 1 << ago;
+
+        new
+    }
+
+    fn resize_to(&mut self, tick: RepliconTick) {
+        let diff = tick - self.last_tick;
+        self.mask = self.mask.wrapping_shl(diff);
+        self.last_tick = tick;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get() {
+        let confirmed = Confirmed::new(RepliconTick(1));
+
+        assert_eq!(confirmed.get(RepliconTick(0)), false);
+        assert_eq!(confirmed.get(RepliconTick(1)), true);
+        assert_eq!(confirmed.get(RepliconTick(2)), false);
+        assert_eq!(confirmed.get(RepliconTick(u32::MAX)), false);
+    }
+
+    #[test]
+    fn set_previous() {
+        let mut confirmed = Confirmed::new(RepliconTick(1));
+
+        confirmed.set(RepliconTick(0));
+
+        assert_eq!(confirmed.get(RepliconTick(0)), true);
+        assert_eq!(confirmed.get(RepliconTick(1)), true);
+        assert_eq!(confirmed.get(RepliconTick(2)), false);
+    }
+
+    #[test]
+    fn set_next() {
+        let mut confirmed = Confirmed::new(RepliconTick(1));
+
+        confirmed.set(RepliconTick(2));
+
+        assert_eq!(confirmed.get(RepliconTick(0)), false);
+        assert_eq!(confirmed.get(RepliconTick(1)), true);
+        assert_eq!(confirmed.get(RepliconTick(2)), true);
+    }
+
+    #[test]
+    fn set_with_resize() {
+        let mut confirmed = Confirmed::new(RepliconTick(1));
+
+        confirmed.set(RepliconTick(65));
+
+        assert_eq!(confirmed.get(RepliconTick(0)), true);
+        assert_eq!(confirmed.get(RepliconTick(1)), true);
+        assert_eq!(confirmed.get(RepliconTick(2)), false);
+        assert_eq!(confirmed.get(RepliconTick(64)), false);
+        assert_eq!(confirmed.get(RepliconTick(65)), true);
+        assert_eq!(confirmed.get(RepliconTick(66)), false);
+    }
+
+    #[test]
+    fn set_with_overflow() {
+        let mut confirmed = Confirmed::new(RepliconTick(u32::MAX));
+
+        confirmed.set(RepliconTick(1));
+
+        assert_eq!(confirmed.get(RepliconTick(0)), false);
+        assert_eq!(confirmed.get(RepliconTick(1)), true);
+        assert_eq!(confirmed.get(RepliconTick(3)), false);
+        assert_eq!(confirmed.get(RepliconTick(u32::MAX)), true);
+    }
+}

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -157,4 +157,26 @@ mod tests {
         assert!(!confirmed.contains(RepliconTick(3)));
         assert!(confirmed.contains(RepliconTick(u32::MAX)));
     }
+
+    #[test]
+    fn confirm_with_resize() {
+        let mut confirmed = Confirmed::new(RepliconTick(1));
+
+        confirmed.confirm(RepliconTick(2));
+
+        assert!(!confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(confirmed.contains(RepliconTick(2)));
+    }
+
+    #[test]
+    fn confirm_with_set() {
+        let mut confirmed = Confirmed::new(RepliconTick(1));
+
+        confirmed.confirm(RepliconTick(0));
+
+        assert!(confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(!confirmed.contains(RepliconTick(2)));
+    }
 }

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -37,7 +37,7 @@ impl Confirmed {
     /// Returns `true` if this tick is confirmed for an entity.
     ///
     /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
-    pub fn get(&self, tick: RepliconTick) -> bool {
+    pub fn test(&self, tick: RepliconTick) -> bool {
         if tick > self.last_tick {
             return false;
         }
@@ -77,13 +77,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn get() {
+    fn test() {
         let confirmed = Confirmed::new(RepliconTick(1));
 
-        assert!(!confirmed.get(RepliconTick(0)));
-        assert!(confirmed.get(RepliconTick(1)));
-        assert!(!confirmed.get(RepliconTick(2)));
-        assert!(!confirmed.get(RepliconTick(u32::MAX)));
+        assert!(!confirmed.test(RepliconTick(0)));
+        assert!(confirmed.test(RepliconTick(1)));
+        assert!(!confirmed.test(RepliconTick(2)));
+        assert!(!confirmed.test(RepliconTick(u32::MAX)));
     }
 
     #[test]
@@ -92,9 +92,9 @@ mod tests {
 
         confirmed.set(1);
 
-        assert!(confirmed.get(RepliconTick(0)));
-        assert!(confirmed.get(RepliconTick(1)));
-        assert!(!confirmed.get(RepliconTick(2)));
+        assert!(confirmed.test(RepliconTick(0)));
+        assert!(confirmed.test(RepliconTick(1)));
+        assert!(!confirmed.test(RepliconTick(2)));
     }
 
     #[test]
@@ -103,9 +103,9 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(2));
 
-        assert!(!confirmed.get(RepliconTick(0)));
-        assert!(confirmed.get(RepliconTick(1)));
-        assert!(confirmed.get(RepliconTick(2)));
+        assert!(!confirmed.test(RepliconTick(0)));
+        assert!(confirmed.test(RepliconTick(1)));
+        assert!(confirmed.test(RepliconTick(2)));
     }
 
     #[test]
@@ -114,9 +114,9 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(1));
 
-        assert!(!confirmed.get(RepliconTick(0)));
-        assert!(confirmed.get(RepliconTick(1)));
-        assert!(!confirmed.get(RepliconTick(2)));
+        assert!(!confirmed.test(RepliconTick(0)));
+        assert!(confirmed.test(RepliconTick(1)));
+        assert!(!confirmed.test(RepliconTick(2)));
     }
 
     #[test]
@@ -125,12 +125,12 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(65));
 
-        assert!(confirmed.get(RepliconTick(0)));
-        assert!(confirmed.get(RepliconTick(1)));
-        assert!(!confirmed.get(RepliconTick(2)));
-        assert!(!confirmed.get(RepliconTick(64)));
-        assert!(confirmed.get(RepliconTick(65)));
-        assert!(!confirmed.get(RepliconTick(66)));
+        assert!(confirmed.test(RepliconTick(0)));
+        assert!(confirmed.test(RepliconTick(1)));
+        assert!(!confirmed.test(RepliconTick(2)));
+        assert!(!confirmed.test(RepliconTick(64)));
+        assert!(confirmed.test(RepliconTick(65)));
+        assert!(!confirmed.test(RepliconTick(66)));
     }
 
     #[test]
@@ -139,9 +139,9 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(1));
 
-        assert!(!confirmed.get(RepliconTick(0)));
-        assert!(confirmed.get(RepliconTick(1)));
-        assert!(!confirmed.get(RepliconTick(3)));
-        assert!(confirmed.get(RepliconTick(u32::MAX)));
+        assert!(!confirmed.test(RepliconTick(0)));
+        assert!(confirmed.test(RepliconTick(1)));
+        assert!(!confirmed.test(RepliconTick(3)));
+        assert!(confirmed.test(RepliconTick(u32::MAX)));
     }
 }

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -59,10 +59,10 @@ mod tests {
     fn get() {
         let confirmed = Confirmed::new(RepliconTick(1));
 
-        assert_eq!(confirmed.get(RepliconTick(0)), false);
-        assert_eq!(confirmed.get(RepliconTick(1)), true);
-        assert_eq!(confirmed.get(RepliconTick(2)), false);
-        assert_eq!(confirmed.get(RepliconTick(u32::MAX)), false);
+        assert!(!confirmed.get(RepliconTick(0)));
+        assert!(confirmed.get(RepliconTick(1)));
+        assert!(!confirmed.get(RepliconTick(2)));
+        assert!(!confirmed.get(RepliconTick(u32::MAX)));
     }
 
     #[test]
@@ -71,9 +71,9 @@ mod tests {
 
         confirmed.set(RepliconTick(0));
 
-        assert_eq!(confirmed.get(RepliconTick(0)), true);
-        assert_eq!(confirmed.get(RepliconTick(1)), true);
-        assert_eq!(confirmed.get(RepliconTick(2)), false);
+        assert!(confirmed.get(RepliconTick(0)));
+        assert!(confirmed.get(RepliconTick(1)));
+        assert!(!confirmed.get(RepliconTick(2)));
     }
 
     #[test]
@@ -82,9 +82,9 @@ mod tests {
 
         confirmed.set(RepliconTick(2));
 
-        assert_eq!(confirmed.get(RepliconTick(0)), false);
-        assert_eq!(confirmed.get(RepliconTick(1)), true);
-        assert_eq!(confirmed.get(RepliconTick(2)), true);
+        assert!(!confirmed.get(RepliconTick(0)));
+        assert!(confirmed.get(RepliconTick(1)));
+        assert!(confirmed.get(RepliconTick(2)));
     }
 
     #[test]
@@ -93,12 +93,12 @@ mod tests {
 
         confirmed.set(RepliconTick(65));
 
-        assert_eq!(confirmed.get(RepliconTick(0)), true);
-        assert_eq!(confirmed.get(RepliconTick(1)), true);
-        assert_eq!(confirmed.get(RepliconTick(2)), false);
-        assert_eq!(confirmed.get(RepliconTick(64)), false);
-        assert_eq!(confirmed.get(RepliconTick(65)), true);
-        assert_eq!(confirmed.get(RepliconTick(66)), false);
+        assert!(confirmed.get(RepliconTick(0)));
+        assert!(confirmed.get(RepliconTick(1)));
+        assert!(!confirmed.get(RepliconTick(2)));
+        assert!(!confirmed.get(RepliconTick(64)));
+        assert!(confirmed.get(RepliconTick(65)));
+        assert!(!confirmed.get(RepliconTick(66)));
     }
 
     #[test]
@@ -107,9 +107,9 @@ mod tests {
 
         confirmed.set(RepliconTick(1));
 
-        assert_eq!(confirmed.get(RepliconTick(0)), false);
-        assert_eq!(confirmed.get(RepliconTick(1)), true);
-        assert_eq!(confirmed.get(RepliconTick(3)), false);
-        assert_eq!(confirmed.get(RepliconTick(u32::MAX)), true);
+        assert!(!confirmed.get(RepliconTick(0)));
+        assert!(confirmed.get(RepliconTick(1)));
+        assert!(!confirmed.get(RepliconTick(3)));
+        assert!(confirmed.get(RepliconTick(u32::MAX)));
     }
 }

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -43,7 +43,7 @@ impl Confirmed {
         }
 
         let ago = self.last_tick - tick;
-        ago >= u64::BITS || (self.mask >> (ago & 1)) == 1
+        ago >= u64::BITS || (self.mask >> ago & 1) == 1
     }
 
     /// Returns `true` if any tick in the given range confirmed for an entity.

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -98,6 +98,17 @@ mod tests {
     }
 
     #[test]
+    fn resize_to_same() {
+        let mut confirmed = Confirmed::new(RepliconTick(1));
+
+        confirmed.resize_to(RepliconTick(1));
+
+        assert!(!confirmed.get(RepliconTick(0)));
+        assert!(confirmed.get(RepliconTick(1)));
+        assert!(!confirmed.get(RepliconTick(2)));
+    }
+
+    #[test]
     fn resize_with_wrapping() {
         let mut confirmed = Confirmed::new(RepliconTick(1));
 

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -37,7 +37,7 @@ impl Confirmed {
     /// Returns `true` if this tick is confirmed for an entity.
     ///
     /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
-    pub fn test(&self, tick: RepliconTick) -> bool {
+    pub fn contains(&self, tick: RepliconTick) -> bool {
         if tick > self.last_tick {
             return false;
         }
@@ -90,13 +90,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test() {
+    fn contains() {
         let confirmed = Confirmed::new(RepliconTick(1));
 
-        assert!(!confirmed.test(RepliconTick(0)));
-        assert!(confirmed.test(RepliconTick(1)));
-        assert!(!confirmed.test(RepliconTick(2)));
-        assert!(!confirmed.test(RepliconTick(u32::MAX)));
+        assert!(!confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(!confirmed.contains(RepliconTick(2)));
+        assert!(!confirmed.contains(RepliconTick(u32::MAX)));
     }
 
     #[test]
@@ -105,9 +105,9 @@ mod tests {
 
         confirmed.set(1);
 
-        assert!(confirmed.test(RepliconTick(0)));
-        assert!(confirmed.test(RepliconTick(1)));
-        assert!(!confirmed.test(RepliconTick(2)));
+        assert!(confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(!confirmed.contains(RepliconTick(2)));
     }
 
     #[test]
@@ -116,9 +116,9 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(2));
 
-        assert!(!confirmed.test(RepliconTick(0)));
-        assert!(confirmed.test(RepliconTick(1)));
-        assert!(confirmed.test(RepliconTick(2)));
+        assert!(!confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(confirmed.contains(RepliconTick(2)));
     }
 
     #[test]
@@ -127,9 +127,9 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(1));
 
-        assert!(!confirmed.test(RepliconTick(0)));
-        assert!(confirmed.test(RepliconTick(1)));
-        assert!(!confirmed.test(RepliconTick(2)));
+        assert!(!confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(!confirmed.contains(RepliconTick(2)));
     }
 
     #[test]
@@ -138,12 +138,12 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(65));
 
-        assert!(confirmed.test(RepliconTick(0)));
-        assert!(confirmed.test(RepliconTick(1)));
-        assert!(!confirmed.test(RepliconTick(2)));
-        assert!(!confirmed.test(RepliconTick(64)));
-        assert!(confirmed.test(RepliconTick(65)));
-        assert!(!confirmed.test(RepliconTick(66)));
+        assert!(confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(!confirmed.contains(RepliconTick(2)));
+        assert!(!confirmed.contains(RepliconTick(64)));
+        assert!(confirmed.contains(RepliconTick(65)));
+        assert!(!confirmed.contains(RepliconTick(66)));
     }
 
     #[test]
@@ -152,9 +152,9 @@ mod tests {
 
         confirmed.resize_to(RepliconTick(1));
 
-        assert!(!confirmed.test(RepliconTick(0)));
-        assert!(confirmed.test(RepliconTick(1)));
-        assert!(!confirmed.test(RepliconTick(3)));
-        assert!(confirmed.test(RepliconTick(u32::MAX)));
+        assert!(!confirmed.contains(RepliconTick(0)));
+        assert!(confirmed.contains(RepliconTick(1)));
+        assert!(!confirmed.contains(RepliconTick(3)));
+        assert!(confirmed.contains(RepliconTick(u32::MAX)));
     }
 }

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -4,16 +4,16 @@ use bevy::prelude::*;
 
 use crate::server::replicon_tick::RepliconTick;
 
-/// Received ticks from server for an entity.
+/// Received ticks from the server for an entity.
 ///
-/// For efficiency reason we store only last received tick and
-/// a bitmask indicating whether the last 64 ticks were received.
+/// For efficiency we store only the last received tick and
+/// a bitmask indicating whether the most recent 64 ticks were received.
 #[derive(Component)]
 pub struct Confirmed {
     /// Previously confirmed ticks, including the last tick at position 0.
     mask: u64,
 
-    /// Last received tick from server for an entity.
+    /// The last received server tick for an entity.
     last_tick: RepliconTick,
 }
 

--- a/src/client/confirmed.rs
+++ b/src/client/confirmed.rs
@@ -46,13 +46,26 @@ impl Confirmed {
         ago >= u64::BITS || (self.mask >> ago & 1) == 1
     }
 
+    /// Confirms a tick.
+    ///
+    /// Useful for unit tests.
+    pub fn confirm(&mut self, tick: RepliconTick) {
+        if tick > self.last_tick {
+            self.resize_to(tick);
+        }
+        let ago = self.last_tick - tick;
+        if ago < u64::BITS {
+            self.set(ago);
+        }
+    }
+
     /// Marks previous tick as received.
     ///
     /// # Panics
     ///
     /// Panics if `debug_assertions` are enabled and
     /// `ago` is bigger then [`u64::BITS`].
-    pub fn set(&mut self, ago: u32) {
+    pub(super) fn set(&mut self, ago: u32) {
         debug_assert!(ago < u64::BITS);
         self.mask |= 1 << ago;
     }
@@ -63,7 +76,7 @@ impl Confirmed {
     ///
     /// Panics if `debug_assertions` are enabled and
     /// `tick` is less then the last tick.
-    pub fn resize_to(&mut self, tick: RepliconTick) {
+    pub(super) fn resize_to(&mut self, tick: RepliconTick) {
         debug_assert!(tick >= self.last_tick);
         let diff = tick - self.last_tick;
         self.mask = self.mask.wrapping_shl(diff);

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, ops::Sub};
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -28,6 +28,14 @@ impl RepliconTick {
     #[inline]
     pub fn increment(&mut self) {
         self.increment_by(1)
+    }
+}
+
+impl Sub for RepliconTick {
+    type Output = u32;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0.wrapping_sub(rhs.0)
     }
 }
 

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, ops::Sub};
+use std::cmp::Ordering;
 
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -28,14 +28,6 @@ impl RepliconTick {
     #[inline]
     pub fn increment(&mut self) {
         self.increment_by(1)
-    }
-}
-
-impl Sub for RepliconTick {
-    type Output = u32;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.0.wrapping_sub(rhs.0)
     }
 }
 

--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -2,12 +2,13 @@ use std::io::Cursor;
 
 use bevy::{ecs::entity::MapEntities, prelude::*, utils::Duration};
 use bevy_replicon::{
-    client::{server_entity_map::ServerEntityMap, ServerInitTick},
+    client::{confirmed::Confirmed, server_entity_map::ServerEntityMap, ServerInitTick},
     core::{
         command_markers::MarkerConfig,
         replication_fns::{command_fns, ctx::WriteCtx, rule_fns::RuleFns},
     },
     prelude::*,
+    server::replicon_tick::RepliconTick,
     test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
@@ -243,6 +244,86 @@ fn marker_with_history() {
             write_history,
             command_fns::default_remove::<BoolComponent>,
         )
+        .replicate::<BoolComponent>();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world
+        .spawn((Replicated, BoolComponent(false)))
+        .id();
+
+    let client_entity = client_app.world.spawn(HistoryMarker).id();
+
+    let client = client_app.world.resource::<RepliconClient>();
+    let client_id = client.id().unwrap();
+
+    let mut entity_map = server_app.world.resource_mut::<ClientEntityMap>();
+    entity_map.insert(
+        client_id,
+        ClientMapping {
+            server_entity,
+            client_entity,
+        },
+    );
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    // Change value, but don't process it on client.
+    let mut component = server_app
+        .world
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap();
+    component.0 = true;
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    // Change value again to generate another update.
+    let mut component = server_app
+        .world
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap();
+    component.0 = false;
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let client_entity = client_app.world.entity(client_entity);
+    let history = client_entity.get::<BoolHistory>().unwrap();
+    assert_eq!(
+        history.0,
+        [false, false, true],
+        "the initial value should come first, then the latest update, \
+        and after that the older update because recent updates processed first"
+    );
+}
+
+#[test]
+fn marker_with_history_consume() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .register_marker_with::<HistoryMarker>(MarkerConfig {
+            need_history: true,
+            ..Default::default()
+        })
+        .set_marker_fns::<HistoryMarker, BoolComponent>(
+            write_history,
+            command_fns::default_remove::<BoolComponent>,
+        )
         .replicate::<BoolComponent>()
         .replicate_mapped::<MappedComponent>();
     }
@@ -278,44 +359,116 @@ fn marker_with_history() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    // Change values, but don't process them on client.
+    // Change value, but don't process it on client.
     let update_entity1 = server_app.world.spawn_empty().id();
-    let mut server_entity = server_app.world.entity_mut(server_entity);
-    server_entity.get_mut::<BoolComponent>().unwrap().0 = true;
-    server_entity.get_mut::<MappedComponent>().unwrap().0 = update_entity1;
-    let server_entity = server_entity.id();
+    let mut component = server_app
+        .world
+        .get_mut::<MappedComponent>(server_entity)
+        .unwrap();
+    component.0 = update_entity1;
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    // Change values again to generate another update.
+    // Change value again to generate another update.
     let update_entity2 = server_app.world.spawn_empty().id();
-    let mut server_entity = server_app.world.entity_mut(server_entity);
-    server_entity.get_mut::<BoolComponent>().unwrap().0 = false;
-    server_entity.get_mut::<MappedComponent>().unwrap().0 = update_entity2;
+    let mut component = server_app
+        .world
+        .get_mut::<MappedComponent>(server_entity)
+        .unwrap();
+    component.0 = update_entity2;
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
-    let history = client_entity.get::<BoolHistory>().unwrap();
-    assert_eq!(
-        history.0,
-        [false, false, true],
-        "the initial value should come first, then the latest update, \
-        and after that the older update because recent updates processed first"
-    );
-
     let entity_map = client_app.world.resource::<ServerEntityMap>();
+    assert!(entity_map.to_client().contains_key(&update_entity2));
     assert!(
         !entity_map.to_client().contains_key(&update_entity1),
-        "client should consume older update for components without history"
+        "client should consume older update for other components with marker that requested history"
     );
     assert_eq!(
         client_app.world.entities().len(),
         3,
-        "client should have 2 initial entities and 1 from update with history"
+        "client should have 2 initial entities and 1 from update"
+    );
+}
+
+#[test]
+fn marker_with_history_old_update() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .register_marker_with::<HistoryMarker>(MarkerConfig {
+            need_history: true,
+            ..Default::default()
+        })
+        .set_marker_fns::<HistoryMarker, BoolComponent>(
+            write_history,
+            command_fns::default_remove::<BoolComponent>,
+        )
+        .replicate::<BoolComponent>();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world
+        .spawn((Replicated, BoolComponent(false)))
+        .id();
+
+    let client_entity = client_app.world.spawn(HistoryMarker).id();
+
+    let client = client_app.world.resource::<RepliconClient>();
+    let client_id = client.id().unwrap();
+
+    let mut entity_map = server_app.world.resource_mut::<ClientEntityMap>();
+    entity_map.insert(
+        client_id,
+        ClientMapping {
+            server_entity,
+            client_entity,
+        },
+    );
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    // Artificially make the last confirmed tick too large
+    // so that the next update for this entity is discarded.
+    let mut replicon_tick = *server_app.world.resource::<RepliconTick>();
+    replicon_tick.increment_by(u64::BITS + 1);
+    let mut confirmed = client_app
+        .world
+        .get_mut::<Confirmed>(client_entity)
+        .unwrap();
+    confirmed.confirm(replicon_tick);
+
+    let mut component = server_app
+        .world
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap();
+    component.0 = true;
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let history = client_app.world.get::<BoolHistory>(client_entity).unwrap();
+    assert_eq!(
+        history.0,
+        [false],
+        "update should be considered too old and discarded"
     );
 }
 

--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -295,8 +295,8 @@ fn marker_with_history() {
 
     let client_entity = client_app.world.entity(client_entity);
     let component = client_entity.get::<BoolComponent>().unwrap();
-    assert_eq!(
-        component.0, false,
+    assert!(
+        !component.0,
         "original component should equal to the value before history marker insertion"
     );
 

--- a/tests/changes.rs
+++ b/tests/changes.rs
@@ -278,8 +278,6 @@ fn marker_with_history() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    client_app.update();
-
     // Change values, but don't process them on client.
     let update_entity1 = server_app.world.spawn_empty().id();
     let mut server_entity = server_app.world.entity_mut(server_entity);

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -245,21 +245,24 @@ fn marker() {
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app.world.spawn(Replicated).id();
+    let client_entity = client_app.world.spawn(ReplaceMarker).id();
+
+    let client = client_app.world.resource::<RepliconClient>();
+    let client_id = client.id().unwrap();
+
+    let mut entity_map = server_app.world.resource_mut::<ClientEntityMap>();
+    entity_map.insert(
+        client_id,
+        ClientMapping {
+            server_entity,
+            client_entity,
+        },
+    );
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
-
-    let client_entity = client_app
-        .world
-        .query_filtered::<Entity, With<Replicated>>()
-        .single(&client_app.world);
-
-    client_app
-        .world
-        .entity_mut(client_entity)
-        .insert(ReplaceMarker);
 
     server_app
         .world

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -245,27 +245,26 @@ fn marker() {
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app.world.spawn(Replicated).id();
-    let client_entity = client_app.world.spawn(Replicated).id();
-
-    client_app
-        .world
-        .resource_mut::<ServerEntityMap>()
-        .insert(server_entity, client_entity);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
+    let client_entity = client_app
+        .world
+        .query_filtered::<Entity, With<Replicated>>()
+        .single(&client_app.world);
+
+    client_app
+        .world
+        .entity_mut(client_entity)
+        .insert(ReplaceMarker);
+
     server_app
         .world
         .entity_mut(server_entity)
         .insert(OriginalComponent);
-
-    client_app
-        .world
-        .entity_mut(server_entity)
-        .insert(ReplaceMarker);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -115,7 +115,7 @@ fn marker() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app.world.spawn((Replicated, OriginalComponent)).id();
     let client_entity = client_app.world.spawn(ReplaceMarker).id();
 
     let client = client_app.world.resource::<RepliconClient>();
@@ -138,7 +138,7 @@ fn marker() {
     server_app
         .world
         .entity_mut(server_entity)
-        .remove::<DummyComponent>();
+        .remove::<OriginalComponent>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::server_entity_map::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
+    client::{confirmed::Confirmed, server_entity_map::ServerEntityMap},
+    prelude::*,
+    test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
 
@@ -199,6 +201,10 @@ fn pre_spawn() {
     let client_entity = client_app.world.entity(client_entity);
     assert!(
         client_entity.contains::<Replicated>(),
+        "entity should start receive replication"
+    );
+    assert!(
+        client_entity.contains::<Confirmed>(),
         "server should confirm replication of client entity"
     );
     assert!(


### PR DESCRIPTION
Storing the last received ticks as components is faster to access and more convenient.
I had to refactor some tests to use pre-spawned entities or query the entity later since `Confirmed` can't be inserted by user.

It's also important to track which previous ticks were confirmed for rollback. This is why the component also includes a mask. Thanks to @NiseVoid for the idea and the code.