### PR TITLE
Fix renet Connecting status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `bevy_replicon_renet` now properly sets `RepliconClientStatus::Connecting` when `RenetClient` is connecting.
+
 ### Changed
 
 - Custom events are now registered with serialization and deserialization functions instead of systems. This makes the API more convenient since the purpose of custom systems was to customize serialization.
 - All events are processed in one system instead of a separate system for each event. Bevy does a [similar optimization](https://github.com/bevyengine/bevy/pull/12936) for event updates. It won't be that noticeable since users register much fewer replicon events.
 - Rename `ConnectedClient::change_tick` into `ConnectedClient::init_tick`.
 - Rename `ConnectedClient::get_change_limit` into `ConnectedClient::get_change_tick`.
-
-### Fixed
-
-- `bevy_replicon_renet` now properly sets `RepliconClientStatus::Connecting` when `RenetClient` is connecting.
 
 ## [0.25.3] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `ConnectedClient::change_tick` into `ConnectedClient::init_tick`.
 - Rename `ConnectedClient::get_change_limit` into `ConnectedClient::get_change_tick`.
 
+### Fixed
+
+- `bevy_replicon_renet` now properly sets `RepliconClientStatus::Connecting` when `RenetClient` is connecting.
+
 ## [0.25.3] - 2024-05-24
 
 ### Fixed

--- a/bevy_replicon_renet/src/lib.rs
+++ b/bevy_replicon_renet/src/lib.rs
@@ -172,7 +172,7 @@ impl Plugin for RepliconRenetClientPlugin {
             .add_systems(
                 PreUpdate,
                 (
-                    Self::set_connecting.run_if(resource_added::<RenetClient>),
+                    Self::set_connecting.run_if(bevy_renet::client_connecting),
                     Self::set_disconnected.run_if(bevy_renet::client_just_disconnected),
                     Self::set_connected.run_if(bevy_renet::client_just_connected),
                     Self::receive_packets.run_if(bevy_renet::client_connected),
@@ -198,7 +198,9 @@ impl RepliconRenetClientPlugin {
     }
 
     fn set_connecting(mut client: ResMut<RepliconClient>) {
-        client.set_status(RepliconClientStatus::Connecting);
+        if client.status() != RepliconClientStatus::Connecting {
+            client.set_status(RepliconClientStatus::Connecting);
+        }
     }
 
     fn set_connected(


### PR DESCRIPTION
`Connecting` is a property of `RenetClient`, not incidental to insertion.