### PR TITLE
Upgrade to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ license = "MIT OR Apache-2.0"
 include = ["/benches", "/src", "/tests", "/LICENSE*"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = ["bevy_scene"] }
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
+  "bevy_scene",
+] }
 bytes = "1.5"
 bincode = "1.3"
 serde = "1.0"
@@ -29,10 +31,11 @@ varint-rs = "2.2"
 ordered-multimap = "0.7"
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
   "serialize",
   "bevy_asset",
   "bevy_sprite",
+  "bevy_state",
 ] }
 criterion = { version = "0.5", default-features = false, features = [
   "cargo_bench_support",

--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -64,7 +64,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
                     }
 
                     server_app
-                        .world
+                        .world_mut()
                         .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
 
                     let instant = Instant::now();
@@ -74,7 +74,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
                     for client_app in &mut client_apps {
                         server_app.exchange_with_client(client_app);
                         client_app.update();
-                        assert_eq!(client_app.world.entities().len(), ENTITIES);
+                        assert_eq!(client_app.world().entities().len(), ENTITIES);
                     }
                 }
 
@@ -95,20 +95,20 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
                 }
 
                 server_app
-                    .world
+                    .world_mut()
                     .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
-                let mut query = server_app.world.query::<&mut C>();
+                let mut query = server_app.world_mut().query::<&mut C>();
 
                 server_app.update();
                 for client_app in &mut client_apps {
                     server_app.exchange_with_client(client_app);
                     client_app.update();
-                    assert_eq!(client_app.world.entities().len(), ENTITIES);
+                    assert_eq!(client_app.world().entities().len(), ENTITIES);
                 }
 
                 let mut elapsed = Duration::ZERO;
                 for _ in 0..iter {
-                    for mut component in query.iter_mut(&mut server_app.world) {
+                    for mut component in query.iter_mut(&mut server_app.world_mut()) {
                         component.set_changed();
                     }
 
@@ -119,7 +119,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
                     for client_app in &mut client_apps {
                         server_app.exchange_with_client(client_app);
                         client_app.update();
-                        assert_eq!(client_app.world.entities().len(), ENTITIES);
+                        assert_eq!(client_app.world().entities().len(), ENTITIES);
                     }
                 }
 
@@ -138,7 +138,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
                 server_app.connect_client(&mut client_app);
 
                 server_app
-                    .world
+                    .world_mut()
                     .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
 
                 server_app.update();
@@ -147,7 +147,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
                 let instant = Instant::now();
                 client_app.update();
                 elapsed += instant.elapsed();
-                assert_eq!(client_app.world.entities().len(), ENTITIES);
+                assert_eq!(client_app.world_mut().entities().len(), ENTITIES);
             }
 
             elapsed
@@ -162,18 +162,18 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
             server_app.connect_client(&mut client_app);
 
             server_app
-                .world
+                .world_mut()
                 .spawn_batch(vec![(Replicated, C::default()); ENTITIES as usize]);
-            let mut query = server_app.world.query::<&mut C>();
+            let mut query = server_app.world_mut().query::<&mut C>();
 
             server_app.update();
             server_app.exchange_with_client(&mut client_app);
             client_app.update();
