### PR TITLE
Separate remove context from despawn

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use crate::{
         command_markers::{CommandMarkers, EntityMarkers},
         common_conditions::{client_connected, client_just_connected, client_just_disconnected},
         replication_fns::{
-            ctx::{DeleteCtx, WriteCtx},
+            ctx::{DespawnCtx, RemoveCtx, WriteCtx},
             ReplicationFns,
         },
         replicon_channels::{ReplicationChannel, RepliconChannels},
@@ -354,12 +354,8 @@ fn apply_init_components(
                     }
                 }
                 ComponentsKind::Removal => {
-                    let ctx = DeleteCtx { message_tick };
-                    component_fns.remove(
-                        &ctx,
-                        params.entity_markers,
-                        commands.entity(client_entity.id()),
-                    );
+                    let mut ctx = RemoveCtx::new(&mut commands, message_tick);
+                    component_fns.remove(&mut ctx, params.entity_markers, &mut client_entity);
                 }
             }
             components_len += 1;
@@ -397,7 +393,7 @@ fn apply_despawns(
             .remove_by_server(server_entity)
             .and_then(|entity| world.get_entity_mut(entity))
         {
-            let ctx = DeleteCtx { message_tick };
+            let ctx = DespawnCtx { message_tick };
             (params.replication_fns.despawn)(&ctx, client_entity);
         }
     }

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -52,7 +52,7 @@ pub trait AppMarkerExt {
         core::{
             command_markers::MarkerConfig,
             replication_fns::{
-                ctx::{DeleteCtx, WriteCtx},
+                ctx::{RemoveCtx, WriteCtx},
                 rule_fns::RuleFns,
             },
         },
@@ -88,8 +88,8 @@ pub trait AppMarkerExt {
     }
 
     /// Removes component `C` and its history.
-    fn remove_history<C: Component>(_ctx: &DeleteCtx, mut entity_commands: EntityCommands) {
-        entity_commands.remove::<History<C>>().remove::<C>();
+    fn remove_history<C: Component>(ctx: &mut RemoveCtx, entity: &mut EntityMut) {
+        ctx.commands.entity(entity.id()).remove::<History<C>>().remove::<C>();
     }
 
     /// If this marker is present on an entity, registered components will be stored in [`History<T>`].

--- a/src/core/replication_fns.rs
+++ b/src/core/replication_fns.rs
@@ -7,11 +7,10 @@ pub mod test_fns;
 use bevy::{ecs::component::ComponentId, prelude::*};
 use serde::{Deserialize, Serialize};
 
-use self::ctx::DeleteCtx;
-
 use super::command_markers::CommandMarkerIndex;
 use command_fns::{RemoveFn, UntypedCommandFns, WriteFn};
 use component_fns::ComponentFns;
+use ctx::DespawnCtx;
 use rule_fns::{RuleFns, UntypedRuleFns};
 
 /// Stores configurable replication functions.
@@ -188,10 +187,10 @@ impl FnsInfo {
 pub struct FnsId(usize);
 
 /// Signature of the entity despawn function.
-pub type DespawnFn = fn(&DeleteCtx, EntityWorldMut);
+pub type DespawnFn = fn(&DespawnCtx, EntityWorldMut);
 
 /// Default entity despawn function.
-pub fn despawn_recursive(_ctx: &DeleteCtx, entity: EntityWorldMut) {
+pub fn despawn_recursive(_ctx: &DespawnCtx, entity: EntityWorldMut) {
     entity.despawn_recursive();
 }
 

--- a/src/core/replication_fns/command_fns.rs
+++ b/src/core/replication_fns/command_fns.rs
@@ -4,10 +4,10 @@ use std::{
     mem,
 };
 
-use bevy::{ecs::system::EntityCommands, prelude::*};
+use bevy::prelude::*;
 
 use super::{
-    ctx::{DeleteCtx, WriteCtx},
+    ctx::{RemoveCtx, WriteCtx},
     rule_fns::RuleFns,
 };
 
@@ -63,8 +63,8 @@ impl UntypedCommandFns {
     }
 
     /// Calls the assigned removal function.
-    pub(super) fn remove(&self, ctx: &DeleteCtx, commands: EntityCommands) {
-        (self.remove)(ctx, commands);
+    pub(super) fn remove(&self, ctx: &mut RemoveCtx, entity: &mut EntityMut) {
+        (self.remove)(ctx, entity);
     }
 }
 
@@ -73,7 +73,7 @@ pub type WriteFn<C> =
     fn(&mut WriteCtx, &RuleFns<C>, &mut EntityMut, &mut Cursor<&[u8]>) -> bincode::Result<()>;
 
 /// Signature of component removal functions.
-pub type RemoveFn = fn(&DeleteCtx, EntityCommands);
+pub type RemoveFn = fn(&mut RemoveCtx, &mut EntityMut);
 
 /// Default component writing function.
 ///
@@ -96,6 +96,6 @@ pub fn default_write<C: Component>(
 }
 
 /// Default component removal function.
-pub fn default_remove<C: Component>(_ctx: &DeleteCtx, mut entity_commands: EntityCommands) {
-    entity_commands.remove::<C>();
+pub fn default_remove<C: Component>(ctx: &mut RemoveCtx, entity: &mut EntityMut) {
+    ctx.commands.entity(entity.id()).remove::<C>();
 }

--- a/src/core/replication_fns/component_fns.rs
+++ b/src/core/replication_fns/component_fns.rs
@@ -1,10 +1,10 @@
 use std::io::Cursor;
 
-use bevy::{ecs::system::EntityCommands, prelude::*, ptr::Ptr};
+use bevy::{prelude::*, ptr::Ptr};
 
 use super::{
     command_fns::UntypedCommandFns,
-    ctx::{DeleteCtx, SerializeCtx, WriteCtx},
+    ctx::{RemoveCtx, SerializeCtx, WriteCtx},
     rule_fns::UntypedRuleFns,
 };
 use crate::core::command_markers::{CommandMarkerIndex, CommandMarkers, EntityMarkers};
@@ -153,9 +153,9 @@ impl ComponentFns {
     /// Same as [`Self::write`], but calls the assigned remove function.
     pub(crate) fn remove(
         &self,
-        ctx: &DeleteCtx,
+        ctx: &mut RemoveCtx,
         entity_markers: &EntityMarkers,
-        entity_commands: EntityCommands,
+        entity: &mut EntityMut,
     ) {
         let command_fns = self
             .markers
@@ -165,7 +165,7 @@ impl ComponentFns {
             .find_map(|(&fns, _)| fns)
             .unwrap_or(self.commands);
 
-        command_fns.remove(ctx, entity_commands)
+        command_fns.remove(ctx, entity)
     }
 }
 

--- a/src/core/replication_fns/ctx.rs
+++ b/src/core/replication_fns/ctx.rs
@@ -53,9 +53,28 @@ impl EntityMapper for WriteCtx<'_, '_, '_> {
     }
 }
 
-/// Replication context for removal and despawn functions.
+/// Replication context for removal.
 #[non_exhaustive]
-pub struct DeleteCtx {
+pub struct RemoveCtx<'a, 'w, 's> {
+    /// A queue to perform structural changes to the [`World`].
+    pub commands: &'a mut Commands<'w, 's>,
+
+    /// Tick for the currently processing message.
+    pub message_tick: RepliconTick,
+}
+
+impl<'a, 'w, 's> RemoveCtx<'a, 'w, 's> {
+    pub(crate) fn new(commands: &'a mut Commands<'w, 's>, message_tick: RepliconTick) -> Self {
+        Self {
+            commands,
+            message_tick,
+        }
+    }
+}
+
+/// Replication context for despawn.
+#[non_exhaustive]
+pub struct DespawnCtx {
     /// Tick for the currently processing message.
     pub message_tick: RepliconTick,
 }

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -6,7 +6,7 @@ use bevy_replicon::{
         command_markers::MarkerConfig,
         replication_fns::{
             command_fns,
-            ctx::{DeleteCtx, WriteCtx},
+            ctx::{DespawnCtx, WriteCtx},
             rule_fns::RuleFns,
             test_fns::TestFnsEntityExt,
             ReplicationFns,
@@ -371,6 +371,6 @@ fn replace(
 }
 
 /// Adds special [`Despawned`] marker instead of despawning an entity.
-fn mark_despawned(_ctx: &DeleteCtx, mut entity: EntityWorldMut) {
+fn mark_despawned(_ctx: &DespawnCtx, mut entity: EntityWorldMut) {
     entity.insert(Despawned);
 }


### PR DESCRIPTION
Sometimes it's useful to access `EntityMut` in removal function. Since I already fetch it on replicon side, I just pass it instead of `EntityCommands`.

Also I moved commands to context for consistency with other contexts. This requires to separate remove and despawn contexts, but I think that it's even better.