### PR TITLE
Add a dedicated readme for renet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ See also [What kind of networking should X game use?](https://github.com/bevyeng
 
 ## Getting Started
 
-Check out the [quick start guide](https://docs.rs/bevy_replicon/latest/bevy_replicon).
+Check out the [quick start guide](https://docs.rs/bevy_replicon).
 
-See also [examples](https://github.com/projectharmonia/bevy_replicon/tree/master/bevy_replicon_renet/examples).
+See also [examples](bevy_replicon_renet/examples) with [`bevy_replicon_renet`](bevy_replicon_renet) as a messaging backed.
 
 Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](https://discord.com/channels/691052431525675048/1090432346907492443) in Bevy's Discord server.
 
@@ -49,7 +49,7 @@ Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](
 
 #### Messaging backends
 
-- `bevy_replicon_renet` - integration for [`bevy_renet`](https://github.com/lucaspoffo/renet/tree/master/bevy_renet). Provided by this repo.
+- [`bevy_replicon_renet`](bevy_replicon_renet) - integration for [`bevy_renet`](https://github.com/lucaspoffo/renet/tree/master/bevy_renet). Provided by this repo.
 - [`bevy_replicon_renet2`](https://github.com/UkoeHB/renet2) - integration for [`bevy_renet2`](https://github.com/UkoeHB/renet2/tree/main/bevy_renet2). Includes a WebTransport backend for browsers, and enables servers that can manage multi-platform clients simultaneously.
 - [`bevy_replicon_quinnet`](https://github.com/Henauxg/bevy_quinnet/tree/main/bevy_replicon_quinnet) - integration for [`bevy_quinnet`](https://github.com/Henauxg/bevy_quinnet).
 
@@ -69,10 +69,10 @@ Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](
 
 ## Bevy compatibility
 
-| bevy   | bevy_replicon | bevy_replicon_renet |
-| ------ | ------------- | ------------------- |
-| 0.13.0 | 0.23-0.26     | 0.1-0.3             |
-| 0.12.1 | 0.18-0.22     |                     |
-| 0.11.0 | 0.6-0.17      |                     |
-| 0.10.1 | 0.2-0.6       |                     |
-| 0.10.0 | 0.1           |                     |
+| bevy   | bevy_replicon |
+| ------ | ------------- |
+| 0.13.0 | 0.23-0.26     |
+| 0.12.1 | 0.18-0.22     |
+| 0.11.0 | 0.6-0.17      |
+| 0.10.1 | 0.2-0.6       |
+| 0.10.0 | 0.1           |

--- a/bevy_replicon_renet/Cargo.toml
+++ b/bevy_replicon_renet/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 edition = "2021"
 description = "Integration with renet for bevy_replicon"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/projectharmonia/bevy_replicon"
 keywords = [
   "bevy",

--- a/bevy_replicon_renet/README.md
+++ b/bevy_replicon_renet/README.md
@@ -1,0 +1,20 @@
+# Bevy Replicon Renet
+
+[![crates.io](https://img.shields.io/crates/v/bevy_replicon_renet)](https://crates.io/crates/bevy_replicon_renet)
+[![docs.rs](https://docs.rs/bevy_replicon_renet/badge.svg)](https://docs.rs/bevy_replicon_renet)
+
+An integration of [`bevy_renet`](https://github.com/lucaspoffo/renet/tree/master/bevy_renet) as a messaging backend for [`bevy_replicon`](https://github.com/projectharmonia/bevy_replicon).
+
+## Getting Started
+
+Check out the [getting started guide](https://docs.rs/bevy_replicon_renet).
+
+See also [examples](examples).
+
+## Compatible versions
+
+| bevy_renet | bevy_replicon | bevy_replicon_renet |
+| ---------- | ------------- | ------------------- |
+| 0.0.11     | 0.26          | 0.3                 |
+| 0.0.11     | 0.25          | 0.2                 |
+| 0.0.11     | 0.24          | 0.1                 |


### PR DESCRIPTION
The separate readme will be displayed on crates.io for `bevy_replicon_renet` instead of the full replicon readme which is nicer.
This way we can also provide a link to it from the main readme and maintain a better compatibility table for it. Inspired by [`bevy_replicon_quinnet`](https://github.com/Henauxg/bevy_quinnet/tree/main/bevy_replicon_quinnet).

I also used shorter notation for GitHub links and docs.rs.

@UkoeHB maybe provide a similar readme for `bevy_replicon_renet2`? If yes, it will be better to point to it from its link.