-            assert_eq!(client_app.world.entities().len(), ENTITIES);
+            assert_eq!(client_app.world().entities().len(), ENTITIES);
 
             let mut elapsed = Duration::ZERO;
             for _ in 0..iter {
-                for mut component in query.iter_mut(&mut server_app.world) {
+                for mut component in query.iter_mut(&mut server_app.world_mut()) {
                     component.set_changed();
                 }
 
@@ -184,7 +184,7 @@ fn replication<C: Component + Default + Serialize + DeserializeOwned + Clone>(c:
 
                 client_app.update();
                 elapsed += instant.elapsed();
-                assert_eq!(client_app.world.entities().len(), ENTITIES);
+                assert_eq!(client_app.world().entities().len(), ENTITIES);
             }
 
             elapsed

--- a/bevy_replicon_renet/Cargo.toml
+++ b/bevy_replicon_renet/Cargo.toml
@@ -22,13 +22,13 @@ include = ["/src", "/tests", "../LICENSE*"]
 
 [dependencies]
 bevy_replicon = { version = "0.25", path = ".." }
-bevy_renet = { version = "0.0.11", default-features = false }
-bevy = { version = "0.13", default-features = false }
+bevy_renet = { git = "https://github.com/notmd/renet.git", branch = "v0.14", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false }
 
 [dev-dependencies]
 serde = "1.0"
 clap = { version = "4.1", features = ["derive"] }
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
   "bevy_text",
   "bevy_ui",
   "bevy_gizmos",

--- a/bevy_replicon_renet/examples/simple_box.rs
+++ b/bevy_replicon_renet/examples/simple_box.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bevy::{
+    color::palettes::css,
     prelude::*,
     winit::{UpdateMode::Continuous, WinitSettings},
 };
@@ -75,7 +76,7 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(
                     ClientId::SERVER,
                     Vec2::ZERO,
-                    Color::GREEN,
+                    css::GREEN.into(),
                 ));
             }
             Cli::Server { port } => {
@@ -114,7 +115,7 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(
                     ClientId::SERVER,
                     Vec2::ZERO,
-                    Color::GREEN,
+                    css::GREEN.into(),
                 ));
             }
             Cli::Client { port, ip } => {
@@ -173,7 +174,7 @@ impl SimpleBoxPlugin {
                     commands.spawn(PlayerBundle::new(
                         *client_id,
                         Vec2::ZERO,
-                        Color::rgb(r, g, b),
+                        Color::srgb(r, g, b),
                     ));
                 }
                 ServerEvent::ClientDisconnected { client_id, reason } => {

--- a/bevy_replicon_renet/examples/tic_tac_toe.rs
+++ b/bevy_replicon_renet/examples/tic_tac_toe.rs
@@ -92,7 +92,7 @@ impl Plugin for TicTacToePlugin {
 
 const GRID_SIZE: usize = 3;
 
-const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
+const BACKGROUND_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
 
 const PROTOCOL_ID: u64 = 0;
 
@@ -110,7 +110,7 @@ impl TicTacToePlugin {
         const LINE_THICKNESS: f32 = 10.0;
         const BOARD_SIZE: f32 = CELL_SIZE * GRID_SIZE as f32 + LINES_COUNT as f32 * LINE_THICKNESS;
 
-        const BOARD_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);
+        const BOARD_COLOR: Color = Color::srgb(0.8, 0.8, 0.8);
 
         for line in 0..LINES_COUNT {
             let position = -BOARD_SIZE / 2.0
@@ -149,7 +149,7 @@ impl TicTacToePlugin {
         const BUTTON_SIZE: f32 = CELL_SIZE / 1.2;
         const BUTTON_MARGIN: f32 = (CELL_SIZE + LINE_THICKNESS - BUTTON_SIZE) / 2.0;
 
-        const TEXT_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+        const TEXT_COLOR: Color = Color::srgb(0.5, 0.5, 1.0);
         const FONT_SIZE: f32 = 40.0;
 
         commands
@@ -196,7 +196,8 @@ impl TicTacToePlugin {
                                             margin: UiRect::all(Val::Px(BUTTON_MARGIN)),
                                             ..Default::default()
                                         },
-                                        background_color: BACKGROUND_COLOR.into(),
+                                        image: UiImage::default()
+                                            .with_color(BACKGROUND_COLOR.into()),
                                         ..Default::default()
                                     });
                                 }
@@ -379,7 +380,7 @@ impl TicTacToePlugin {
         children: Query<&Children>,
         mut pick_events: EventWriter<CellPick>,
     ) {
-        const HOVER_COLOR: Color = Color::rgb(0.85, 0.85, 0.85);
+        const HOVER_COLOR: Color = Color::srgb(0.85, 0.85, 0.85);
 
         for (button_entity, button_parent, interaction, mut background) in &mut buttons {
             match interaction {
@@ -600,8 +601,8 @@ impl Symbol {
 
     fn color(self) -> Color {
         match self {
-            Symbol::Cross => Color::rgb(1.0, 0.5, 0.5),
-            Symbol::Nought => Color::rgb(0.5, 0.5, 1.0),
+            Symbol::Cross => Color::srgb(1.0, 0.5, 0.5),
+            Symbol::Nought => Color::srgb(0.5, 0.5, 1.0),
         }
     }
 

--- a/bevy_replicon_renet/src/lib.rs
+++ b/bevy_replicon_renet/src/lib.rs
@@ -46,7 +46,7 @@ use bevy_replicon_renet::{renet::ConnectionConfig, RenetChannelsExt, RepliconRen
 
 # let mut app = App::new();
 # app.add_plugins(RepliconPlugins);
-let channels = app.world.resource::<RepliconChannels>();
+let channels = app.world_mut().resource::<RepliconChannels>();
 let connection_config = ConnectionConfig {
     server_channels_config: channels.get_server_configs(),
     client_channels_config: channels.get_client_configs(),

--- a/bevy_replicon_renet/tests/transport.rs
+++ b/bevy_replicon_renet/tests/transport.rs
@@ -32,20 +32,20 @@ fn connect_disconnect() {
 
     setup(&mut server_app, &mut client_app);
 
-    let mut renet_client = client_app.world.resource_mut::<RenetClient>();
+    let mut renet_client = client_app.world_mut().resource_mut::<RenetClient>();
     assert!(renet_client.is_connected());
     renet_client.disconnect();
 
     client_app.update();
     server_app.update();
 
-    let renet_server = server_app.world.resource::<RenetServer>();
+    let renet_server = server_app.world().resource::<RenetServer>();
     assert_eq!(renet_server.connected_clients(), 0);
 
-    let connected_clients = server_app.world.resource::<ConnectedClients>();
+    let connected_clients = server_app.world().resource::<ConnectedClients>();
     assert_eq!(connected_clients.len(), 0);
 
-    let replicon_client = client_app.world.resource_mut::<RepliconClient>();
+    let replicon_client = client_app.world_mut().resource_mut::<RepliconClient>();
     assert!(replicon_client.is_disconnected());
 }
 
@@ -66,12 +66,12 @@ fn replication() {
 
     setup(&mut server_app, &mut client_app);
 
-    server_app.world.spawn(Replicated);
+    server_app.world_mut().spawn(Replicated);
 
     server_app.update();
     client_app.update();
 
-    assert_eq!(client_app.world.entities().len(), 1);
+    assert_eq!(client_app.world().entities().len(), 1);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn server_event() {
 
     setup(&mut server_app, &mut client_app);
 
-    server_app.world.send_event(ToClients {
+    server_app.world_mut().send_event(ToClients {
         mode: SendMode::Broadcast,
         event: DummyEvent,
     });
@@ -100,7 +100,7 @@ fn server_event() {
     server_app.update();
     client_app.update();
 
-    let dummy_events = client_app.world.resource::<Events<DummyEvent>>();
+    let dummy_events = client_app.world().resource::<Events<DummyEvent>>();
     assert_eq!(dummy_events.len(), 1);
 }
 
@@ -122,13 +122,13 @@ fn client_event() {
 
     setup(&mut server_app, &mut client_app);
 
-    client_app.world.send_event(DummyEvent);
+    client_app.world_mut().send_event(DummyEvent);
 
     client_app.update();
     server_app.update();
 
     let client_events = server_app
-        .world
+        .world()
         .resource::<Events<FromClient<DummyEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
@@ -141,7 +141,7 @@ fn setup(server_app: &mut App, client_app: &mut App) {
 }
 
 fn setup_client(app: &mut App, client_id: u64, port: u16) {
-    let channels = app.world.resource::<RepliconChannels>();
+    let channels = app.world().resource::<RepliconChannels>();
 
     let server_channels_config = channels.get_server_configs();
     let client_channels_config = channels.get_client_configs();
@@ -157,7 +157,7 @@ fn setup_client(app: &mut App, client_id: u64, port: u16) {
 }
 
 fn setup_server(app: &mut App, max_clients: usize) -> u16 {
-    let channels = app.world.resource::<RepliconChannels>();
+    let channels = app.world().resource::<RepliconChannels>();
 
     let server_channels_config = channels.get_server_configs();
     let client_channels_config = channels.get_client_configs();
@@ -218,7 +218,7 @@ fn wait_for_connection(server_app: &mut App, client_app: &mut App) {
     loop {
         client_app.update();
         server_app.update();
-        if client_app.world.resource::<RenetClient>().is_connected() {
+        if client_app.world().resource::<RenetClient>().is_connected() {
             break;
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ pub mod server_entity_map;
 
 use std::{io::Cursor, mem};
 
-use bevy::{ecs::system::CommandQueue, prelude::*};
+use bevy::{ecs::world::CommandQueue, prelude::*};
 use bincode::{DefaultOptions, Options};
 use bytes::Bytes;
 use varint_rs::VarintReader;

--- a/src/client/server_entity_map.rs
+++ b/src/client/server_entity_map.rs
@@ -33,7 +33,7 @@ impl ServerEntityMap {
     /// # Examples
     ///
     /// ```
-    /// # use bevy::{ecs::system::CommandQueue, prelude::*};
+    /// # use bevy::{ecs::world::CommandQueue, prelude::*};
     /// # use bevy_replicon::{client::server_entity_map::ServerEntityMap, prelude::*};
     /// # let mut entity_map = ServerEntityMap::default();
     /// # let mut queue = CommandQueue::default();

--- a/src/core/command_markers.rs
+++ b/src/core/command_markers.rs
@@ -127,14 +127,14 @@ impl AppMarkerExt for App {
     }
 
     fn register_marker_with<M: Component>(&mut self, config: MarkerConfig) -> &mut Self {
-        let component_id = self.world.init_component::<M>();
-        let mut command_markers = self.world.resource_mut::<CommandMarkers>();
+        let component_id = self.world_mut().init_component::<M>();
+        let mut command_markers = self.world_mut().resource_mut::<CommandMarkers>();
         let marker_id = command_markers.insert(CommandMarker {
             component_id,
             config,
         });
 
-        let mut replicaton_fns = self.world.resource_mut::<ReplicationFns>();
+        let mut replicaton_fns = self.world_mut().resource_mut::<ReplicationFns>();
         replicaton_fns.register_marker(marker_id);
 
         self
@@ -145,10 +145,10 @@ impl AppMarkerExt for App {
         write: WriteFn<C>,
         remove: RemoveFn,
     ) -> &mut Self {
-        let component_id = self.world.init_component::<M>();
-        let command_markers = self.world.resource::<CommandMarkers>();
+        let component_id = self.world_mut().init_component::<M>();
+        let command_markers = self.world().resource::<CommandMarkers>();
         let marker_id = command_markers.marker_id(component_id);
-        self.world
+        self.world_mut()
             .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
                 replication_fns.set_marker_fns::<C>(world, marker_id, write, remove);
             });
@@ -157,7 +157,7 @@ impl AppMarkerExt for App {
     }
 
     fn set_command_fns<C: Component>(&mut self, write: WriteFn<C>, remove: RemoveFn) -> &mut Self {
-        self.world
+        self.world_mut()
             .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
                 replication_fns.set_command_fns::<C>(world, write, remove);
             });
@@ -326,7 +326,7 @@ mod tests {
             })
             .register_marker::<DummyMarkerD>();
 
-        let markers = app.world.resource::<CommandMarkers>();
+        let markers = app.world().resource::<CommandMarkers>();
         let priorities: Vec<_> = markers
             .0
             .iter()

--- a/src/core/replication_fns/test_fns.rs
+++ b/src/core/replication_fns/test_fns.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use bevy::{ecs::system::CommandQueue, prelude::*};
+use bevy::{ecs::world::CommandQueue, prelude::*};
 
 use super::{
     ctx::{DespawnCtx, RemoveCtx, WriteCtx},
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 let mut app = App::new();
 app.add_plugins((MinimalPlugins, RepliconPlugins));
 
-let tick = **app.world.resource::<ServerTick>();
+let tick = **app.world().resource::<ServerTick>();
 
 // Register rule functions manually to obtain `FnsInfo`.
 let fns_info = app
@@ -46,7 +46,7 @@ let fns_info = app
         replication_fns.register_rule_fns(world, RuleFns::<DummyComponent>::default())
     });
 
-let mut entity = app.world.spawn(DummyComponent);
+let mut entity = app.world_mut().spawn(DummyComponent);
 let data = entity.serialize(fns_info);
 entity.remove::<DummyComponent>();
 
@@ -57,7 +57,7 @@ entity.apply_remove(fns_info, tick);
 assert!(!entity.contains::<DummyComponent>());
 
 entity.apply_despawn(tick);
-assert!(app.world.entities().is_empty());
+assert!(app.world().entities().is_empty());
 
 #[derive(Component, Serialize, Deserialize)]
 struct DummyComponent;

--- a/src/core/replication_rules.rs
+++ b/src/core/replication_rules.rs
@@ -164,25 +164,29 @@ impl AppRuleExt for App {
     where
         C: Component,
     {
-        let rule = self
-            .world
-            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-                let fns_info = replication_fns.register_rule_fns(world, rule_fns);
-                ReplicationRule::new(vec![fns_info])
-            });
+        let rule =
+            self.world_mut()
+                .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                    let fns_info = replication_fns.register_rule_fns(world, rule_fns);
+                    ReplicationRule::new(vec![fns_info])
+                });
 
-        self.world.resource_mut::<ReplicationRules>().insert(rule);
+        self.world_mut()
+            .resource_mut::<ReplicationRules>()
+            .insert(rule);
         self
     }
 
     fn replicate_group<C: GroupReplication>(&mut self) -> &mut Self {
-        let rule = self
-            .world
-            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-                C::register(world, &mut replication_fns)
-            });
+        let rule =
+            self.world_mut()
+                .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                    C::register(world, &mut replication_fns)
+                });
 
-        self.world.resource_mut::<ReplicationRules>().insert(rule);
+        self.world_mut()
+            .resource_mut::<ReplicationRules>()
+            .insert(rule);
         self
     }
 }
@@ -358,7 +362,7 @@ mod tests {
             .replicate::<ComponentC>()
             .replicate::<ComponentD>();
 
-        let replication_rules = app.world.resource::<ReplicationRules>();
+        let replication_rules = app.world().resource::<ReplicationRules>();
         let priorities: Vec<_> = replication_rules.iter().map(|rule| rule.priority).collect();
         assert_eq!(priorities, [2, 2, 1, 1, 1, 1]);
     }

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -136,7 +136,7 @@ impl ClientEventAppExt for App {
         receive_system: impl IntoSystemConfigs<Marker2>,
     ) -> &mut Self {
         let channel_id = self
-            .world
+            .world_mut()
             .resource_mut::<RepliconChannels>()
             .create_client_channel(channel.into());
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -158,7 +158,7 @@ impl ServerEventAppExt for App {
         receive_system: impl IntoSystemConfigs<Marker2>,
     ) -> &mut Self {
         let channel_id = self
-            .world
+            .world_mut()
             .resource_mut::<RepliconChannels>()
             .create_server_channel(channel.into());
 

--- a/src/parent_sync.rs
+++ b/src/parent_sync.rs
@@ -101,8 +101,8 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((RepliconCorePlugin, ParentSyncPlugin));
 
-        let child_entity = app.world.spawn_empty().id();
-        app.world.spawn_empty().add_child(child_entity);
+        let child_entity = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn_empty().add_child(child_entity);
 
         app.add_systems(Update, move |mut commands: Commands| {
             // Should be inserted in `Update` to avoid sync in `PreUpdate`.
@@ -111,7 +111,7 @@ mod tests {
 
         app.update();
 
-        let child_entity = app.world.entity(child_entity);
+        let child_entity = app.world().entity(child_entity);
         let parent = child_entity.get::<Parent>().unwrap();
         let parent_sync = child_entity.get::<ParentSync>().unwrap();
         assert!(parent_sync.0.is_some_and(|entity| entity == **parent));
@@ -122,9 +122,9 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((RepliconCorePlugin, ParentSyncPlugin));
 
-        let parent_entity = app.world.spawn_empty().id();
+        let parent_entity = app.world_mut().spawn_empty().id();
         let child_entity = app
-            .world
+            .world_mut()
             .spawn_empty()
             .set_parent(parent_entity)
             .remove_parent()
@@ -139,7 +139,7 @@ mod tests {
 
         app.update();
 
-        let parent_sync = app.world.get::<ParentSync>(child_entity).unwrap();
+        let parent_sync = app.world().get::<ParentSync>(child_entity).unwrap();
         assert!(parent_sync.0.is_none());
     }
 
@@ -148,12 +148,12 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((RepliconCorePlugin, ParentSyncPlugin));
 
-        let parent_entity = app.world.spawn_empty().id();
-        let child_entity = app.world.spawn(ParentSync(Some(parent_entity))).id();
+        let parent_entity = app.world_mut().spawn_empty().id();
+        let child_entity = app.world_mut().spawn(ParentSync(Some(parent_entity))).id();
 
         app.update();
 
-        let child_entity = app.world.entity(child_entity);
+        let child_entity = app.world().entity(child_entity);
         let parent = child_entity.get::<Parent>().unwrap();
         let parent_sync = child_entity.get::<ParentSync>().unwrap();
         assert!(parent_sync.0.is_some_and(|entity| entity == **parent));
@@ -164,18 +164,18 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((RepliconCorePlugin, ParentSyncPlugin));
 
-        let child_entity = app.world.spawn_empty().id();
-        app.world.spawn_empty().add_child(child_entity);
+        let child_entity = app.world_mut().spawn_empty().id();
+        app.world_mut().spawn_empty().add_child(child_entity);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .entity_mut(child_entity)
             .insert(ParentSync::default());
 
         app.update();
 
-        let child_entity = app.world.entity(child_entity);
+        let child_entity = app.world_mut().entity(child_entity);
         assert!(!child_entity.contains::<Parent>());
         assert!(child_entity.get::<ParentSync>().unwrap().0.is_none());
     }
@@ -191,23 +191,23 @@ mod tests {
         ));
 
         let mut scene_world = World::new();
-        scene_world.insert_resource(app.world.resource::<AppTypeRegistry>().clone());
+        scene_world.insert_resource(app.world().resource::<AppTypeRegistry>().clone());
         let parent_entity = scene_world.spawn_empty().id();
         scene_world.spawn(ParentSync(Some(parent_entity)));
         let dynamic_scene = DynamicScene::from_world(&scene_world);
 
-        let mut scenes = app.world.resource_mut::<Assets<DynamicScene>>();
+        let mut scenes = app.world_mut().resource_mut::<Assets<DynamicScene>>();
         let scene_handle = scenes.add(dynamic_scene);
-        let mut scene_spawner = app.world.resource_mut::<SceneSpawner>();
+        let mut scene_spawner = app.world_mut().resource_mut::<SceneSpawner>();
         scene_spawner.spawn_dynamic(scene_handle);
 
         app.update();
         app.update();
 
         let (parent, parent_sync) = app
-            .world
+            .world_mut()
             .query::<(&Parent, &ParentSync)>()
-            .single(&app.world);
+            .single(&app.world());
         assert!(parent_sync.0.is_some_and(|entity| entity == **parent));
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -23,7 +23,7 @@ use serde::de::DeserializeSeed;
 # app.add_plugins(RepliconPlugins);
 
 // Serialization
-let registry = app.world.resource::<AppTypeRegistry>();
+let registry = app.world_mut().resource::<AppTypeRegistry>();
 let mut scene = DynamicScene::default();
 scene::replicate_into(&mut scene, &app.world);
 let scene = scene

--- a/src/server/despawn_buffer.rs
+++ b/src/server/despawn_buffer.rs
@@ -48,15 +48,17 @@ mod tests {
         app.add_plugins(DespawnBufferPlugin)
             .init_resource::<RepliconServer>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world.spawn(Replicated).despawn();
+        app.world_mut().spawn(Replicated).despawn();
 
         app.update();
 
-        let despawn_buffer = app.world.resource::<DespawnBuffer>();
+        let despawn_buffer = app.world_mut().resource::<DespawnBuffer>();
         assert_eq!(despawn_buffer.len(), 1);
     }
 }

--- a/src/server/removal_buffer.rs
+++ b/src/server/removal_buffer.rs
@@ -217,17 +217,19 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .init_resource::<ReplicationRules>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA))
             .remove::<ComponentA>();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world().resource::<RemovalBuffer>();
         assert!(removal_buffer.removals.is_empty());
     }
 
@@ -240,17 +242,19 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .replicate::<ComponentA>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA))
             .remove::<ComponentA>();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world().resource::<RemovalBuffer>();
         assert_eq!(removal_buffer.removals.len(), 1);
 
         let (_, removals_id) = removal_buffer.removals.first().unwrap();
@@ -266,17 +270,19 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA, ComponentB))
             .remove::<(ComponentA, ComponentB)>();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world().resource::<RemovalBuffer>();
         assert_eq!(removal_buffer.removals.len(), 1);
 
         let (_, removals_id) = removal_buffer.removals.first().unwrap();
@@ -292,17 +298,19 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA, ComponentB))
             .remove::<ComponentA>();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world().resource::<RemovalBuffer>();
         assert_eq!(removal_buffer.removals.len(), 1);
 
         let (_, removals_id) = removal_buffer.removals.first().unwrap();
@@ -319,17 +327,19 @@ mod tests {
             .replicate::<ComponentA>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA, ComponentB))
             .remove::<(ComponentA, ComponentB)>();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world_mut().resource::<RemovalBuffer>();
         assert_eq!(removal_buffer.removals.len(), 1);
 
         let (_, removals_id) = removal_buffer.removals.first().unwrap();
@@ -346,17 +356,19 @@ mod tests {
             .replicate::<ComponentA>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA, ComponentB))
             .remove::<ComponentA>();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world().resource::<RemovalBuffer>();
         assert_eq!(removal_buffer.removals.len(), 1);
 
         let (_, removals_id) = removal_buffer.removals.first().unwrap();
