### PR TITLE
Rework events organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `ServerEventsPlugin` and `ClientEventsPlugin` can be disabled on client-only and server-only apps respectively.
+- Move `server::events::event_data` module to `core::event_registry::server_event`.
+- Move `client::events::event_data` module to `core::event_registry::client_event`.
+- Move `ClientEventAppExt`, `client::events::SerializeFn`, `client::events::DeserializeFn`, `default_serialize`, `default_serialize_mapped`, `default_deserialize` and `FromClient` to `core::event_registry::client_event`.
+- Move `ServerEventAppExt`, `server::events::SerializeFn`, `server::events::DeserializeFn`, `default_serialize`, `default_serialize_mapped`, `default_deserialize`, `ToClients` and `SendMode` to `core::event_registry::server_event`.
+
 ## [0.27.0-rc.2] - 2024-06-16
 
 ### Changed

--- a/src/client/events.rs
+++ b/src/client/events.rs
@@ -1,179 +1,41 @@
-mod event_data;
-
-use std::io::Cursor;
-
-use bevy::{
-    ecs::{entity::MapEntities, event::ManualEventReader},
-    prelude::*,
+use super::{
+    replicon_client::RepliconClient, server_entity_map::ServerEntityMap, ClientPlugin, ClientSet,
+    ServerInitTick,
 };
-use bincode::{DefaultOptions, Options};
-use serde::{de::DeserializeOwned, Serialize};
-
-use super::{replicon_client::RepliconClient, server_entity_map::ServerEntityMap, ClientSet};
-use crate::{
-    core::{
-        channels::{RepliconChannel, RepliconChannels},
-        common_conditions::*,
-        ctx::{ClientSendCtx, ServerReceiveCtx},
-        ClientId,
-    },
-    server::{replicon_server::RepliconServer, ServerSet},
+use crate::core::{
+    common_conditions::*,
+    ctx::{ClientReceiveCtx, ClientSendCtx},
+    event_registry::EventRegistry,
 };
-use event_data::ClientEventData;
-
-/// An extension trait for [`App`] for creating client events.
-pub trait ClientEventAppExt {
-    /// Registers [`FromClient<E>`] and `E` events.
-    ///
-    /// [`FromClient<E>`] will be emitted on the server after sending `E` event on client.
-    /// In listen-server mode `E` will be drained right after sending and re-emitted as
-    /// [`FromClient<E>`] with [`ClientId::SERVER`](crate::core::ClientId::SERVER).
-    ///
-    /// Can be called for events that were registered with [add_event](bevy::app::App::add_event).
-    /// A duplicate registration for `E` won't be created.
-    /// But be careful, since on listen servers all events `E` are drained,
-    /// which could break other Bevy or third-party plugin systems that listen for `E`.
-    ///
-    /// See also [`Self::add_client_event_with`] and the [corresponding section](../index.html#from-client-to-server)
-    /// from the quick start guide.
-    fn add_client_event<E: Event + Serialize + DeserializeOwned>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-    ) -> &mut Self {
-        self.add_client_event_with(channel, default_serialize::<E>, default_deserialize::<E>)
-    }
-
-    /// Same as [`Self::add_client_event`], but additionally maps client entities to server inside the event before sending.
-    ///
-    /// Always use it for events that contain entities.
-    /// See also [`Self::add_client_event`].
-    fn add_mapped_client_event<E: Event + Serialize + DeserializeOwned + MapEntities + Clone>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-    ) -> &mut Self {
-        self.add_client_event_with(
-            channel,
-            default_serialize_mapped::<E>,
-            default_deserialize::<E>,
-        )
-    }
-
-    /**
-    Same as [`Self::add_client_event`], but uses the specified functions for serialization and deserialization.
-
-    # Examples
-
-    Register an event with [`Box<dyn Reflect>`]:
-
-    ```
-    use std::io::Cursor;
-
-    use bevy::{
-        prelude::*,
-        reflect::serde::{ReflectSerializer, ReflectDeserializer},
-    };
-    use bevy_replicon::{
-        core::ctx::{ClientSendCtx, ServerReceiveCtx},
-        prelude::*,
-    };
-    use bincode::{DefaultOptions, Options};
-    use serde::de::DeserializeSeed;
-
-    let mut app = App::new();
-    app.add_plugins((MinimalPlugins, RepliconPlugins));
-    app.add_client_event_with(
-        ChannelKind::Ordered,
-        serialize_reflect,
-        deserialize_reflect,
-    );
-
-    fn serialize_reflect(
-        ctx: &mut ClientSendCtx,
-        event: &ReflectEvent,
-        cursor: &mut Cursor<Vec<u8>>,
-    ) -> bincode::Result<()> {
-        let serializer = ReflectSerializer::new(&*event.0, ctx.registry);
-        DefaultOptions::new().serialize_into(cursor, &serializer)
-    }
-
-    fn deserialize_reflect(
-        ctx: &mut ServerReceiveCtx,
-        cursor: &mut Cursor<&[u8]>,
-    ) -> bincode::Result<ReflectEvent> {
-        let mut deserializer = bincode::Deserializer::with_reader(cursor, DefaultOptions::new());
-        let reflect = ReflectDeserializer::new(ctx.registry).deserialize(&mut deserializer)?;
-        Ok(ReflectEvent(reflect))
-    }
-
-    #[derive(Event)]
-    struct ReflectEvent(Box<dyn Reflect>);
-    ```
-    */
-    fn add_client_event_with<E: Event>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
-    ) -> &mut Self;
-}
-
-impl ClientEventAppExt for App {
-    fn add_client_event_with<E: Event>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
-    ) -> &mut Self {
-        self.add_event::<E>()
-            .add_event::<FromClient<E>>()
-            .init_resource::<ClientEventReader<E>>();
-
-        let channel_id = self
-            .world_mut()
-            .resource_mut::<RepliconChannels>()
-            .create_client_channel(channel.into());
-
-        self.world_mut()
-            .resource_scope(|world, mut event_registry: Mut<ClientEventRegistry>| {
-                event_registry.0.push(ClientEventData::new(
-                    world.components(),
-                    channel_id,
-                    serialize,
-                    deserialize,
-                ));
-            });
-
-        self
-    }
-}
+use bevy::prelude::*;
 
 /// Sending events from a client to the server.
 ///
-/// Requires [`ClientPlugin`](super::ClientPlugin) for clients
-/// and [`ServerPlugin`](crate::server::ServerPlugin) for the server.
+/// Requires [`ClientPlugin`].
+/// Can be disabled for apps that act only as servers.
 pub struct ClientEventsPlugin;
 
 impl Plugin for ClientEventsPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ClientEventRegistry>()
-            .add_systems(
-                PreUpdate,
-                (
-                    Self::reset.in_set(ClientSet::ResetEvents),
-                    Self::receive
-                        .in_set(ServerSet::Receive)
-                        .run_if(server_running),
-                ),
+        app.add_systems(
+            PreUpdate,
+            (
+                Self::reset.in_set(ClientSet::ResetEvents),
+                Self::receive
+                    .after(ClientPlugin::receive_replication)
+                    .in_set(ClientSet::Receive)
+                    .run_if(client_connected),
+            ),
+        )
+        .add_systems(
+            PostUpdate,
+            (
+                Self::send.run_if(client_connected),
+                Self::resend_locally.run_if(has_authority),
             )
-            .add_systems(
-                PostUpdate,
-                (
-                    Self::send.run_if(client_connected),
-                    Self::resend_locally.run_if(has_authority),
-                )
-                    .chain()
-                    .in_set(ClientSet::Send),
-            );
+                .chain()
+                .in_set(ClientSet::Send),
+        );
     }
 }
 
