### PR TITLE
Do not divide values per seconds by the number of messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ServerEventsPlugin` and `ClientEventsPlugin` can be disabled on client-only and server-only apps respectively.
+- Do not divide values per seconds by the number of messages.
 - Move `server::events::event_data` module to `core::event_registry::server_event`.
 - Move `client::events::event_data` module to `core::event_registry::client_event`.
 - Move `ClientEventAppExt`, `client::events::SerializeFn`, `client::events::DeserializeFn`, `default_serialize`, `default_serialize_mapped`, `default_deserialize` and `FromClient` to `core::event_registry::client_event`.

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -90,41 +90,11 @@ impl ClientDiagnosticsPlugin {
     pub const DIAGNOSTIC_HISTORY_LEN: usize = 60;
 
     fn add_measurements(mut stats: ResMut<ClientStats>, mut diagnostics: Diagnostics) {
-        diagnostics.add_measurement(&Self::ENTITY_CHANGES, || {
-            if stats.messages == 0 {
-                0_f64
-            } else {
-                stats.entities_changed as f64 / stats.messages as f64
-            }
-        });
-        diagnostics.add_measurement(&Self::COMPONENT_CHANGES, || {
-            if stats.messages == 0 {
-                0_f64
-            } else {
-                stats.components_changed as f64 / stats.messages as f64
-            }
-        });
-        diagnostics.add_measurement(&Self::MAPPINGS, || {
-            if stats.messages == 0 {
-                0_f64
-            } else {
-                stats.mappings as f64 / stats.messages as f64
-            }
-        });
-        diagnostics.add_measurement(&Self::DESPAWNS, || {
-            if stats.messages == 0 {
-                0_f64
-            } else {
-                stats.despawns as f64 / stats.messages as f64
-            }
-        });
-        diagnostics.add_measurement(&Self::BYTES, || {
-            if stats.messages == 0 {
-                0_f64
-            } else {
-                stats.bytes as f64 / stats.messages as f64
-            }
-        });
+        diagnostics.add_measurement(&Self::ENTITY_CHANGES, || stats.entities_changed as f64);
+        diagnostics.add_measurement(&Self::COMPONENT_CHANGES, || stats.components_changed as f64);
+        diagnostics.add_measurement(&Self::MAPPINGS, || stats.mappings as f64);
+        diagnostics.add_measurement(&Self::DESPAWNS, || stats.despawns as f64);
+        diagnostics.add_measurement(&Self::BYTES, || stats.bytes as f64);
         diagnostics.add_measurement(&Self::MESSAGES, || stats.messages as f64);
         *stats = ClientStats::default();
     }


### PR DESCRIPTION
We explicitly say in docs that all diagnostics data is measured per second, not per message.