@@ -372,15 +384,17 @@ mod tests {
             .init_resource::<ReplicationRules>()
             .replicate::<ComponentA>();
 
-        app.world.resource_mut::<RepliconServer>().set_running(true);
+        app.world_mut()
+            .resource_mut::<RepliconServer>()
+            .set_running(true);
 
         app.update();
 
-        app.world.spawn((ComponentA, Replicated)).despawn();
+        app.world_mut().spawn((ComponentA, Replicated)).despawn();
 
         app.update();
 
-        let removal_buffer = app.world.resource::<RemovalBuffer>();
+        let removal_buffer = app.world().resource::<RemovalBuffer>();
         assert!(
             removal_buffer.removals.is_empty(),
             "despawns shouldn't be counted as removals"

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -139,9 +139,9 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<ReplicationRules>();
 
-        app.world.spawn_empty();
+        app.world_mut().spawn_empty();
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         assert!(archetypes.is_empty());
     }
 
@@ -150,9 +150,9 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<ReplicationRules>();
 
-        app.world.spawn(Replicated);
+        app.world_mut().spawn(Replicated);
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         assert_eq!(archetypes.len(), 1);
 
         let archetype = archetypes.first().unwrap();
@@ -166,9 +166,9 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate::<ComponentA>();
 
-        app.world.spawn((Replicated, ComponentB));
+        app.world_mut().spawn((Replicated, ComponentB));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert!(archetype.components.is_empty());
     }
