### PR TITLE
Make the documentation more friendly for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/bevy_replicon/badge.svg)](https://docs.rs/bevy_replicon)
 [![codecov](https://codecov.io/gh/projectharmonia/bevy_replicon/graph/badge.svg?token=N1G28NQB1L)](https://codecov.io/gh/projectharmonia/bevy_replicon)
 
-ECS-focused high-level networking crate for the [Bevy game engine](https://bevyengine.org).
+Server-authoritative networking crate for the [Bevy game engine](https://bevyengine.org).
 
 ## Features
 
@@ -16,6 +16,8 @@ ECS-focused high-level networking crate for the [Bevy game engine](https://bevye
 - Customizable serialization and deserialization even for types that don't implement `serde` traits (like `Box<dyn Reflect>`).
 - No builtin I/O. Use it with any messaging library. We provide a first-party integration with [`renet`](https://github.com/lucaspoffo/renet) via `bevy_replicon_renet`.
 - API focused on writing logic once that automatically works for singleplayer, client, server, and listen server (when server is also a player).
+
+If you are new to networking, see [glossary](https://gist.github.com/maniwani/f92cc5d827b00163f5846ea7dcb90d44).
 
 ## Goals
 
@@ -30,6 +32,8 @@ The purpose of the crate is to provide a minimal and fast core that can be exten
 All of these examples also have drastically different optimization requirements. This is why modularity is essential. It also allows for more developers to be involved and for each to maintain what they use.
 
 Check out [related crates](#related-crates) to extend the core functionality.
+
+See also [What kind of networking should X game use?](https://github.com/bevyengine/bevy/discussions/8675).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Check out the [quick start guide](https://docs.rs/bevy_replicon/latest/bevy_repl
 
 See also [examples](https://github.com/projectharmonia/bevy_replicon/tree/master/bevy_replicon_renet/examples).
 
+Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](https://discord.com/channels/691052431525675048/1090432346907492443) in Bevy's Discord server.
+
 ## Related Crates
 
 - [bevy_replicon_snap](https://github.com/Bendzae/bevy_replicon_snap) - adds snapshot interpolation and client-side prediction.

--- a/src/core/replication_rules.rs
+++ b/src/core/replication_rules.rs
@@ -21,7 +21,8 @@ pub trait AppRuleExt {
     ///
     /// If your component contains any [`Entity`] inside, use [`Self::replicate_mapped`].
     ///
-    /// See also [`Self::replicate_with`].
+    /// See also [`Self::replicate_with`] and [`components`](../../index.html#components)
+    /// section from the quick start guide.
     fn replicate<C>(&mut self) -> &mut Self
     where
         C: Component + Serialize + DeserializeOwned,
@@ -29,11 +30,33 @@ pub trait AppRuleExt {
         self.replicate_with::<C>(RuleFns::default())
     }
 
-    /// Same as [`Self::replicate`], but additionally maps server entities to client inside the component after receiving.
-    ///
-    /// Always use it for components that contain entities.
-    ///
-    /// See also [`Self::replicate`].
+    /**
+    Same as [`Self::replicate`], but additionally maps server entities to client inside the component after receiving.
+
+    Always use it for components that contain entities.
+
+    See also [`Self::replicate`].
+
+    # Examples
+
+    ```
+    # use bevy::{prelude::*, ecs::entity::{EntityMapper, MapEntities}};
+    # use bevy_replicon::prelude::*;
+    # use serde::{Deserialize, Serialize};
+    # let mut app = App::new();
+    # app.add_plugins(RepliconPlugins);
+    app.replicate_mapped::<MappedComponent>();
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct MappedComponent(Entity);
+
+    impl MapEntities for MappedComponent {
+        fn map_entities<T: EntityMapper>(&mut self, mapper: &mut T) {
+            self.0 = mapper.map_entity(self.0);
+        }
+    }
+    ```
+    **/
     fn replicate_mapped<C>(&mut self) -> &mut Self
     where
         C: Component + Serialize + DeserializeOwned + MapEntities,

--- a/src/core/replication_rules.rs
+++ b/src/core/replication_rules.rs
@@ -21,8 +21,8 @@ pub trait AppRuleExt {
     ///
     /// If your component contains any [`Entity`] inside, use [`Self::replicate_mapped`].
     ///
-    /// See also [`Self::replicate_with`] and [`components`](../../index.html#components)
-    /// section from the quick start guide.
+    /// See also [`Self::replicate_with`] and the section on [`components`](../../index.html#components)
+    /// from the quick start guide.
     fn replicate<C>(&mut self) -> &mut Self
     where
         C: Component + Serialize + DeserializeOwned,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,11 @@ If you want to write an integration for a messaging backend,
 see the documentation for [`RepliconServer`], [`RepliconClient`] and [`ServerEvent`].
 You can also use `bevy_replicon_renet` as a reference.
 
-Also depending on your game, you may want to use additional crates. For example, if you game
+Also depending on your game, you may want to use additional crates. For example, if your game
 is fast-paced, you will need interpolation and rollback.
 For details see [`goals`](https://github.com/projectharmonia/bevy_replicon#goals) and
 [`related crates`](https://github.com/projectharmonia/bevy_replicon#related-crates).
-But before adding advanced functionality, it's recommended to read the quick start guide
+Before adding advanced functionality, it's recommended to read the quick start guide
 first to understand the basics.
 
 ## Initialization
@@ -45,8 +45,8 @@ If you are planning to separate client and server you can use
 [`PluginGroupBuilder::disable()`] to disable [`ClientPlugin`] or [`ServerPlugin`] on [`RepliconPlugins`].
 You will need to disable similar plugins on your messaing library of choice too.
 
-Typically updates are not sent every frame. Instead, they are sent once at a certain interval
-to save traffic. You can change the defaults it with [`TickPolicy`] on [`ServerPlugin`]:
+Typically updates are not sent every frame. Instead, they are sent at a certain interval
+to save traffic. You can change the defaults with [`TickPolicy`] in the [`ServerPlugin`]:
 
 ```
 # use bevy::prelude::*;
@@ -85,23 +85,24 @@ in combination with [network events](#network-events).
 
 ## System conditions
 
-To run a system based on a network condition, use [`core::common_conditions`] module.
+To run a system based on a network condition, use the [`core::common_conditions`] module.
 This module is also available from [`prelude`].
 
 For example, to display a "connecting" message, you can use [`client_connecting`].
 But for gameplay systems, you most likely want to run them in both server and single-player
 sessions. For example, damage registration or procedural generation systems. Use [`has_authority`]
-condition for them.
+condition for those cases.
 
-If you want your systems to run only on frames when server send updates to clients use [`ServerSet::Send`].
+If you want your systems to run only on frames when the server sends updates to clients,
+use [`ServerSet::Send`].
 
 ## Replication
 
 It's a process of sending changes from server to clients in order to
 keep the world in sync.
 
-To prevent cheating, you can't replicate from client. If you need to send
-information from client to server, use [events](#network-events).
+To prevent cheating, we do not support replicating from the client. If you need to send
+information from clients to the server, use [events](#network-events).
 
 ### Marking for replication
 
@@ -167,14 +168,14 @@ waiting on replication.
 
 The idea was borrowed from [iyes_scene_tools](https://github.com/IyesGames/iyes_scene_tools#blueprints-pattern).
 You don't want to replicate all components because not all of them are
-necessary to send over the network. For example, components that computed based on other
+necessary to send over the network. For example, components that are computed based on other
 components (like [`GlobalTransform`]) can be inserted after replication.
 This can be easily done using a system with query filter.
 This way, you detect when such entities are spawned into the world, and you can
 do any additional setup on them using code. For example, if you have a
 character with mesh, you can replicate only your `Player` and [`Transform`] components and insert
 necessary components after replication. To avoid one frame delay, put
-your initialization systems to [`ClientSet::Receive`]:
+your initialization systems in [`ClientSet::Receive`]:
 
 ```
 # use bevy::{prelude::*, sprite::Mesh2dHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ you can use [`AppRuleExt::replicate_group`].
 
 If you want to customize how the received component will be written or removed on clients based
 on some marker component (for example, write into a different component), see [`AppMarkerExt`].
+Useful for implementing rollback and interpolation.
 
 In order to serialize Bevy components you need to enable the `serialize` feature on Bevy.
 

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -3,11 +3,22 @@ use std::cmp::Ordering;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// A tick that increments each time we need the server to compute and send an update.
+/// Like to [`Tick`](bevy::ecs::component::Tick), but for replication.
 ///
-/// Used only on server.
-/// See [`ServerInitTick`](crate::client::ServerInitTick) for tick tracking on the client.
-/// See also [`TickPolicy`](crate::server::TickPolicy).
+/// Used only on server. The [`ServerPlugin`](super::ServerPlugin) sends replication data
+/// in [`PostUpdate`] any time this resource changes.
+/// By default, its incremented in [`PostUpdate`] per the [`TickPolicy`](super::TickPolicy).
+///
+/// If you set [`TickPolicy::Manual`](super::TickPolicy::Manual), you can increment [`RepliconTick`]
+/// at the start of your game loop inside [`FixedMain`](bevy::app::FixedMain).
+/// This value can represent your simulation step, and is made available to the client in the custom
+/// deserialization, despawn and component removal functions.
+///
+/// One use for this is rollback networking: you may want to rollback time and apply the update
+/// for the tick frame, which is in the past, then resimulate.
+///
+/// See [`ServerInitTick`](crate::client::ServerInitTick) for tick tracking the last received
+/// tick on the client.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Resource, Serialize)]
 pub struct RepliconTick(pub(crate) u32);
 

--- a/src/server/replicon_tick.rs
+++ b/src/server/replicon_tick.rs
@@ -3,22 +3,22 @@ use std::cmp::Ordering;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// Like to [`Tick`](bevy::ecs::component::Tick), but for replication.
+/// Like [`Tick`](bevy::ecs::component::Tick), but for replication.
 ///
-/// Used only on server. The [`ServerPlugin`](super::ServerPlugin) sends replication data
+/// Used only on the server. The [`ServerPlugin`](super::ServerPlugin) sends replication data
 /// in [`PostUpdate`] any time this resource changes.
 /// By default, its incremented in [`PostUpdate`] per the [`TickPolicy`](super::TickPolicy).
 ///
 /// If you set [`TickPolicy::Manual`](super::TickPolicy::Manual), you can increment [`RepliconTick`]
-/// at the start of your game loop inside [`FixedMain`](bevy::app::FixedMain).
-/// This value can represent your simulation step, and is made available to the client in the custom
-/// deserialization, despawn and component removal functions.
+/// at the start of your game loop (e.g. inside [`FixedMain`](bevy::app::FixedMain)).
+/// This value can be used to represent your simulation step, and is made available to the client in
+/// the custom deserialization, despawn, and component removal functions.
 ///
 /// One use for this is rollback networking: you may want to rollback time and apply the update
 /// for the tick frame, which is in the past, then resimulate.
 ///
-/// See [`ServerInitTick`](crate::client::ServerInitTick) for tick tracking the last received
-/// tick on the client.
+/// See [`ServerInitTick`](crate::client::ServerInitTick) for tracking the last received
+/// tick on clients.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Resource, Serialize)]
 pub struct RepliconTick(pub(crate) u32);
 


### PR DESCRIPTION
- Put more links to the readme for beginners.
- Clarify some parts that may be unclear for beginners.
- Move a few advanced sections from the quick start guide to corresponding functions/structs.
- Move system conditions section upper and rewrite it.
- Wrap information about client and server in the same world into a warning block.