### PR TITLE
Set type annottations for transmute

### DIFF
--- a/src/client/events/event_data.rs
+++ b/src/client/events/event_data.rs
@@ -89,8 +89,8 @@ impl ClientEventData {
             receive: receive::<E>,
             resend_locally: resend_locally::<E>,
             reset: reset::<E>,
-            serialize: unsafe { mem::transmute(serialize) },
-            deserialize: unsafe { mem::transmute(deserialize) },
+            serialize: unsafe { mem::transmute::<SerializeFn<E>, unsafe fn()>(serialize) },
+            deserialize: unsafe { mem::transmute::<DeserializeFn<E>, unsafe fn()>(deserialize) },
         }
     }
 

--- a/src/core/replication_registry/command_fns.rs
+++ b/src/core/replication_registry/command_fns.rs
@@ -31,7 +31,7 @@ impl UntypedCommandFns {
             type_id: TypeId::of::<C>(),
             type_name: any::type_name::<C>(),
             // SAFETY: the function won't be called until the type is restored.
-            write: unsafe { mem::transmute(write) },
+            write: unsafe { mem::transmute::<WriteFn<C>, unsafe fn()>(write) },
             remove,
         }
     }

--- a/src/core/replication_registry/rule_fns.rs
+++ b/src/core/replication_registry/rule_fns.rs
@@ -39,10 +39,14 @@ impl UntypedRuleFns {
         );
 
         RuleFns {
-            serialize: unsafe { mem::transmute(self.serialize) },
-            deserialize: unsafe { mem::transmute(self.deserialize) },
-            deserialize_in_place: unsafe { mem::transmute(self.deserialize_in_place) },
-            consume: unsafe { mem::transmute(self.consume) },
+            serialize: unsafe { mem::transmute::<unsafe fn(), SerializeFn<C>>(self.serialize) },
+            deserialize: unsafe {
+                mem::transmute::<unsafe fn(), DeserializeFn<C>>(self.deserialize)
+            },
+            deserialize_in_place: unsafe {
+                mem::transmute::<unsafe fn(), DeserializeInPlaceFn<C>>(self.deserialize_in_place)
+            },
+            consume: unsafe { mem::transmute::<unsafe fn(), ConsumeFn<C>>(self.consume) },
         }
     }
 }
@@ -53,10 +57,14 @@ impl<C: Component> From<RuleFns<C>> for UntypedRuleFns {
         Self {
             type_id: TypeId::of::<C>(),
             type_name: any::type_name::<C>(),
-            serialize: unsafe { mem::transmute(value.serialize) },
-            deserialize: unsafe { mem::transmute(value.deserialize) },
-            deserialize_in_place: unsafe { mem::transmute(value.deserialize_in_place) },
-            consume: unsafe { mem::transmute(value.consume) },
+            serialize: unsafe { mem::transmute::<SerializeFn<C>, unsafe fn()>(value.serialize) },
+            deserialize: unsafe {
+                mem::transmute::<DeserializeFn<C>, unsafe fn()>(value.deserialize)
+            },
+            deserialize_in_place: unsafe {
+                mem::transmute::<DeserializeInPlaceFn<C>, unsafe fn()>(value.deserialize_in_place)
+            },
+            consume: unsafe { mem::transmute::<ConsumeFn<C>, unsafe fn()>(value.consume) },
         }
     }
 }

--- a/src/server/events/event_data.rs
+++ b/src/server/events/event_data.rs
@@ -95,8 +95,8 @@ impl ServerEventData {
             receive: receive::<E>,
             resend_locally: resend_locally::<E>,
             reset: reset::<E>,
-            serialize: unsafe { mem::transmute(serialize) },
-            deserialize: unsafe { mem::transmute(deserialize) },
+            serialize: unsafe { mem::transmute::<SerializeFn<E>, unsafe fn()>(serialize) },
+            deserialize: unsafe { mem::transmute::<DeserializeFn<E>, unsafe fn()>(deserialize) },
         }
     }
 


### PR DESCRIPTION
This is a new lint for Clippy that causes CI to fail. For details see https://rust-lang.github.io/rust-clippy/master/index.html#/missing_transmute_annotations