@@ -180,9 +180,9 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate::<ComponentA>();
 
-        app.world.spawn((Replicated, ComponentA));
+        app.world_mut().spawn((Replicated, ComponentA));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert_eq!(archetype.components.len(), 1);
     }
@@ -194,9 +194,9 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replicated, ComponentA, ComponentB));
+        app.world_mut().spawn((Replicated, ComponentA, ComponentB));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert_eq!(archetype.components.len(), 2);
     }
@@ -208,9 +208,9 @@ mod tests {
             .init_resource::<ReplicationFns>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replicated, ComponentA));
+        app.world_mut().spawn((Replicated, ComponentA));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert!(archetype.components.is_empty());
     }
@@ -223,9 +223,9 @@ mod tests {
             .replicate::<ComponentA>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replicated, ComponentA, ComponentB));
+        app.world_mut().spawn((Replicated, ComponentA, ComponentB));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert_eq!(archetype.components.len(), 2);
     }
@@ -239,9 +239,9 @@ mod tests {
             .replicate::<ComponentB>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world.spawn((Replicated, ComponentA, ComponentB));
+        app.world_mut().spawn((Replicated, ComponentA, ComponentB));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert_eq!(archetype.components.len(), 2);
     }
@@ -254,10 +254,10 @@ mod tests {
             .replicate_group::<(ComponentA, ComponentC)>()
             .replicate_group::<(ComponentA, ComponentB)>();
 
-        app.world
+        app.world_mut()
             .spawn((Replicated, ComponentA, ComponentB, ComponentC));
 
-        let archetypes = match_archetypes(&mut app.world);
+        let archetypes = match_archetypes(&mut app.world_mut());
         let archetype = archetypes.first().unwrap();
         assert_eq!(archetype.components.len(), 3);
     }

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -33,7 +33,7 @@ for app in [&mut server_app, &mut client_app] {
 // - client app will be in connected state.
 server_app.connect_client(&mut client_app);
 
-server_app.world.spawn(Replicated);
+server_app.world_mut().spawn(Replicated);
 
 // Run tick for each app and trigger message exchange.
 server_app.update();
@@ -41,7 +41,7 @@ server_app.exchange_with_client(&mut client_app);
 client_app.update();
 
 assert_eq!(
-    client_app.world.entities().len(),
+    client_app.world_mut().entities().len(),
     1,
     "client should replicate spawned entity"
 );
@@ -83,7 +83,7 @@ pub trait ServerTestAppExt {
 
 impl ServerTestAppExt for App {
     fn connect_client(&mut self, client_app: &mut App) {
-        let mut client = client_app.world.resource_mut::<RepliconClient>();
+        let mut client = client_app.world_mut().resource_mut::<RepliconClient>();
         assert!(
             client.is_disconnected(),
             "client can't be connected multiple times"
@@ -92,7 +92,7 @@ impl ServerTestAppExt for App {
         // Use client number as ID.
         // Server ID (0) will always be skipped.
         let max_id = self
-            .world
+            .world_mut()
             .resource_mut::<ConnectedClients>()
             .iter_client_ids()
             .max()
@@ -102,10 +102,10 @@ impl ServerTestAppExt for App {
             client_id: Some(client_id),
         });
 
-        let mut server = self.world.resource_mut::<RepliconServer>();
+        let mut server = self.world_mut().resource_mut::<RepliconServer>();
         server.set_running(true);
 
-        self.world
+        self.world_mut()
             .send_event(ServerEvent::ClientConnected { client_id });
 
         self.update(); // Will update `ConnectedClients`, otherwise next call will assign the same ID.
@@ -113,29 +113,30 @@ impl ServerTestAppExt for App {
     }
 
     fn disconnect_client(&mut self, client_app: &mut App) {
-        let mut client = client_app.world.resource_mut::<RepliconClient>();
+        let mut client = client_app.world_mut().resource_mut::<RepliconClient>();
         let client_id = client
             .id()
             .expect("client should have an assigned ID for disconnect");
 
         client.set_status(RepliconClientStatus::Disconnected);
 
-        self.world.send_event(ServerEvent::ClientDisconnected {
-            client_id,
-            reason: "Disconnected by server".to_string(),
-        });
+        self.world_mut()
+            .send_event(ServerEvent::ClientDisconnected {
+                client_id,
+                reason: "Disconnected by server".to_string(),
+            });
 
         self.update();
         client_app.update();
     }
 
     fn exchange_with_client(&mut self, client_app: &mut App) {
-        let mut client = client_app.world.resource_mut::<RepliconClient>();
+        let mut client = client_app.world_mut().resource_mut::<RepliconClient>();
         let client_id = client
             .id()
             .expect("client should have an assigned ID for exchanging messages");
 
-        let mut server = self.world.resource_mut::<RepliconServer>();
+        let mut server = self.world_mut().resource_mut::<RepliconServer>();
         for (channel_id, message) in client.drain_sent() {
             server.insert_received(client_id, channel_id, message)
         }

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -41,14 +41,14 @@ fn sending_receiving() {
 
     server_app.connect_client(&mut client_app);
 
-    client_app.world.send_event(DummyEvent);
+    client_app.world_mut().send_event(DummyEvent);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
     let client_events = server_app
-        .world
+        .world()
         .resource::<Events<FromClient<DummyEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
@@ -67,18 +67,20 @@ fn mapping_and_sending_receiving() {
     let client_entity = Entity::from_raw(0);
     let server_entity = Entity::from_raw(client_entity.index() + 1);
     client_app
-        .world
+        .world_mut()
         .resource_mut::<ServerEntityMap>()
         .insert(server_entity, client_entity);
 
-    client_app.world.send_event(MappedEvent(client_entity));
+    client_app
+        .world_mut()
+        .send_event(MappedEvent(client_entity));
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
     let mapped_entities: Vec<_> = server_app
-        .world
+        .world_mut()
         .resource_mut::<Events<FromClient<MappedEvent>>>()
         .drain()
         .map(|event| event.event.0)
@@ -92,14 +94,14 @@ fn local_resending() {
     app.add_plugins((TimePlugin, RepliconPlugins))
         .add_client_event::<DummyEvent>(ChannelKind::Ordered);
 
-    app.world.send_event(DummyEvent);
+    app.world_mut().send_event(DummyEvent);
 
     app.update();
 
-    let dummy_events = app.world.resource::<Events<DummyEvent>>();
+    let dummy_events = app.world().resource::<Events<DummyEvent>>();
     assert!(dummy_events.is_empty());
 
-    let client_events = app.world.resource::<Events<FromClient<DummyEvent>>>();
+    let client_events = app.world().resource::<Events<FromClient<DummyEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
 

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -20,23 +20,23 @@ fn single() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
-    let client_entity = client_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+    let client_entity = client_app.world_mut().spawn(Replicated).id();
 
     client_app
-        .world
+        .world_mut()
         .resource_mut::<ServerEntityMap>()
         .insert(server_entity, client_entity);
 
-    server_app.world.despawn(server_entity);
+    server_app.world_mut().despawn(server_entity);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world().entities().is_empty());
 
-    let entity_map = client_app.world.resource::<ServerEntityMap>();
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
     assert!(entity_map.to_client().is_empty());
     assert!(entity_map.to_server().is_empty());
 }
@@ -57,35 +57,35 @@ fn with_heirarchy() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_child_entity = server_app.world.spawn(Replicated).id();
+    let server_child_entity = server_app.world_mut().spawn(Replicated).id();
     let server_entity = server_app
-        .world
+        .world_mut()
         .spawn(Replicated)
         .push_children(&[server_child_entity])
         .id();
 
-    let client_child_entity = client_app.world.spawn(Replicated).id();
+    let client_child_entity = client_app.world_mut().spawn(Replicated).id();
     let client_entity = client_app
-        .world
+        .world_mut()
         .spawn(Replicated)
         .push_children(&[client_child_entity])
         .id();
 
-    let mut entity_map = client_app.world.resource_mut::<ServerEntityMap>();
+    let mut entity_map = client_app.world_mut().resource_mut::<ServerEntityMap>();
     entity_map.insert(server_entity, client_entity);
     entity_map.insert(server_child_entity, client_child_entity);
 
-    server_app.world.despawn(server_entity);
-    server_app.world.despawn(server_child_entity);
+    server_app.world_mut().despawn(server_entity);
+    server_app.world_mut().despawn(server_child_entity);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    server_app.world.despawn(server_entity);
-    server_app.world.despawn(server_child_entity);
+    server_app.world_mut().despawn(server_entity);
+    server_app.world_mut().despawn(server_child_entity);
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world().entities().is_empty());
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn after_spawn() {
 
     // Insert and remove `Replicated` to trigger spawn and despawn for client at the same time.
     server_app
-        .world
+        .world_mut()
         .spawn((Replicated, DummyComponent))
         .remove::<Replicated>();
 
@@ -115,7 +115,7 @@ fn after_spawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world().entities().is_empty());
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -23,13 +23,13 @@ fn serialize_missing_component() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins));
 
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn_empty();
+    let mut entity = app.world_mut().spawn_empty();
     let _ = entity.serialize(fns_info);
 }
 
@@ -38,14 +38,14 @@ fn write() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins));
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn(OriginalComponent);
+    let mut entity = app.world_mut().spawn(OriginalComponent);
     let data = entity.serialize(fns_info);
     entity.remove::<OriginalComponent>();
     entity.apply_write(&data, fns_info, tick);
@@ -57,14 +57,14 @@ fn remove() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins));
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn(OriginalComponent);
+    let mut entity = app.world_mut().spawn(OriginalComponent);
     entity.apply_remove(fns_info, tick);
     assert!(!entity.contains::<OriginalComponent>());
 }
