### PR TITLE
Minor connected client refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom events are now registered with serialization and deserialization functions instead of systems. This makes the API more convenient since the purpose of custom systems was to customize serialization.
 - All events are processed in one system instead of a separate system for each event. Bevy does a [similar optimization](https://github.com/bevyengine/bevy/pull/12936) for event updates. It won't be that noticeable since users register much fewer replicon events.
 - Rename `ConnectedClient::change_tick` into `ConnectedClient::init_tick`.
+- Rename `ConnectedClient::set_change_limit` into `ConnectedClient::get_change_tick`.
 
 ## [0.25.3] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom events are now registered with serialization and deserialization functions instead of systems. This makes the API more convenient since the purpose of custom systems was to customize serialization.
 - All events are processed in one system instead of a separate system for each event. Bevy does a [similar optimization](https://github.com/bevyengine/bevy/pull/12936) for event updates. It won't be that noticeable since users register much fewer replicon events.
 - Rename `ConnectedClient::change_tick` into `ConnectedClient::init_tick`.
-- Rename `ConnectedClient::get_change_limit`/`ConnectedClient::set_change_limit` into `ConnectedClient::get_change_tick`/`ConnectedClient::set_change_tick`.
+- Rename `ConnectedClient::get_change_limit` into `ConnectedClient::get_change_tick`.
 
 ## [0.25.3] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom events are now registered with serialization and deserialization functions instead of systems. This makes the API more convenient since the purpose of custom systems was to customize serialization.
 - All events are processed in one system instead of a separate system for each event. Bevy does a [similar optimization](https://github.com/bevyengine/bevy/pull/12936) for event updates. It won't be that noticeable since users register much fewer replicon events.
 - Rename `ConnectedClient::change_tick` into `ConnectedClient::init_tick`.
-- Rename `ConnectedClient::set_change_limit` into `ConnectedClient::get_change_tick`.
+- Rename `ConnectedClient::get_change_limit`/`ConnectedClient::set_change_limit` into `ConnectedClient::get_change_tick`/`ConnectedClient::set_change_tick`.
 
 ## [0.25.3] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Custom events are now registered with serialization and deserialization functions instead of systems. This makes the API more convenient since the purpose of custom systems was to customize serialization.
 - All events are processed in one system instead of a separate system for each event. Bevy does a [similar optimization](https://github.com/bevyengine/bevy/pull/12936) for event updates. It won't be that noticeable since users register much fewer replicon events.
+- Rename `ConnectedClient::change_tick` into `ConnectedClient::init_tick`.
 
 ## [0.25.3] - 2024-05-24
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -375,7 +375,7 @@ fn collect_changes(
                     }
 
                     if let Some(tick) = client
-                        .get_change_limit(entity.id())
+                        .get_change_tick(entity.id())
                         .filter(|_| !marker_added)
                         .filter(|_| visibility != Visibility::Gained)
                         .filter(|_| !ticks.is_added(change_tick.last_run(), change_tick.this_run()))
@@ -417,7 +417,7 @@ fn collect_changes(
                     // If there is any insertion, removal, or we must initialize, include all updates into init message.
                     // and bump the last acknowledged tick to keep entity updates atomic.
                     init_message.take_entity_data(update_message)?;
-                    client.set_change_limit(entity.id(), change_tick.this_run());
+                    client.set_change_tick(entity.id(), change_tick.this_run());
                 } else {
                     update_message.end_entity_data()?;
                 }

--- a/src/server/connected_clients.rs
+++ b/src/server/connected_clients.rs
@@ -156,12 +156,12 @@ pub struct ConnectedClient {
     /// Entity visibility settings.
     visibility: ClientVisibility,
 
-    /// The last tick in which a replicated entity was spawned, despawned, or gained/lost a component from the
+    /// The last tick in which a replicated entity had an insertion, removal, or gained/lost a component from the
     /// perspective of the client.
     ///
     /// It should be included in update messages and server events to avoid needless waiting for the next init
     /// message to arrive.
-    change_tick: RepliconTick,
+    init_tick: RepliconTick,
 
     /// Update message indexes mapped to their info.
     updates: HashMap<u16, UpdateInfo>,
@@ -178,7 +178,7 @@ impl ConnectedClient {
             id,
             ticks: Default::default(),
             visibility: ClientVisibility::new(policy),
-            change_tick: Default::default(),
+            init_tick: Default::default(),
             updates: Default::default(),
             next_update_index: Default::default(),
         }
@@ -199,15 +199,15 @@ impl ConnectedClient {
         &mut self.visibility
     }
 
-    /// Sets the client's change tick.
-    pub(super) fn set_change_tick(&mut self, tick: RepliconTick) {
-        self.change_tick = tick;
+    /// Sets the client's init tick.
+    pub(super) fn set_init_tick(&mut self, tick: RepliconTick) {
+        self.init_tick = tick;
     }
 
-    /// Returns the last tick in which a replicated entity was spawned, despawned, or gained/lost a component from the
+    /// Returns the last tick in which a replicated entity had an insertion, removal, or gained/lost a component from the
     /// perspective of the client.
-    pub fn change_tick(&self) -> RepliconTick {
-        self.change_tick
+    pub fn init_tick(&self) -> RepliconTick {
+        self.init_tick
     }
 
     /// Clears all entities for unacknowledged updates, returning them as an iterator.

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -395,7 +395,7 @@ impl InitMessage {
             return Ok(());
         }
 
-        client.set_change_tick(replicon_tick);
+        client.set_init_tick(replicon_tick);
 
         let mut header = [0; mem::size_of::<RepliconTick>()];
         bincode::serialize_into(&mut header[..], &replicon_tick)?;
@@ -578,7 +578,7 @@ impl UpdateMessage {
         trace!("sending update message(s) to {:?}", client.id());
         const TICKS_SIZE: usize = 2 * mem::size_of::<RepliconTick>();
         let mut header = [0; TICKS_SIZE + mem::size_of::<u16>()];
-        bincode::serialize_into(&mut header[..], &(client.change_tick(), replicon_tick))?;
+        bincode::serialize_into(&mut header[..], &(client.init_tick(), replicon_tick))?;
 
         let mut message_size = 0;
         let client_id = client.id();

--- a/src/server_event/server_event_data.rs
+++ b/src/server_event/server_event_data.rs
@@ -394,16 +394,16 @@ unsafe fn serialize_with<E: Event>(
     previous_message: Option<SerializedMessage>,
 ) -> bincode::Result<SerializedMessage> {
     if let Some(previous_message) = previous_message {
-        if previous_message.tick == client.change_tick() {
+        if previous_message.tick == client.init_tick() {
             return Ok(previous_message);
         }
 
-        let tick_size = DefaultOptions::new().serialized_size(&client.change_tick())? as usize;
+        let tick_size = DefaultOptions::new().serialized_size(&client.init_tick())? as usize;
         let mut bytes = Vec::with_capacity(tick_size + previous_message.event_bytes().len());
-        DefaultOptions::new().serialize_into(&mut bytes, &client.change_tick())?;
+        DefaultOptions::new().serialize_into(&mut bytes, &client.init_tick())?;
         bytes.extend_from_slice(previous_message.event_bytes());
         let message = SerializedMessage {
-            tick: client.change_tick(),
+            tick: client.init_tick(),
             tick_size,
             bytes: bytes.into(),
         };
@@ -411,11 +411,11 @@ unsafe fn serialize_with<E: Event>(
         Ok(message)
     } else {
         let mut cursor = Cursor::new(Vec::new());
-        DefaultOptions::new().serialize_into(&mut cursor, &client.change_tick())?;
+        DefaultOptions::new().serialize_into(&mut cursor, &client.init_tick())?;
         let tick_size = cursor.get_ref().len();
         event_data.serialize(ctx, event, &mut cursor)?;
         let message = SerializedMessage {
-            tick: client.change_tick(),
+            tick: client.init_tick(),
             tick_size,
             bytes: cursor.into_inner().into(),
         };


### PR DESCRIPTION
A few changes to have consistent naming. We use `init_tick` terminology on client and `change_tick` usually referenced as a Bevy's tick.