@@ -182,14 +44,14 @@ impl ClientEventsPlugin {
         world.resource_scope(|world, mut client: Mut<RepliconClient>| {
             world.resource_scope(|world, registry: Mut<AppTypeRegistry>| {
                 world.resource_scope(|world, entity_map: Mut<ServerEntityMap>| {
-                    world.resource_scope(|world, event_registry: Mut<ClientEventRegistry>| {
+                    world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
                         let mut ctx = ClientSendCtx {
                             entity_map: &entity_map,
                             registry: &registry.read(),
                         };
 
                         let world_cell = world.as_unsafe_world_cell();
-                        for event_data in &event_registry.0 {
+                        for event_data in event_registry.iter_client_events() {
                             // SAFETY: both resources mutably borrowed uniquely.
                             let (events, reader) = unsafe {
                                 let events = world_cell
@@ -218,32 +80,50 @@ impl ClientEventsPlugin {
     }
 
     fn receive(world: &mut World) {
-        world.resource_scope(|world, mut server: Mut<RepliconServer>| {
+        world.resource_scope(|world, mut client: Mut<RepliconClient>| {
             world.resource_scope(|world, registry: Mut<AppTypeRegistry>| {
-                world.resource_scope(|world, event_registry: Mut<ClientEventRegistry>| {
-                    let mut ctx = ServerReceiveCtx {
-                        registry: &registry.read(),
-                    };
-
-                    for event_data in &event_registry.0 {
-                        let client_events = world
-                            .get_resource_mut_by_id(event_data.client_events_id())
-                            .expect("client events shouldn't be removed");
-
-                        // SAFETY: passed pointer was obtained using this event data.
-                        unsafe {
-                            event_data.receive(&mut ctx, client_events.into_inner(), &mut server)
+                world.resource_scope(|world, entity_map: Mut<ServerEntityMap>| {
+                    world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
+                        let init_tick = **world.resource::<ServerInitTick>();
+                        let mut ctx = ClientReceiveCtx {
+                            registry: &registry.read(),
+                            entity_map: &entity_map,
                         };
-                    }
+
+                        let world_cell = world.as_unsafe_world_cell();
+                        for event_data in event_registry.iter_server_events() {
+                            // SAFETY: both resources mutably borrowed uniquely.
+                            let (events, queue) = unsafe {
+                                let events = world_cell
+                                    .get_resource_mut_by_id(event_data.events_id())
+                                    .expect("events shouldn't be removed");
+                                let queue = world_cell
+                                    .get_resource_mut_by_id(event_data.queue_id())
+                                    .expect("event queue shouldn't be removed");
+                                (events, queue)
+                            };
+
+                            // SAFETY: passed pointers were obtained using this event data.
+                            unsafe {
+                                event_data.receive(
+                                    &mut ctx,
+                                    events.into_inner(),
+                                    queue.into_inner(),
+                                    &mut client,
+                                    init_tick,
+                                )
+                            };
+                        }
+                    });
                 });
             });
         });
     }
 
     fn resend_locally(world: &mut World) {
-        world.resource_scope(|world, event_registry: Mut<ClientEventRegistry>| {
+        world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
             let world_cell = world.as_unsafe_world_cell();
-            for event_data in &event_registry.0 {
+            for event_data in event_registry.iter_client_events() {
                 // SAFETY: both resources mutably borrowed uniquely.
                 let (client_events, events) = unsafe {
                     let client_events = world_cell
@@ -264,8 +144,8 @@ impl ClientEventsPlugin {
     }
 
     fn reset(world: &mut World) {
-        world.resource_scope(|world, event_registry: Mut<ClientEventRegistry>| {
-            for event_data in &event_registry.0 {
+        world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
+            for event_data in event_registry.iter_client_events() {
                 let events = world
                     .get_resource_mut_by_id(event_data.events_id())
                     .expect("events shouldn't be removed");
@@ -273,65 +153,15 @@ impl ClientEventsPlugin {
                 // SAFETY: passed pointer was obtained using this event data.
                 unsafe { event_data.reset(events.into_inner()) };
             }
+
+            for event_data in event_registry.iter_server_events() {
+                let queue = world
+                    .get_resource_mut_by_id(event_data.queue_id())
+                    .expect("event queue shouldn't be removed");
+
+                // SAFETY: passed pointer was obtained using this event data.
+                unsafe { event_data.reset(queue.into_inner()) };
+            }
         });
     }
-}
-
-/// Registered client events.
-#[derive(Resource, Default)]
-struct ClientEventRegistry(Vec<ClientEventData>);
-
-/// Tracks read events for [`ClientEventPlugin::send`].
-///
-/// Unlike with server events, we don't always drain all events in [`ClientEventPlugin::resend_locally`].
-#[derive(Resource, Deref, DerefMut)]
-struct ClientEventReader<E: Event>(ManualEventReader<E>);
-
-impl<E: Event> FromWorld for ClientEventReader<E> {
-    fn from_world(world: &mut World) -> Self {
-        let events = world.resource::<Events<E>>();
-        Self(events.get_reader())
-    }
-}
-
-/// Signature of client event serialization functions.
-pub type SerializeFn<E> = fn(&mut ClientSendCtx, &E, &mut Cursor<Vec<u8>>) -> bincode::Result<()>;
-
-/// Signature of client event deserialization functions.
-pub type DeserializeFn<E> = fn(&mut ServerReceiveCtx, &mut Cursor<&[u8]>) -> bincode::Result<E>;
-
-/// Default event serialization function.
-pub fn default_serialize<E: Event + Serialize>(
-    _ctx: &mut ClientSendCtx,
-    event: &E,
-    cursor: &mut Cursor<Vec<u8>>,
-) -> bincode::Result<()> {
-    DefaultOptions::new().serialize_into(cursor, event)
-}
-
-/// Like [`default_serialize`], but also maps entities.
-pub fn default_serialize_mapped<E: Event + MapEntities + Clone + Serialize>(
-    ctx: &mut ClientSendCtx,
-    event: &E,
-    cursor: &mut Cursor<Vec<u8>>,
-) -> bincode::Result<()> {
-    let mut event = event.clone();
-    event.map_entities(ctx);
-    DefaultOptions::new().serialize_into(cursor, &event)
-}
-
-/// Default event deserialization function.
-pub fn default_deserialize<E: Event + DeserializeOwned>(
-    _ctx: &mut ServerReceiveCtx,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<E> {
-    DefaultOptions::new().deserialize_from(cursor)
-}
-
-/// An event indicating that a message from client was received.
-/// Emited only on server.
-#[derive(Clone, Copy, Event)]
-pub struct FromClient<T> {
-    pub client_id: ClientId,
-    pub event: T,
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,6 +2,7 @@ pub mod channels;
 pub mod command_markers;
 pub mod common_conditions;
 pub mod ctx;
+pub mod event_registry;
 pub mod replication_registry;
 pub mod replication_rules;
 pub mod replicon_tick;
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use channels::RepliconChannels;
 use command_markers::CommandMarkers;
+use event_registry::EventRegistry;
 use replication_registry::ReplicationRegistry;
 use replication_rules::ReplicationRules;
 
@@ -22,7 +24,8 @@ impl Plugin for RepliconCorePlugin {
             .init_resource::<RepliconChannels>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<ReplicationRules>()
-            .init_resource::<CommandMarkers>();
+            .init_resource::<CommandMarkers>()
+            .init_resource::<EventRegistry>();
     }
 }
 

--- a/src/core/event_registry.rs
+++ b/src/core/event_registry.rs
@@ -1,0 +1,31 @@
+pub(crate) mod client_event;
+pub(crate) mod server_event;
+
+use bevy::prelude::*;
+use client_event::ClientEvent;
+use server_event::ServerEvent;
+
+/// Registered server and client events.
+#[derive(Resource, Default)]
+pub(crate) struct EventRegistry {
+    server: Vec<ServerEvent>,
+    client: Vec<ClientEvent>,
+}
+
+impl EventRegistry {
+    pub(crate) fn register_server_event(&mut self, event_data: ServerEvent) {
+        self.server.push(event_data);
+    }
+
+    pub(crate) fn register_client_event(&mut self, event_data: ClientEvent) {
+        self.client.push(event_data);
+    }
+
+    pub(crate) fn iter_server_events(&self) -> impl Iterator<Item = &ServerEvent> {
+        self.server.iter()
+    }
+
+    pub(crate) fn iter_client_events(&self) -> impl Iterator<Item = &ClientEvent> {
+        self.client.iter()
+    }
+}

--- a/src/core/event_registry/client_event.rs
+++ b/src/core/event_registry/client_event.rs
@@ -5,25 +5,158 @@ use std::{
 };
 
 use bevy::{
-    ecs::component::{ComponentId, Components},
+    ecs::{
+        component::{ComponentId, Components},
+        entity::MapEntities,
+        event::ManualEventReader,
+    },
     prelude::*,
     ptr::{Ptr, PtrMut},
 };
+use bincode::{DefaultOptions, Options};
+use serde::{de::DeserializeOwned, Serialize};
 
-use super::{ClientEventReader, DeserializeFn, FromClient, SerializeFn};
+use super::EventRegistry;
 use crate::{
     client::replicon_client::RepliconClient,
     core::{
+        channels::{RepliconChannel, RepliconChannels},
         ctx::{ClientSendCtx, ServerReceiveCtx},
         ClientId,
     },
     server::replicon_server::RepliconServer,
 };
 
+/// An extension trait for [`App`] for creating client events.
+pub trait ClientEventAppExt {
+    /// Registers [`FromClient<E>`] and `E` events.
+    ///
+    /// [`FromClient<E>`] will be emitted on the server after sending `E` event on client.
+    /// In listen-server mode `E` will be drained right after sending and re-emitted as
+    /// [`FromClient<E>`] with [`ClientId::SERVER`](crate::core::ClientId::SERVER).
+    ///
+    /// Can be called for events that were registered with [add_event](bevy::app::App::add_event).
+    /// A duplicate registration for `E` won't be created.
+    /// But be careful, since on listen servers all events `E` are drained,
+    /// which could break other Bevy or third-party plugin systems that listen for `E`.
+    ///
+    /// See also [`Self::add_client_event_with`] and the [corresponding section](../index.html#from-client-to-server)
+    /// from the quick start guide.
+    fn add_client_event<E: Event + Serialize + DeserializeOwned>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+    ) -> &mut Self {
+        self.add_client_event_with(channel, default_serialize::<E>, default_deserialize::<E>)
+    }
+
+    /// Same as [`Self::add_client_event`], but additionally maps client entities to server inside the event before sending.
+    ///
+    /// Always use it for events that contain entities.
+    /// See also [`Self::add_client_event`].
+    fn add_mapped_client_event<E: Event + Serialize + DeserializeOwned + MapEntities + Clone>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+    ) -> &mut Self {
+        self.add_client_event_with(
+            channel,
+            default_serialize_mapped::<E>,
+            default_deserialize::<E>,
+        )
+    }
+
+    /**
+    Same as [`Self::add_client_event`], but uses the specified functions for serialization and deserialization.
+
+    # Examples
+
+    Register an event with [`Box<dyn Reflect>`]:
+
+    ```
+    use std::io::Cursor;
+
+    use bevy::{
+        prelude::*,
+        reflect::serde::{ReflectSerializer, ReflectDeserializer},
+    };
+    use bevy_replicon::{
+        core::ctx::{ClientSendCtx, ServerReceiveCtx},
+        prelude::*,
+    };
+    use bincode::{DefaultOptions, Options};
+    use serde::de::DeserializeSeed;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins));
+    app.add_client_event_with(
+        ChannelKind::Ordered,
+        serialize_reflect,
+        deserialize_reflect,
+    );
+
+    fn serialize_reflect(
+        ctx: &mut ClientSendCtx,
+        event: &ReflectEvent,
+        cursor: &mut Cursor<Vec<u8>>,
+    ) -> bincode::Result<()> {
+        let serializer = ReflectSerializer::new(&*event.0, ctx.registry);
+        DefaultOptions::new().serialize_into(cursor, &serializer)
+    }
+
+    fn deserialize_reflect(
+        ctx: &mut ServerReceiveCtx,
+        cursor: &mut Cursor<&[u8]>,
+    ) -> bincode::Result<ReflectEvent> {
+        let mut deserializer = bincode::Deserializer::with_reader(cursor, DefaultOptions::new());
+        let reflect = ReflectDeserializer::new(ctx.registry).deserialize(&mut deserializer)?;
+        Ok(ReflectEvent(reflect))
+    }
+
+    #[derive(Event)]
+    struct ReflectEvent(Box<dyn Reflect>);
+    ```
+    */
+    fn add_client_event_with<E: Event>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+        serialize: SerializeFn<E>,
+        deserialize: DeserializeFn<E>,
+    ) -> &mut Self;
+}
+
+impl ClientEventAppExt for App {
+    fn add_client_event_with<E: Event>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+        serialize: SerializeFn<E>,
+        deserialize: DeserializeFn<E>,
+    ) -> &mut Self {
+        self.add_event::<E>()
+            .add_event::<FromClient<E>>()
+            .init_resource::<ClientEventReader<E>>();
+
+        let channel_id = self
+            .world_mut()
+            .resource_mut::<RepliconChannels>()
+            .create_client_channel(channel.into());
+
+        self.world_mut()
+            .resource_scope(|world, mut event_registry: Mut<EventRegistry>| {
+                event_registry.register_client_event(ClientEvent::new(
+                    world.components(),
+                    channel_id,
+                    serialize,
+                    deserialize,
+                ));
+            });
+
+        self
+    }
+}
+
 /// Type-erased functions and metadata for a registered client event.
 ///
 /// Needed so events of different types can be processed together.
-pub(super) struct ClientEventData {
+pub(crate) struct ClientEvent {
     type_id: TypeId,
     type_name: &'static str,
 
@@ -47,8 +180,8 @@ pub(super) struct ClientEventData {
     deserialize: unsafe fn(),
 }
 
-impl ClientEventData {
-    pub(super) fn new<E: Event>(
+impl ClientEvent {
+    fn new<E: Event>(
         components: &Components,
         channel_id: u8,
         serialize: SerializeFn<E>,
@@ -94,15 +227,15 @@ impl ClientEventData {
         }
     }
 
-    pub(super) fn events_id(&self) -> ComponentId {
+    pub(crate) fn events_id(&self) -> ComponentId {
         self.events_id
     }
 
-    pub(super) fn reader_id(&self) -> ComponentId {
+    pub(crate) fn reader_id(&self) -> ComponentId {
         self.reader_id
     }
 
-    pub(super) fn client_events_id(&self) -> ComponentId {
+    pub(crate) fn client_events_id(&self) -> ComponentId {
         self.client_events_id
     }
 
@@ -112,7 +245,7 @@ impl ClientEventData {
     ///
     /// The caller must ensure that `events` is [`Events<E>`], `reader` is [`ClientEventReader<E>`]
     /// and this instance was created for `E`.
-    pub(super) unsafe fn send(
+    pub(crate) unsafe fn send(
         &self,
         ctx: &mut ClientSendCtx,
         events: &Ptr,
@@ -128,7 +261,7 @@ impl ClientEventData {
     ///
     /// The caller must ensure that `events` is [`Events<FromClient<E>>`]
     /// and this instance was created for `E`.
-    pub(super) unsafe fn receive(
+    pub(crate) unsafe fn receive(
         &self,
         ctx: &mut ServerReceiveCtx,
         client_events: PtrMut,
@@ -143,7 +276,7 @@ impl ClientEventData {
     ///
     /// The caller must ensure that `events` is [`Events<E>`], `client_events` is [`Events<FromClient<E>>`]
     /// and this instance was created for `E`.
-    pub(super) unsafe fn resend_locally(&self, client_events: PtrMut, events: PtrMut) {
+    pub(crate) unsafe fn resend_locally(&self, client_events: PtrMut, events: PtrMut) {
         (self.resend_locally)(client_events, events);
     }
 
@@ -153,7 +286,7 @@ impl ClientEventData {
     ///
     /// The caller must ensure that `events` is [`Events<E>`]
     /// and this instance was created for `E`.
-    pub(super) unsafe fn reset(&self, events: PtrMut) {
+    pub(crate) unsafe fn reset(&self, events: PtrMut) {
         (self.reset)(events);
     }
 
@@ -162,7 +295,7 @@ impl ClientEventData {
     /// # Safety
     ///
     /// The caller must ensure that this instance was created for `E`.
-    pub(super) unsafe fn serialize<E: Event>(
+    unsafe fn serialize<E: Event>(
         &self,
         ctx: &mut ClientSendCtx,
         event: &E,
@@ -178,7 +311,7 @@ impl ClientEventData {
     /// # Safety
     ///
     /// The caller must ensure that this instance was created for `E`.
-    pub(super) unsafe fn deserialize<E: Event>(
+    unsafe fn deserialize<E: Event>(
         &self,
         ctx: &mut ServerReceiveCtx,
         cursor: &mut Cursor<&[u8]>,
@@ -199,11 +332,17 @@ impl ClientEventData {
     }
 }
 
+/// Signature of client event serialization functions.
+pub type SerializeFn<E> = fn(&mut ClientSendCtx, &E, &mut Cursor<Vec<u8>>) -> bincode::Result<()>;
+
+/// Signature of client event deserialization functions.
+pub type DeserializeFn<E> = fn(&mut ServerReceiveCtx, &mut Cursor<&[u8]>) -> bincode::Result<E>;
+
 /// Signature of client event sending functions.
-type SendFn = unsafe fn(&ClientEventData, &mut ClientSendCtx, &Ptr, PtrMut, &mut RepliconClient);
+type SendFn = unsafe fn(&ClientEvent, &mut ClientSendCtx, &Ptr, PtrMut, &mut RepliconClient);
 
 /// Signature of client event receiving functions.
-type ReceiveFn = unsafe fn(&ClientEventData, &mut ServerReceiveCtx, PtrMut, &mut RepliconServer);
+type ReceiveFn = unsafe fn(&ClientEvent, &mut ServerReceiveCtx, PtrMut, &mut RepliconServer);
 
 /// Signature of client event resending functions.
 type ResendLocallyFn = unsafe fn(PtrMut, PtrMut);
@@ -218,7 +357,7 @@ type ResetFn = unsafe fn(PtrMut);
 /// The caller must ensure that `events` is [`Events<FromClient<E>>`], `reader` is [`ClientEventReader<E>`],
 /// and `event_data` was created for `E`.
 unsafe fn send<E: Event>(
-    event_data: &ClientEventData,
+    event_data: &ClientEvent,
     ctx: &mut ClientSendCtx,
     events: &Ptr,
     reader: PtrMut,
@@ -243,7 +382,7 @@ unsafe fn send<E: Event>(
 /// The caller must ensure that `events` is [`Events<E>`]
 /// and `event_data` was created for `E`.
 unsafe fn receive<E: Event>(
-    event_data: &ClientEventData,
+    event_data: &ClientEvent,
     ctx: &mut ServerReceiveCtx,
     events: PtrMut,
     server: &mut RepliconServer,
@@ -289,4 +428,53 @@ unsafe fn reset<E: Event>(events: PtrMut) {
     if drained_count > 0 {
         warn!("discarded {drained_count} client events due to a disconnect");
     }
+}
+
+/// Tracks read events for [`ClientEventPlugin::send`].
+///
+/// Unlike with server events, we don't always drain all events in [`ClientEventPlugin::resend_locally`].
+#[derive(Resource, Deref, DerefMut)]
+struct ClientEventReader<E: Event>(ManualEventReader<E>);
+
+impl<E: Event> FromWorld for ClientEventReader<E> {
+    fn from_world(world: &mut World) -> Self {
+        let events = world.resource::<Events<E>>();
+        Self(events.get_reader())
+    }
+}
+
+/// An event indicating that a message from client was received.
+/// Emited only on server.
+#[derive(Clone, Copy, Event)]
+pub struct FromClient<T> {
+    pub client_id: ClientId,
+    pub event: T,
+}
+
+/// Default event serialization function.
+pub fn default_serialize<E: Event + Serialize>(
+    _ctx: &mut ClientSendCtx,
+    event: &E,
+    cursor: &mut Cursor<Vec<u8>>,
+) -> bincode::Result<()> {
+    DefaultOptions::new().serialize_into(cursor, event)
+}
+
+/// Like [`default_serialize`], but also maps entities.
+pub fn default_serialize_mapped<E: Event + MapEntities + Clone + Serialize>(
+    ctx: &mut ClientSendCtx,
+    event: &E,
+    cursor: &mut Cursor<Vec<u8>>,
+) -> bincode::Result<()> {
+    let mut event = event.clone();
+    event.map_entities(ctx);
+    DefaultOptions::new().serialize_into(cursor, &event)
+}
+
+/// Default event deserialization function.
+pub fn default_deserialize<E: Event + DeserializeOwned>(
+    _ctx: &mut ServerReceiveCtx,
+    cursor: &mut Cursor<&[u8]>,
+) -> bincode::Result<E> {
+    DefaultOptions::new().deserialize_from(cursor)
 }

--- a/src/core/event_registry/server_event.rs
+++ b/src/core/event_registry/server_event.rs
@@ -5,17 +5,23 @@ use std::{
 };
 
 use bevy::{
-    ecs::component::{ComponentId, Components},
+    ecs::{
+        component::{ComponentId, Components},
+        entity::MapEntities,
+    },
     prelude::*,
     ptr::{Ptr, PtrMut},
 };
 use bincode::{DefaultOptions, Options};
 use bytes::Bytes;
+use ordered_multimap::ListOrderedMultimap;
+use serde::{de::DeserializeOwned, Serialize};
 
-use super::{DeserializeFn, SendMode, SerializeFn, ServerEventQueue, ToClients};
+use super::EventRegistry;
 use crate::{
     client::replicon_client::RepliconClient,
     core::{
+        channels::{RepliconChannel, RepliconChannels},
         ctx::{ClientReceiveCtx, ServerSendCtx},
         replicon_tick::RepliconTick,
         ClientId,
@@ -26,10 +32,134 @@ use crate::{
     },
 };
 
+/// An extension trait for [`App`] for creating client events.
+pub trait ServerEventAppExt {
+    /// Registers `E` and [`ToClients<E>`] events.
+    ///
+    /// `E` will be emitted on client after sending [`ToClients<E>`] on the server.
+    /// If [`ClientId::SERVER`] is a recipient of the event, then [`ToClients<E>`] will be drained
+    /// after sending to clients and `E` events will be emitted on the server.
+    ///
+    /// Can be called for already existing regular events, a duplicate registration
+    /// for `E` won't be created.
+    ///
+    /// See also [`Self::add_server_event_with`] and the [corresponding section](../index.html#from-server-to-client)
+    /// from the quick start guide.
+    fn add_server_event<E: Event + Serialize + DeserializeOwned>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+    ) -> &mut Self {
+        self.add_server_event_with(channel, default_serialize::<E>, default_deserialize::<E>)
+    }
+
+    /// Same as [`Self::add_server_event`], but additionally maps server entities to client inside the event after receiving.
+    ///
+    /// Always use it for events that contain entities.
+    /// See also [`Self::add_server_event`].
+    fn add_mapped_server_event<E: Event + Serialize + DeserializeOwned + MapEntities>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+    ) -> &mut Self {
+        self.add_server_event_with(
+            channel,
+            default_serialize::<E>,
+            default_deserialize_mapped::<E>,
+        )
+    }
+
+    /**
+    Same as [`Self::add_server_event`], but uses the specified functions for serialization and deserialization.
+
+    # Examples
+
+    Register an event with [`Box<dyn Reflect>`]:
+
+    ```
+    use std::io::Cursor;
+
+    use bevy::{
+        prelude::*,
+        reflect::serde::{ReflectSerializer, ReflectDeserializer},
+    };
+    use bevy_replicon::{
+        core::ctx::{ClientReceiveCtx, ServerSendCtx},
+        prelude::*,
+    };
+    use bincode::{DefaultOptions, Options};
+    use serde::de::DeserializeSeed;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, RepliconPlugins));
+    app.add_server_event_with(
+        ChannelKind::Ordered,
+        serialize_reflect,
+        deserialize_reflect,
+    );
+
+    fn serialize_reflect(
+        ctx: &mut ServerSendCtx,
+        event: &ReflectEvent,
+        cursor: &mut Cursor<Vec<u8>>,
+    ) -> bincode::Result<()> {
+        let serializer = ReflectSerializer::new(&*event.0, ctx.registry);
+        DefaultOptions::new().serialize_into(cursor, &serializer)
+    }
+
+    fn deserialize_reflect(
+        ctx: &mut ClientReceiveCtx,
+        cursor: &mut Cursor<&[u8]>,
+    ) -> bincode::Result<ReflectEvent> {
+        let mut deserializer = bincode::Deserializer::with_reader(cursor, DefaultOptions::new());
+        let reflect = ReflectDeserializer ::new(ctx.registry).deserialize(&mut deserializer)?;
+        Ok(ReflectEvent(reflect))
+    }
+
+    #[derive(Event)]
+    struct ReflectEvent(Box<dyn Reflect>);
+    ```
+    */
+    fn add_server_event_with<E: Event>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+        serialize: SerializeFn<E>,
+        deserialize: DeserializeFn<E>,
+    ) -> &mut Self;
+}
+
+impl ServerEventAppExt for App {
+    fn add_server_event_with<E: Event>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+        serialize: SerializeFn<E>,
+        deserialize: DeserializeFn<E>,
+    ) -> &mut Self {
+        self.add_event::<E>()
+            .add_event::<ToClients<E>>()
+            .init_resource::<ServerEventQueue<E>>();
+
+        let channel_id = self
+            .world_mut()
+            .resource_mut::<RepliconChannels>()
+            .create_server_channel(channel.into());
+
+        self.world_mut()
+            .resource_scope(|world, mut event_registry: Mut<EventRegistry>| {
+                event_registry.register_server_event(ServerEvent::new(
+                    world.components(),
+                    channel_id,
+                    serialize,
+                    deserialize,
+                ));
+            });
+
+        self
+    }
+}
+
 /// Type-erased functions and metadata for a registered server event.
 ///
 /// Needed so events of different types can be processed together.
-pub(super) struct ServerEventData {
+pub(crate) struct ServerEvent {
     type_id: TypeId,
     type_name: &'static str,
 
@@ -53,8 +183,8 @@ pub(super) struct ServerEventData {
     deserialize: unsafe fn(),
 }
 
-impl ServerEventData {
-    pub(super) fn new<E: Event>(
+impl ServerEvent {
+    fn new<E: Event>(
         components: &Components,
         channel_id: u8,
         serialize: SerializeFn<E>,
@@ -100,15 +230,15 @@ impl ServerEventData {
         }
     }
 
-    pub(super) fn events_id(&self) -> ComponentId {
+    pub(crate) fn events_id(&self) -> ComponentId {
         self.events_id
     }
 
-    pub(super) fn server_events_id(&self) -> ComponentId {
+    pub(crate) fn server_events_id(&self) -> ComponentId {
         self.server_events_id
     }
 
-    pub(super) fn queue_id(&self) -> ComponentId {
+    pub(crate) fn queue_id(&self) -> ComponentId {
         self.queue_id
     }
 
@@ -118,7 +248,7 @@ impl ServerEventData {
     ///
     /// The caller must ensure that `events` is [`Events<ToClients<E>>`]
     /// and this instance was created for `E`.
-    pub(super) unsafe fn send(
+    pub(crate) unsafe fn send(
         &self,
         ctx: &mut ServerSendCtx,
         server_events: &Ptr,
@@ -134,7 +264,7 @@ impl ServerEventData {
     ///
     /// The caller must ensure that `events` is [`Events<E>`], `queue` is [`ServerEventQueue<E>`],
     /// and this instance was created for `E`.
-    pub(super) unsafe fn receive(
+    pub(crate) unsafe fn receive(
         &self,
         ctx: &mut ClientReceiveCtx,
         events: PtrMut,
@@ -151,7 +281,7 @@ impl ServerEventData {
     ///
     /// The caller must ensure that `events` is [`Events<E>`], `server_events` is [`Events<ToClients<E>>`],
     /// and this instance was created for `E`.
-    pub(super) unsafe fn resend_locally(&self, server_events: PtrMut, events: PtrMut) {
+    pub(crate) unsafe fn resend_locally(&self, server_events: PtrMut, events: PtrMut) {
         (self.resend_locally)(server_events, events);
     }
 
@@ -163,7 +293,7 @@ impl ServerEventData {
     ///
     /// The caller must ensure that `queue` is [`Events<E>`]
     /// and this instance was created for `E`.
-    pub(super) unsafe fn reset(&self, queue: PtrMut) {
+    pub(crate) unsafe fn reset(&self, queue: PtrMut) {
         (self.reset)(queue);
     }
 
@@ -172,7 +302,7 @@ impl ServerEventData {
     /// # Safety
     ///
     /// The caller must ensure that this instance was created for `E`.
-    pub(super) unsafe fn serialize<E: Event>(
+    unsafe fn serialize<E: Event>(
         &self,
         ctx: &mut ServerSendCtx,
         event: &E,
@@ -188,7 +318,7 @@ impl ServerEventData {
     /// # Safety
     ///
     /// The caller must ensure that this instance was created for `E`.
-    pub(super) unsafe fn deserialize<E: Event>(
+    unsafe fn deserialize<E: Event>(
         &self,
         ctx: &mut ClientReceiveCtx,
         cursor: &mut Cursor<&[u8]>,
@@ -209,13 +339,19 @@ impl ServerEventData {
     }
 }
 
+/// Signature of server event serialization functions.
+pub type SerializeFn<E> = fn(&mut ServerSendCtx, &E, &mut Cursor<Vec<u8>>) -> bincode::Result<()>;
+
+/// Signature of server event deserialization functions.
+pub type DeserializeFn<E> = fn(&mut ClientReceiveCtx, &mut Cursor<&[u8]>) -> bincode::Result<E>;
+
 /// Signature of server event sending functions.
 type SendFn =
-    unsafe fn(&ServerEventData, &mut ServerSendCtx, &Ptr, &mut RepliconServer, &ConnectedClients);
+    unsafe fn(&ServerEvent, &mut ServerSendCtx, &Ptr, &mut RepliconServer, &ConnectedClients);
 
 /// Signature of server event receiving functions.
 type ReceiveFn = unsafe fn(
-    &ServerEventData,
+    &ServerEvent,
     &mut ClientReceiveCtx,
     PtrMut,
     PtrMut,
@@ -236,7 +372,7 @@ type ResetFn = unsafe fn(PtrMut);
 /// The caller must ensure that `events` is [`Events<ToClients<E>>`]
 /// and `event_data` was created for `E`.
 unsafe fn send<E: Event>(
-    event_data: &ServerEventData,
+    event_data: &ServerEvent,
     ctx: &mut ServerSendCtx,
     server_events: &Ptr,
     server: &mut RepliconServer,
@@ -259,7 +395,7 @@ unsafe fn send<E: Event>(
 /// The caller must ensure that `events` is [`Events<E>`], `queue` is [`ServerEventQueue<E>`]
 /// and `event_data` was created for `E`.
 unsafe fn receive<E: Event>(
-    event_data: &ServerEventData,
+    event_data: &ServerEvent,
     ctx: &mut ClientReceiveCtx,
     events: PtrMut,
     queue: PtrMut,
@@ -341,7 +477,7 @@ unsafe fn reset<E: Event>(queue: PtrMut) {
 ///
 /// The caller must ensure that `event_data` was created for `E`.
 unsafe fn send_with<E: Event>(
-    event_data: &ServerEventData,
+    event_data: &ServerEvent,
     ctx: &mut ServerSendCtx,
     event: &E,
     mode: &SendMode,
@@ -390,7 +526,7 @@ unsafe fn send_with<E: Event>(
 ///
 /// The caller must ensure that `event_data` was created for `E`.
 unsafe fn serialize_with<E: Event>(
-    event_data: &ServerEventData,
+    event_data: &ServerEvent,
     ctx: &mut ServerSendCtx,
     event: &E,
     client: &ConnectedClient,
@@ -434,7 +570,7 @@ unsafe fn serialize_with<E: Event>(
 /// The caller must ensure that `event_data` was created for `E`.
 unsafe fn deserialize_with<E: Event>(
     ctx: &mut ClientReceiveCtx,
-    event_data: &ServerEventData,
+    event_data: &ServerEvent,
     cursor: &mut Cursor<&[u8]>,
 ) -> bincode::Result<(RepliconTick, E)> {
     let tick = DefaultOptions::new().deserialize_from(&mut *cursor)?;
@@ -454,4 +590,73 @@ impl SerializedMessage {
     fn event_bytes(&self) -> &[u8] {
         &self.bytes[self.tick_size..]
     }
+}
+
+/// An event that will be send to client(s).
+#[derive(Clone, Copy, Debug, Event)]
+pub struct ToClients<T> {
+    pub mode: SendMode,
+    pub event: T,
+}
+
+/// Type of server message sending.
+#[derive(Clone, Copy, Debug)]
+pub enum SendMode {
+    Broadcast,
+    BroadcastExcept(ClientId),
+    Direct(ClientId),
+}
+
+/// Stores all received events from server that arrived earlier then replication message with their tick.
+///
+/// Stores data sorted by ticks and maintains order of arrival.
+/// Needed to ensure that when an event is triggered, all the data that it affects or references already exists.
+#[derive(Resource, Deref, DerefMut)]
+struct ServerEventQueue<T>(ListOrderedMultimap<RepliconTick, T>);
+
+impl<T> ServerEventQueue<T> {
+    /// Pops the next event that is at least as old as the specified replicon tick.
+    fn pop_if_le(&mut self, init_tick: RepliconTick) -> Option<(RepliconTick, T)> {
+        let (tick, _) = self.0.front()?;
+        if *tick > init_tick {
+            return None;
+        }
+        self.0
+            .pop_front()
+            .map(|(tick, event)| (tick.into_owned(), event))
+    }
+}
+
+impl<T> Default for ServerEventQueue<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+/// Default event serialization function.
+pub fn default_serialize<E: Event + Serialize>(
+    _ctx: &mut ServerSendCtx,
+    event: &E,
+    cursor: &mut Cursor<Vec<u8>>,
+) -> bincode::Result<()> {
+    DefaultOptions::new().serialize_into(cursor, event)
+}
+
+/// Default event deserialization function.
+pub fn default_deserialize<E: Event + DeserializeOwned>(
+    _ctx: &mut ClientReceiveCtx,
+    cursor: &mut Cursor<&[u8]>,
+) -> bincode::Result<E> {
+    DefaultOptions::new().deserialize_from(cursor)
+}
+
+/// Default event deserialization function.
+pub fn default_deserialize_mapped<E: Event + DeserializeOwned + MapEntities>(
+    ctx: &mut ClientReceiveCtx,
+    cursor: &mut Cursor<&[u8]>,
+) -> bincode::Result<E> {
+    let mut event: E = DefaultOptions::new().deserialize_from(cursor)?;
+    event.map_entities(ctx);
+
+    Ok(event)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,7 @@ pub mod prelude {
     pub use super::{
         client::{
             diagnostics::{ClientDiagnosticsPlugin, ClientStats},
-            events::{ClientEventAppExt, ClientEventsPlugin, FromClient},
+            events::ClientEventsPlugin,
             replicon_client::{RepliconClient, RepliconClientStatus},
             ClientPlugin, ClientSet,
         },
@@ -462,6 +462,10 @@ pub mod prelude {
             channels::{ChannelKind, RepliconChannel, RepliconChannels},
             command_markers::AppMarkerExt,
             common_conditions::*,
+            event_registry::{
+                client_event::{ClientEventAppExt, FromClient},
+                server_event::{SendMode, ServerEventAppExt, ToClients},
+            },
             replication_rules::AppRuleExt,
             ClientId, Replicated, RepliconCorePlugin,
         },
@@ -471,7 +475,7 @@ pub mod prelude {
             connected_clients::{
                 client_visibility::ClientVisibility, ConnectedClient, ConnectedClients,
             },
-            events::{SendMode, ServerEventAppExt, ServerEventsPlugin, ToClients},
+            events::ServerEventsPlugin,
             replicon_server::RepliconServer,
             ServerEvent, ServerPlugin, ServerSet, TickPolicy, VisibilityPolicy,
         },

--- a/src/server/events.rs
+++ b/src/server/events.rs
@@ -1,182 +1,38 @@
-mod event_data;
-
-use std::io::Cursor;
-
-use bevy::{ecs::entity::MapEntities, prelude::*};
-use bincode::{DefaultOptions, Options};
-use ordered_multimap::ListOrderedMultimap;
-use serde::{de::DeserializeOwned, Serialize};
+use bevy::prelude::*;
 
 use super::{
     connected_clients::ConnectedClients, replicon_server::RepliconServer, ServerPlugin, ServerSet,
 };
-use crate::{
-    client::{
-        replicon_client::RepliconClient, server_entity_map::ServerEntityMap, ClientPlugin,
-        ClientSet, ServerInitTick,
-    },
-    core::{
-        channels::{RepliconChannel, RepliconChannels},
-        common_conditions::*,
-        ctx::{ClientReceiveCtx, ServerSendCtx},
-        replicon_tick::RepliconTick,
-        ClientId,
-    },
+use crate::core::{
+    common_conditions::*,
+    ctx::{ServerReceiveCtx, ServerSendCtx},
+    event_registry::EventRegistry,
 };
-use event_data::ServerEventData;
-
-/// An extension trait for [`App`] for creating client events.
-pub trait ServerEventAppExt {
-    /// Registers `E` and [`ToClients<E>`] events.
-    ///
-    /// `E` will be emitted on client after sending [`ToClients<E>`] on the server.
-    /// If [`ClientId::SERVER`] is a recipient of the event, then [`ToClients<E>`] will be drained
-    /// after sending to clients and `E` events will be emitted on the server.
-    ///
-    /// Can be called for already existing regular events, a duplicate registration
-    /// for `E` won't be created.
-    ///
-    /// See also [`Self::add_server_event_with`] and the [corresponding section](../index.html#from-server-to-client)
-    /// from the quick start guide.
-    fn add_server_event<E: Event + Serialize + DeserializeOwned>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-    ) -> &mut Self {
-        self.add_server_event_with(channel, default_serialize::<E>, default_deserialize::<E>)
-    }
-
-    /// Same as [`Self::add_server_event`], but additionally maps server entities to client inside the event after receiving.
-    ///
-    /// Always use it for events that contain entities.
-    /// See also [`Self::add_server_event`].
-    fn add_mapped_server_event<E: Event + Serialize + DeserializeOwned + MapEntities>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-    ) -> &mut Self {
-        self.add_server_event_with(
-            channel,
-            default_serialize::<E>,
-            default_deserialize_mapped::<E>,
-        )
-    }
-
-    /**
-    Same as [`Self::add_server_event`], but uses the specified functions for serialization and deserialization.
-
-    # Examples
-
-    Register an event with [`Box<dyn Reflect>`]:
-
-    ```
-    use std::io::Cursor;
-
-    use bevy::{
-        prelude::*,
-        reflect::serde::{ReflectSerializer, ReflectDeserializer},
-    };
-    use bevy_replicon::{
-        core::ctx::{ClientReceiveCtx, ServerSendCtx},
-        prelude::*,
-    };
-    use bincode::{DefaultOptions, Options};
-    use serde::de::DeserializeSeed;
-
-    let mut app = App::new();
-    app.add_plugins((MinimalPlugins, RepliconPlugins));
-    app.add_server_event_with(
-        ChannelKind::Ordered,
-        serialize_reflect,
-        deserialize_reflect,
-    );
-
-    fn serialize_reflect(
-        ctx: &mut ServerSendCtx,
-        event: &ReflectEvent,
-        cursor: &mut Cursor<Vec<u8>>,
-    ) -> bincode::Result<()> {
-        let serializer = ReflectSerializer::new(&*event.0, ctx.registry);
-        DefaultOptions::new().serialize_into(cursor, &serializer)
-    }
-
-    fn deserialize_reflect(
-        ctx: &mut ClientReceiveCtx,
-        cursor: &mut Cursor<&[u8]>,
-    ) -> bincode::Result<ReflectEvent> {
-        let mut deserializer = bincode::Deserializer::with_reader(cursor, DefaultOptions::new());
-        let reflect = ReflectDeserializer ::new(ctx.registry).deserialize(&mut deserializer)?;
-        Ok(ReflectEvent(reflect))
-    }
-
-    #[derive(Event)]
-    struct ReflectEvent(Box<dyn Reflect>);
-    ```
-    */
-    fn add_server_event_with<E: Event>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
-    ) -> &mut Self;
-}
-
-impl ServerEventAppExt for App {
-    fn add_server_event_with<E: Event>(
-        &mut self,
-        channel: impl Into<RepliconChannel>,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
-    ) -> &mut Self {
-        self.add_event::<E>()
-            .add_event::<ToClients<E>>()
-            .init_resource::<ServerEventQueue<E>>();
-
-        let channel_id = self
-            .world_mut()
-            .resource_mut::<RepliconChannels>()
-            .create_server_channel(channel.into());
-
-        self.world_mut()
-            .resource_scope(|world, mut event_registry: Mut<ServerEventRegistry>| {
-                event_registry.0.push(ServerEventData::new(
-                    world.components(),
-                    channel_id,
-                    serialize,
-                    deserialize,
-                ));
-            });
-
-        self
-    }
-}
 
 /// Sending events from the server to clients.
 ///
-/// Requires [`ServerPlugin`] for the server and [`ClientPlugin`] for clients.
+/// Requires [`ServerPlugin`].
+/// Can be disabled for apps that act only as clients.
 pub struct ServerEventsPlugin;
 
 impl Plugin for ServerEventsPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<ServerEventRegistry>()
-            .add_systems(
-                PreUpdate,
-                (
-                    Self::reset.in_set(ClientSet::ResetEvents),
-                    Self::receive
-                        .after(ClientPlugin::receive_replication)
-                        .in_set(ClientSet::Receive)
-                        .run_if(client_connected),
-                ),
+        app.add_systems(
+            PreUpdate,
+            Self::receive
+                .in_set(ServerSet::Receive)
+                .run_if(server_running),
+        )
+        .add_systems(
+            PostUpdate,
+            (
+                Self::send.run_if(server_running),
+                Self::resend_locally.run_if(has_authority),
             )
-            .add_systems(
-                PostUpdate,
-                (
-                    Self::send.run_if(server_running),
-                    Self::resend_locally.run_if(has_authority),
-                )
-                    .chain()
-                    .after(ServerPlugin::send_replication)
-                    .in_set(ServerSet::Send),
-            );
+                .chain()
+                .after(ServerPlugin::send_replication)
+                .in_set(ServerSet::Send),
+        );
     }
 }
 
@@ -185,12 +41,12 @@ impl ServerEventsPlugin {
         world.resource_scope(|world, mut server: Mut<RepliconServer>| {
             world.resource_scope(|world, registry: Mut<AppTypeRegistry>| {
                 world.resource_scope(|world, connected_clients: Mut<ConnectedClients>| {
-                    world.resource_scope(|world, event_registry: Mut<ServerEventRegistry>| {
+                    world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
                         let mut ctx = ServerSendCtx {
                             registry: &registry.read(),
                         };
 
-                        for event_data in &event_registry.0 {
+                        for event_data in event_registry.iter_server_events() {
                             let server_events = world
                                 .get_resource_by_id(event_data.server_events_id())
                                 .expect("server events shouldn't be removed");
@@ -212,50 +68,32 @@ impl ServerEventsPlugin {
     }
 
     fn receive(world: &mut World) {
-        world.resource_scope(|world, mut client: Mut<RepliconClient>| {
+        world.resource_scope(|world, mut server: Mut<RepliconServer>| {
             world.resource_scope(|world, registry: Mut<AppTypeRegistry>| {
-                world.resource_scope(|world, entity_map: Mut<ServerEntityMap>| {
-                    world.resource_scope(|world, event_registry: Mut<ServerEventRegistry>| {
-                        let init_tick = **world.resource::<ServerInitTick>();
-                        let mut ctx = ClientReceiveCtx {
-                            registry: &registry.read(),
-                            entity_map: &entity_map,
+                world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
+                    let mut ctx = ServerReceiveCtx {
+                        registry: &registry.read(),
+                    };
+
+                    for event_data in event_registry.iter_client_events() {
+                        let client_events = world
+                            .get_resource_mut_by_id(event_data.client_events_id())
+                            .expect("client events shouldn't be removed");
+
+                        // SAFETY: passed pointer was obtained using this event data.
+                        unsafe {
+                            event_data.receive(&mut ctx, client_events.into_inner(), &mut server)
                         };
-
-                        let world_cell = world.as_unsafe_world_cell();
-                        for event_data in &event_registry.0 {
-                            // SAFETY: both resources mutably borrowed uniquely.
-                            let (events, queue) = unsafe {
-                                let events = world_cell
-                                    .get_resource_mut_by_id(event_data.events_id())
-                                    .expect("events shouldn't be removed");
-                                let queue = world_cell
-                                    .get_resource_mut_by_id(event_data.queue_id())
-                                    .expect("event queue shouldn't be removed");
-                                (events, queue)
-                            };
-
-                            // SAFETY: passed pointers were obtained using this event data.
-                            unsafe {
-                                event_data.receive(
-                                    &mut ctx,
-                                    events.into_inner(),
-                                    queue.into_inner(),
-                                    &mut client,
-                                    init_tick,
-                                )
-                            };
-                        }
-                    });
+                    }
                 });
             });
         });
     }
 
     fn resend_locally(world: &mut World) {
-        world.resource_scope(|world, event_registry: Mut<ServerEventRegistry>| {
+        world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
             let world_cell = world.as_unsafe_world_cell();
-            for event_data in &event_registry.0 {
+            for event_data in event_registry.iter_server_events() {
                 // SAFETY: both resources mutably borrowed uniquely.
                 let (server_events, events) = unsafe {
                     let server_events = world_cell
@@ -273,97 +111,5 @@ impl ServerEventsPlugin {
                 };
             }
         });
-    }
-
-    fn reset(world: &mut World) {
-        world.resource_scope(|world, event_registry: Mut<ServerEventRegistry>| {
-            for event_data in &event_registry.0 {
-                let queue = world
-                    .get_resource_mut_by_id(event_data.queue_id())
-                    .expect("event queue shouldn't be removed");
-
-                // SAFETY: passed pointer was obtained using this event data.
-                unsafe { event_data.reset(queue.into_inner()) };
-            }
-        });
-    }
-}
-
-/// Registered server events.
-#[derive(Resource, Default)]
-struct ServerEventRegistry(Vec<ServerEventData>);
-
-/// Signature of server event serialization functions.
-pub type SerializeFn<E> = fn(&mut ServerSendCtx, &E, &mut Cursor<Vec<u8>>) -> bincode::Result<()>;
-
-/// Signature of server event deserialization functions.
-pub type DeserializeFn<E> = fn(&mut ClientReceiveCtx, &mut Cursor<&[u8]>) -> bincode::Result<E>;
-
-/// Default event serialization function.
-pub fn default_serialize<E: Event + Serialize>(
-    _ctx: &mut ServerSendCtx,
-    event: &E,
-    cursor: &mut Cursor<Vec<u8>>,
-) -> bincode::Result<()> {
-    DefaultOptions::new().serialize_into(cursor, event)
-}
-
-/// Default event deserialization function.
-pub fn default_deserialize<E: Event + DeserializeOwned>(
-    _ctx: &mut ClientReceiveCtx,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<E> {
-    DefaultOptions::new().deserialize_from(cursor)
-}
-
-/// Default event deserialization function.
-pub fn default_deserialize_mapped<E: Event + DeserializeOwned + MapEntities>(
-    ctx: &mut ClientReceiveCtx,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<E> {
-    let mut event: E = DefaultOptions::new().deserialize_from(cursor)?;
-    event.map_entities(ctx);
-
-    Ok(event)
-}
-
-/// An event that will be send to client(s).
-#[derive(Clone, Copy, Debug, Event)]
-pub struct ToClients<T> {
-    pub mode: SendMode,
-    pub event: T,
-}
-
-/// Type of server message sending.
-#[derive(Clone, Copy, Debug)]
-pub enum SendMode {
-    Broadcast,
-    BroadcastExcept(ClientId),
-    Direct(ClientId),
-}
-
-/// Stores all received events from server that arrived earlier then replication message with their tick.
-///
-/// Stores data sorted by ticks and maintains order of arrival.
-/// Needed to ensure that when an event is triggered, all the data that it affects or references already exists.
-#[derive(Resource, Deref, DerefMut)]
-struct ServerEventQueue<T>(ListOrderedMultimap<RepliconTick, T>);
-
-impl<T> ServerEventQueue<T> {
-    /// Pops the next event that is at least as old as the specified replicon tick.
-    fn pop_if_le(&mut self, init_tick: RepliconTick) -> Option<(RepliconTick, T)> {
-        let (tick, _) = self.0.front()?;
-        if *tick > init_tick {
-            return None;
-        }
-        self.0
-            .pop_front()
-            .map(|(tick, event)| (tick.into_owned(), event))
-    }
-}
-
-impl<T> Default for ServerEventQueue<T> {
-    fn default() -> Self {
-        Self(Default::default())
     }
 }


### PR DESCRIPTION
- Swap `receive` system between ServerEventsPlugin and `ClientEventsPlugin` to properly separate what what runs on client or server.
- Move `ServerEventsPlugin::reset` logic inside `ClientEventsPlugin::reset` because this logic runs on client.
- Move `server::events::event_data` module to `core::event_registry::server_event`.
- Move `client::events::event_data` module to `core::event_registry::client_event`.

No functional changes, except `ServerEventsPlugin` and `ClientEventsPlugin` can be disabled on client-only and server-only apps respectively.

Closes #276.