@@ -75,14 +75,14 @@ fn write_with_command() {
     app.add_plugins((MinimalPlugins, RepliconPlugins))
         .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn(OriginalComponent);
+    let mut entity = app.world_mut().spawn(OriginalComponent);
     let data = entity.serialize(fns_info);
     entity.apply_write(&data, fns_info, tick);
     assert!(entity.contains::<ReplacedComponent>());
@@ -94,14 +94,14 @@ fn remove_with_command() {
     app.add_plugins((MinimalPlugins, RepliconPlugins))
         .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn(ReplacedComponent);
+    let mut entity = app.world_mut().spawn(ReplacedComponent);
     entity.apply_remove(fns_info, tick);
     assert!(!entity.contains::<ReplacedComponent>());
 }
@@ -116,14 +116,14 @@ fn write_without_marker() {
             command_fns::default_remove::<ReplacedComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn(OriginalComponent);
+    let mut entity = app.world_mut().spawn(OriginalComponent);
     let data = entity.serialize(fns_info);
     entity.remove::<OriginalComponent>();
     entity.apply_write(&data, fns_info, tick);
@@ -140,14 +140,14 @@ fn remove_without_marker() {
             command_fns::default_remove::<ReplacedComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn(OriginalComponent);
+    let mut entity = app.world_mut().spawn(OriginalComponent);
     entity.apply_remove(fns_info, tick);
     assert!(!entity.contains::<OriginalComponent>());
 }
@@ -162,14 +162,14 @@ fn write_with_marker() {
             command_fns::default_remove::<ReplacedComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn((OriginalComponent, ReplaceMarker));
+    let mut entity = app.world_mut().spawn((OriginalComponent, ReplaceMarker));
     let data = entity.serialize(fns_info);
     entity.apply_write(&data, fns_info, tick);
     assert!(entity.contains::<ReplacedComponent>());
@@ -185,14 +185,14 @@ fn remove_with_marker() {
             command_fns::default_remove::<ReplacedComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
-    let mut entity = app.world.spawn((ReplacedComponent, ReplaceMarker));
+    let mut entity = app.world_mut().spawn((ReplacedComponent, ReplaceMarker));
     entity.apply_remove(fns_info, tick);
     assert!(!entity.contains::<ReplacedComponent>());
 }
@@ -212,15 +212,15 @@ fn write_with_multiple_markers() {
             command_fns::default_remove::<OriginalComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
     let mut entity = app
-        .world
+        .world_mut()
         .spawn((OriginalComponent, ReplaceMarker, DummyMarker));
     let data = entity.serialize(fns_info);
     entity.apply_write(&data, fns_info, tick);
@@ -245,15 +245,15 @@ fn remove_with_mutltiple_markers() {
             command_fns::default_remove::<OriginalComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
     let mut entity = app
-        .world
+        .world_mut()
         .spawn((ReplacedComponent, ReplaceMarker, DummyMarker));
     entity.apply_remove(fns_info, tick);
     assert!(
@@ -280,15 +280,15 @@ fn write_with_priority_marker() {
             command_fns::default_remove::<OriginalComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
     let mut entity = app
-        .world
+        .world_mut()
         .spawn((OriginalComponent, ReplaceMarker, DummyMarker));
     let data = entity.serialize(fns_info);
     entity.apply_write(&data, fns_info, tick);
@@ -313,15 +313,15 @@ fn remove_with_priority_marker() {
             command_fns::default_remove::<OriginalComponent>,
         );
 
-    let tick = **app.world.resource::<ServerTick>();
-    let fns_info = app
-        .world
-        .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
-            replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
-        });
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let fns_info =
+        app.world_mut()
+            .resource_scope(|world, mut replication_fns: Mut<ReplicationFns>| {
+                replication_fns.register_rule_fns(world, RuleFns::<OriginalComponent>::default())
+            });
 
     let mut entity = app
-        .world
+        .world_mut()
         .spawn((ReplacedComponent, ReplaceMarker, DummyMarker));
     entity.apply_remove(fns_info, tick);
     assert!(!entity.contains::<ReplacedComponent>());
@@ -332,14 +332,14 @@ fn despawn() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins));
 
-    let mut replication_fns = app.world.resource_mut::<ReplicationFns>();
+    let mut replication_fns = app.world_mut().resource_mut::<ReplicationFns>();
     replication_fns.despawn = mark_despawned;
 
-    let tick = **app.world.resource::<ServerTick>();
-    let entity = app.world.spawn_empty();
+    let tick = **app.world_mut().resource::<ServerTick>();
+    let entity = app.world_mut().spawn_empty();
     let id = entity.id(); // Take ID since despawn function consumes entity.
     entity.apply_despawn(tick);
-    assert!(app.world.get::<Despawned>(id).is_some());
+    assert!(app.world_mut().get::<Despawned>(id).is_some());
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -26,7 +26,7 @@ fn table_storage() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -34,7 +34,7 @@ fn table_storage() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(TableComponent);
 
@@ -43,9 +43,9 @@ fn table_storage() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), With<TableComponent>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn sparse_set_storage() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -73,7 +73,7 @@ fn sparse_set_storage() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(SparseSetComponent);
 
@@ -82,9 +82,9 @@ fn sparse_set_storage() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), With<SparseSetComponent>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -105,14 +105,14 @@ fn mapped_existing_entity() {
     server_app.connect_client(&mut client_app);
 
     // Make client and server have different entity IDs.
-    server_app.world.spawn_empty();
+    server_app.world_mut().spawn_empty();
 
-    let server_entity = server_app.world.spawn(Replicated).id();
-    let server_map_entity = server_app.world.spawn_empty().id();
-    let client_map_entity = client_app.world.spawn_empty().id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+    let server_map_entity = server_app.world_mut().spawn_empty().id();
+    let client_map_entity = client_app.world_mut().spawn_empty().id();
 
     client_app
-        .world
+        .world_mut()
         .resource_mut::<ServerEntityMap>()
         .insert(server_map_entity, client_map_entity);
 
@@ -122,7 +122,7 @@ fn mapped_existing_entity() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(MappedComponent(server_map_entity));
 
@@ -131,9 +131,9 @@ fn mapped_existing_entity() {
     client_app.update();
 
     let mapped_component = client_app
-        .world
+        .world_mut()
         .query::<&MappedComponent>()
-        .single(&client_app.world);
+        .single(&client_app.world());
     assert_eq!(mapped_component.0, client_map_entity);
 }
 
@@ -155,10 +155,10 @@ fn mapped_new_entity() {
     server_app.connect_client(&mut client_app);
 
     // Make client and server have different entity IDs.
-    server_app.world.spawn_empty();
+    server_app.world_mut().spawn_empty();
 
-    let server_entity = server_app.world.spawn(Replicated).id();
-    let server_map_entity = server_app.world.spawn_empty().id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+    let server_map_entity = server_app.world_mut().spawn_empty().id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -166,7 +166,7 @@ fn mapped_new_entity() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(MappedComponent(server_map_entity));
 
@@ -175,11 +175,11 @@ fn mapped_new_entity() {
     client_app.update();
 
     let mapped_component = client_app
-        .world
+        .world_mut()
         .query::<&MappedComponent>()
-        .single(&client_app.world);
-    assert!(client_app.world.get_entity(mapped_component.0).is_some());
-    assert_eq!(client_app.world.entities().len(), 2);
+        .single(&client_app.world());
+    assert!(client_app.world().get_entity(mapped_component.0).is_some());
+    assert_eq!(client_app.world_mut().entities().len(), 2);
 }
 
 #[test]
@@ -200,7 +200,7 @@ fn command_fns() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -208,7 +208,7 @@ fn command_fns() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(OriginalComponent);
 
@@ -217,9 +217,9 @@ fn command_fns() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<ReplacedComponent>, Without<OriginalComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -244,13 +244,13 @@ fn marker() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
-    let client_entity = client_app.world.spawn(ReplaceMarker).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+    let client_entity = client_app.world_mut().spawn(ReplaceMarker).id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
 
-    let mut entity_map = server_app.world.resource_mut::<ClientEntityMap>();
+    let mut entity_map = server_app.world_mut().resource_mut::<ClientEntityMap>();
     entity_map.insert(
         client_id,
         ClientMapping {
@@ -265,7 +265,7 @@ fn marker() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(OriginalComponent);
 
@@ -273,7 +273,7 @@ fn marker() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(!client_entity.contains::<OriginalComponent>());
     assert!(client_entity.contains::<ReplacedComponent>());
 }
@@ -295,7 +295,7 @@ fn group() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -303,7 +303,7 @@ fn group() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert((GroupComponentA, GroupComponentB));
 
@@ -312,9 +312,9 @@ fn group() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<GroupComponentA>, With<GroupComponentB>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -333,7 +333,7 @@ fn not_replicated() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -341,7 +341,7 @@ fn not_replicated() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(NotReplicatedComponent);
 
@@ -350,9 +350,9 @@ fn not_replicated() {
     client_app.update();
 
     let not_replicated_components = client_app
-        .world
+        .world_mut()
         .query_filtered::<(), With<NotReplicatedComponent>>()
-        .iter(&client_app.world)
+        .iter(&client_app.world())
         .count();
     assert_eq!(not_replicated_components, 0);
 }
@@ -374,7 +374,10 @@ fn after_removal() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, TableComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, TableComponent))
+        .id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -383,7 +386,7 @@ fn after_removal() {
 
     // Insert and remove at the same time.
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<TableComponent>()
         .insert(TableComponent);
@@ -393,9 +396,9 @@ fn after_removal() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), With<TableComponent>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -25,7 +25,10 @@ fn single() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -33,12 +36,12 @@ fn single() {
     server_app.exchange_with_client(&mut client_app);
 
     let client_entity = client_app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<DummyComponent>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<DummyComponent>();
 
@@ -46,7 +49,7 @@ fn single() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(!client_entity.contains::<DummyComponent>());
 }
 
@@ -68,7 +71,10 @@ fn command_fns() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, OriginalComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, OriginalComponent))
+        .id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -76,12 +82,12 @@ fn command_fns() {
     server_app.exchange_with_client(&mut client_app);
 
     let client_entity = client_app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ReplacedComponent>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<OriginalComponent>();
 
@@ -89,7 +95,7 @@ fn command_fns() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(!client_entity.contains::<ReplacedComponent>());
 }
 
