### PR TITLE
Add `bevy_replicon_quinnet` to related crates and create a "Messaging backend" category

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](
 
 #### Messaging backends
 
-- [bevy_replicon_quinnet](https://github.com/Henauxg/bevy_quinnet/tree/main/bevy_replicon_quinnet) - Provides integration to use bevy_quinnet as a messaging backend.
+- [bevy_replicon_quinnet](https://github.com/Henauxg/bevy_quinnet/tree/main/bevy_replicon_quinnet) - Provides integration to use `bevy_quinnet` as a messaging backend.
 
 #### Helper crates
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](
 
 **Note:** Ensure that your `bevy_replicon` version is compatible with the used crate according to semantic versioning.
 
+#### Messaging backends
+
+- [bevy_replicon_quinnet](https://github.com/Henauxg/bevy_quinnet/tree/main/bevy_replicon_quinnet) - Provides integration to use bevy_quinnet as a messaging backend.
+
 #### Helper crates
 
 - [bevy_bundlication](https://github.com/NiseVoid/bevy_bundlication) - adds registration of replication groups using a bundle-like api.


### PR DESCRIPTION
- Add a `bevy_replicon_quinnet` entry to a newly created `Messaging backend` section in `Related Crates` 