@@ -115,13 +121,16 @@ fn marker() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, OriginalComponent)).id();
-    let client_entity = client_app.world.spawn(ReplaceMarker).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, OriginalComponent))
+        .id();
+    let client_entity = client_app.world_mut().spawn(ReplaceMarker).id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
 
-    let mut entity_map = server_app.world.resource_mut::<ClientEntityMap>();
+    let mut entity_map = server_app.world_mut().resource_mut::<ClientEntityMap>();
     entity_map.insert(
         client_id,
         ClientMapping {
@@ -136,7 +145,7 @@ fn marker() {
     server_app.exchange_with_client(&mut client_app);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<OriginalComponent>();
 
@@ -144,7 +153,7 @@ fn marker() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(!client_entity.contains::<ReplacedComponent>());
 }
 
@@ -166,7 +175,7 @@ fn group() {
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
-        .world
+        .world_mut()
         .spawn((Replicated, (GroupComponentA, GroupComponentB)))
         .id();
 
@@ -176,12 +185,12 @@ fn group() {
     server_app.exchange_with_client(&mut client_app);
 
     let client_entity = client_app
-        .world
+        .world_mut()
         .query_filtered::<Entity, (With<GroupComponentA>, With<GroupComponentB>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<(GroupComponentA, GroupComponentB)>();
 
@@ -189,7 +198,7 @@ fn group() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(!client_entity.contains::<GroupComponentA>());
     assert!(!client_entity.contains::<GroupComponentB>());
 }
@@ -211,7 +220,7 @@ fn not_replicated() {
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
-        .world
+        .world_mut()
         .spawn((Replicated, NotReplicatedComponent))
         .id();
 
@@ -221,17 +230,17 @@ fn not_replicated() {
     server_app.exchange_with_client(&mut client_app);
 
     let client_entity = client_app
-        .world
+        .world_mut()
         .query_filtered::<Entity, (With<Replicated>, Without<NotReplicatedComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     client_app
-        .world
+        .world_mut()
         .entity_mut(client_entity)
         .insert(NotReplicatedComponent);
 
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<NotReplicatedComponent>();
 
@@ -239,7 +248,7 @@ fn not_replicated() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(client_entity.contains::<NotReplicatedComponent>());
 }
 
@@ -260,7 +269,10 @@ fn after_insertion() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -268,13 +280,13 @@ fn after_insertion() {
     server_app.exchange_with_client(&mut client_app);
 
     let client_entity = client_app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<DummyComponent>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     // Insert and remove at the same time.
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(DummyComponent)
         .remove::<DummyComponent>();
@@ -283,7 +295,7 @@ fn after_insertion() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(!client_entity.contains::<DummyComponent>());
 }
 
@@ -304,18 +316,21 @@ fn with_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    assert_eq!(client_app.world.entities().len(), 1);
+    assert_eq!(client_app.world_mut().entities().len(), 1);
 
     // Un-replicate and remove at the same time.
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .remove::<DummyComponent>()
         .remove::<Replicated>();
@@ -324,7 +339,7 @@ fn with_despawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world_mut().entities().is_empty());
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -9,10 +9,10 @@ fn replicated_entity() {
         .register_type::<DummyComponent>()
         .replicate::<DummyComponent>();
 
-    let entity = app.world.spawn((Replicated, DummyComponent)).id();
+    let entity = app.world_mut().spawn((Replicated, DummyComponent)).id();
 
     let mut scene = DynamicScene::default();
-    scene::replicate_into(&mut scene, &app.world);
+    scene::replicate_into(&mut scene, &app.world());
 
     assert!(scene.resources.is_empty());
     assert_eq!(scene.entities.len(), 1);
@@ -27,11 +27,11 @@ fn empty_entity() {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins);
 
-    let entity = app.world.spawn(Replicated).id();
+    let entity = app.world_mut().spawn(Replicated).id();
 
     // Extend with replicated components.
     let mut scene = DynamicScene::default();
-    scene::replicate_into(&mut scene, &app.world);
+    scene::replicate_into(&mut scene, &app.world());
 
     assert!(scene.resources.is_empty());
     assert_eq!(scene.entities.len(), 1);
@@ -48,10 +48,10 @@ fn not_replicated_entity() {
         .register_type::<DummyComponent>()
         .replicate::<DummyComponent>();
 
-    app.world.spawn(DummyComponent);
+    app.world_mut().spawn(DummyComponent);
 
     let mut scene = DynamicScene::default();
-    scene::replicate_into(&mut scene, &app.world);
+    scene::replicate_into(&mut scene, &app.world());
 
     assert!(scene.resources.is_empty());
     assert!(scene.entities.is_empty());
@@ -66,18 +66,18 @@ fn entity_update() {
         .register_type::<OtherReflectedComponent>();
 
     let entity = app
-        .world
+        .world_mut()
         .spawn((Replicated, DummyComponent, OtherReflectedComponent))
         .id();
 
     // Populate scene only with a single non-replicated component.
-    let mut scene = DynamicSceneBuilder::from_world(&app.world)
+    let mut scene = DynamicSceneBuilder::from_world(&app.world())
         .allow::<OtherReflectedComponent>()
         .extract_entity(entity)
         .build();
 
     // Update already extracted entity with replicated components.
-    scene::replicate_into(&mut scene, &app.world);
+    scene::replicate_into(&mut scene, &app.world());
 
     assert!(scene.resources.is_empty());
     assert_eq!(scene.entities.len(), 1);

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -49,7 +49,7 @@ fn sending_receiving() {
 
     server_app.connect_client(&mut client_app);
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
 
     for (mode, events_count) in [
@@ -59,7 +59,7 @@ fn sending_receiving() {
         (SendMode::BroadcastExcept(ClientId::SERVER), 1),
         (SendMode::BroadcastExcept(client_id), 0),
     ] {
-        server_app.world.send_event(ToClients {
+        server_app.world_mut().send_event(ToClients {
             mode,
             event: DummyEvent,
         });
@@ -69,7 +69,7 @@ fn sending_receiving() {
         client_app.update();
         server_app.exchange_with_client(&mut client_app);
 
-        let mut dummy_events = client_app.world.resource_mut::<Events<DummyEvent>>();
+        let mut dummy_events = client_app.world_mut().resource_mut::<Events<DummyEvent>>();
         assert_eq!(
             dummy_events.drain().count(),
             events_count,
@@ -98,11 +98,11 @@ fn sending_receiving_and_mapping() {
     let client_entity = Entity::from_raw(0);
     let server_entity = Entity::from_raw(client_entity.index() + 1);
     client_app
-        .world
+        .world_mut()
         .resource_mut::<ServerEntityMap>()
         .insert(server_entity, client_entity);
 
-    server_app.world.send_event(ToClients {
+    server_app.world_mut().send_event(ToClients {
         mode: SendMode::Broadcast,
         event: MappedEvent(server_entity),
     });
@@ -112,7 +112,7 @@ fn sending_receiving_and_mapping() {
     client_app.update();
 
     let mapped_entities: Vec<_> = client_app
-        .world
+        .world_mut()
         .resource_mut::<Events<MappedEvent>>()
         .drain()
         .map(|event| event.0)
@@ -140,17 +140,17 @@ fn local_resending() {
         (SendMode::BroadcastExcept(ClientId::SERVER), 0),
         (SendMode::BroadcastExcept(DUMMY_CLIENT_ID), 1),
     ] {
-        app.world.send_event(ToClients {
+        app.world_mut().send_event(ToClients {
             mode,
             event: DummyEvent,
         });
 
         app.update();
 
-        let server_events = app.world.resource::<Events<ToClients<DummyEvent>>>();
+        let server_events = app.world_mut().resource::<Events<ToClients<DummyEvent>>>();
         assert!(server_events.is_empty());
 
-        let mut dummy_events = app.world.resource_mut::<Events<DummyEvent>>();
+        let mut dummy_events = app.world_mut().resource_mut::<Events<DummyEvent>>();
         assert_eq!(
             dummy_events.drain().count(),
             events_count,
@@ -178,7 +178,7 @@ fn event_queue() {
     server_app.connect_client(&mut client_app);
 
     // Spawn entity to trigger world change.
-    server_app.world.spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -186,10 +186,10 @@ fn event_queue() {
     server_app.exchange_with_client(&mut client_app);
 
     // Artificially reset the init tick to force the next received event to be queued.
-    let mut init_tick = client_app.world.resource_mut::<ServerInitTick>();
+    let mut init_tick = client_app.world_mut().resource_mut::<ServerInitTick>();
     let previous_tick = *init_tick;
     *init_tick = Default::default();
-    server_app.world.send_event(ToClients {
+    server_app.world_mut().send_event(ToClients {
         mode: SendMode::Broadcast,
         event: DummyEvent,
     });
@@ -198,14 +198,23 @@ fn event_queue() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(client_app.world.resource::<Events<DummyEvent>>().is_empty());
+    assert!(client_app
+        .world_mut()
+        .resource::<Events<DummyEvent>>()
+        .is_empty());
 
     // Restore the init tick to receive the event.
-    *client_app.world.resource_mut::<ServerInitTick>() = previous_tick;
+    *client_app.world_mut().resource_mut::<ServerInitTick>() = previous_tick;
 
     client_app.update();
 
-    assert_eq!(client_app.world.resource::<Events<DummyEvent>>().len(), 1);
+    assert_eq!(
+        client_app
+            .world_mut()
+            .resource::<Events<DummyEvent>>()
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -229,7 +238,7 @@ fn different_ticks() {
     server_app.connect_client(&mut client_app1);
 
     // Spawn entity to trigger world change.
-    server_app.world.spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, DummyComponent));
 
     // Update client 1 to initialize their replicon tick.
     server_app.update();
@@ -241,7 +250,7 @@ fn different_ticks() {
     // since only client 1 will recieve an init message here.
     server_app.connect_client(&mut client_app2);
 
-    server_app.world.send_event(ToClients {
+    server_app.world_mut().send_event(ToClients {
         mode: SendMode::Broadcast,
         event: DummyEvent,
     });
@@ -254,8 +263,14 @@ fn different_ticks() {
     client_app1.update();
     client_app2.update();
 
-    assert_eq!(client_app1.world.resource::<Events<DummyEvent>>().len(), 1);
-    assert_eq!(client_app2.world.resource::<Events<DummyEvent>>().len(), 1);
+    assert_eq!(
+        client_app1.world().resource::<Events<DummyEvent>>().len(),
+        1
+    );
+    assert_eq!(
+        client_app2.world().resource::<Events<DummyEvent>>().len(),
+        1
+    );
 }
 
 #[derive(Component, Serialize, Deserialize)]

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -22,18 +22,18 @@ fn empty() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<Replicated>>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
-    let entity_map = client_app.world.resource::<ServerEntityMap>();
+    let entity_map = client_app.world().resource::<ServerEntityMap>();
     assert_eq!(
         entity_map.to_client().get(&server_entity),
         Some(&client_entity),
@@ -63,16 +63,16 @@ fn with_component() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world.spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -93,18 +93,18 @@ fn with_old_component() {
     server_app.connect_client(&mut client_app);
 
     // Spawn an entity with replicated component, but without a marker.
-    let server_entity = server_app.world.spawn(DummyComponent).id();
+    let server_entity = server_app.world_mut().spawn(DummyComponent).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world_mut().entities().is_empty());
 
     // Enable replication for previously spawned entity
     server_app
-        .world
+        .world_mut()
         .entity_mut(server_entity)
         .insert(Replicated);
 
@@ -113,9 +113,9 @@ fn with_old_component() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn before_connection() {
     }
 
     // Spawn an entity before client connected.
-    server_app.world.spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, DummyComponent));
 
     server_app.connect_client(&mut client_app);
 
@@ -142,9 +142,9 @@ fn before_connection() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -165,15 +165,18 @@ fn pre_spawn() {
     server_app.connect_client(&mut client_app);
 
     // Make client and server have different entity IDs.
-    server_app.world.spawn_empty();
+    server_app.world_mut().spawn_empty();
 
-    let client_entity = client_app.world.spawn_empty().id();
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let client_entity = client_app.world_mut().spawn_empty().id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
 
-    let mut entity_map = server_app.world.resource_mut::<ClientEntityMap>();
+    let mut entity_map = server_app.world_mut().resource_mut::<ClientEntityMap>();
     entity_map.insert(
         client_id,
         ClientMapping {
@@ -186,7 +189,7 @@ fn pre_spawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let entity_map = client_app.world.resource::<ServerEntityMap>();
+    let entity_map = client_app.world_mut().resource::<ServerEntityMap>();
     assert_eq!(
         entity_map.to_client().get(&server_entity),
         Some(&client_entity),
@@ -198,7 +201,7 @@ fn pre_spawn() {
         "replicated entity on client should be mapped to a server entity"
     );
 
-    let client_entity = client_app.world.entity(client_entity);
+    let client_entity = client_app.world_mut().entity(client_entity);
     assert!(
         client_entity.contains::<Replicated>(),
         "entity should start receive replication"
@@ -213,7 +216,7 @@ fn pre_spawn() {
     );
 
     assert_eq!(
-        client_app.world.entities().len(),
+        client_app.world_mut().entities().len(),
         1,
         "new entity shouldn't be spawned on client"
     );
@@ -238,7 +241,7 @@ fn after_despawn() {
 
     // Remove and insert `Replicated` to trigger despawn and spawn for client at the same time.
     server_app
-        .world
+        .world_mut()
         .spawn((Replicated, DummyComponent))
         .remove::<Replicated>()
         .insert(Replicated);
@@ -248,9 +251,9 @@ fn after_despawn() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -19,11 +19,14 @@ fn all() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false); // Shouldn't have any effect for this policy.
 
@@ -33,12 +36,12 @@ fn all() {
     server_app.exchange_with_client(&mut client_app);
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     // Reverse visibility back.
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, true);
 
@@ -47,9 +50,9 @@ fn all() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -70,16 +73,16 @@ fn empty_blacklist() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world.spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -100,11 +103,14 @@ fn blacklist() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false);
 
@@ -113,10 +119,10 @@ fn blacklist() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world_mut().entities().is_empty());
 
     // Reverse visibility back.
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, true);
 
@@ -125,9 +131,9 @@ fn blacklist() {
     client_app.update();
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 }
 
 #[test]
@@ -148,22 +154,22 @@ fn blacklist_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false);
-    server_app.world.despawn(server_entity);
+    server_app.world_mut().despawn(server_entity);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world_mut().entities().is_empty());
 
-    let connected_clients = server_app.world.resource::<ConnectedClients>();
+    let connected_clients = server_app.world_mut().resource::<ConnectedClients>();
     let visibility = connected_clients.client(client_id).visibility();
     assert!(visibility.is_visible(server_entity)); // The missing entity must be removed from the list, so this should return `true`.
 }
@@ -186,14 +192,14 @@ fn empty_whitelist() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world.spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, DummyComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     assert!(
-        client_app.world.entities().is_empty(),
+        client_app.world_mut().entities().is_empty(),
         "no entities should be replicated without adding to whitelist"
     );
 }
@@ -216,11 +222,14 @@ fn whitelist() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn((Replicated, DummyComponent)).id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, true);
 
@@ -230,12 +239,12 @@ fn whitelist() {
     server_app.exchange_with_client(&mut client_app);
 
     client_app
-        .world
+        .world_mut()
         .query_filtered::<(), (With<Replicated>, With<DummyComponent>)>()
-        .single(&client_app.world);
+        .single(&client_app.world());
 
     // Reverse visibility.
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false);
 
@@ -244,7 +253,7 @@ fn whitelist() {
     client_app.update();
 
     assert!(
-        client_app.world.entities().is_empty(),
+        client_app.world_mut().entities().is_empty(),
         "entity should be despawned after removing from whitelist"
     );
 }
@@ -267,22 +276,22 @@ fn whitelist_despawn() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world.spawn(Replicated).id();
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
 
-    let client = client_app.world.resource::<RepliconClient>();
+    let client = client_app.world_mut().resource::<RepliconClient>();
     let client_id = client.id().unwrap();
-    let mut connected_clients = server_app.world.resource_mut::<ConnectedClients>();
+    let mut connected_clients = server_app.world_mut().resource_mut::<ConnectedClients>();
     let visibility = connected_clients.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, true);
-    server_app.world.despawn(server_entity);
+    server_app.world_mut().despawn(server_entity);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(client_app.world.entities().is_empty());
+    assert!(client_app.world_mut().entities().is_empty());
 
-    let connected_clients = server_app.world.resource::<ConnectedClients>();
+    let connected_clients = server_app.world_mut().resource::<ConnectedClients>();
     let visibility = connected_clients.client(client_id).visibility();
     assert!(!visibility.is_visible(server_entity));
 }


### PR DESCRIPTION
Part of #245
- Upgrade to Bevy 0.14 to take advantage of the new `EventRegistry`. I'm using a fork of `bevy_renet` for now so this probably should be merged after `bevy_renet` release a new version with Bevy 0.14 support.
- The example currently is broken due to https://github.com/bevyengine/bevy/issues/13175