### PR TITLE
Put `ClientDiagnosticsPlugin` under `diagnostics` feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo clippy --benches --tests -- -D warnings
 
       - name: Rustdoc
-        run: cargo rustdoc -- -D warnings
+        run: cargo rustdoc --all-features -- -D warnings
 
   doctest:
     name: Doctest
@@ -66,7 +66,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Test doc
-        run: cargo test --doc
+        run: cargo test --all-features --doc
 
   test:
     name: Test
@@ -88,7 +88,7 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Test
-        run: cargo tarpaulin --engine llvm --out lcov --exclude-files benches/* --exclude-files bevy_replicon_renet/*
+        run: cargo tarpaulin --all-features --engine llvm --out lcov --exclude-files benches/* --exclude-files bevy_replicon_renet/*
 
       - name: Upload code coverage results
         if: github.actor != 'dependabot[bot]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ServerEventsPlugin` and `ClientEventsPlugin` can be disabled on client-only and server-only apps respectively.
+- Put `ClientDiagnosticsPlugin` under `diagnostics` feature and make it part of the `RepliconPlugins` group.
 - Do not divide values per seconds by the number of messages for `ClientDiagnosticsPlugin`.
 - Move `server::events::event_data` module to `core::event_registry::server_event`.
 - Move `client::events::event_data` module to `core::event_registry::client_event`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ license = "MIT OR Apache-2.0"
 include = ["/benches", "/src", "/tests", "/LICENSE*"]
 
 [package.metadata.docs.rs]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ categories = ["game-development", "network-programming"]
 license = "MIT OR Apache-2.0"
 include = ["/benches", "/src", "/tests", "/LICENSE*"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 bevy = { version = "0.14.0-rc.3", default-features = false, features = [
   "bevy_scene",
@@ -39,6 +42,10 @@ bevy = { version = "0.14.0-rc.3", default-features = false, features = [
 criterion = { version = "0.5", default-features = false, features = [
   "cargo_bench_support",
 ] }
+
+[features]
+default = []
+diagnostics = []
 
 [lints.clippy]
 type_complexity = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ criterion = { version = "0.5", default-features = false, features = [
 
 [features]
 default = []
+
+# Plugin for integration with Bevy diagnostics.
 diagnostics = []
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,17 @@ default = []
 # Plugin for integration with Bevy diagnostics.
 diagnostics = []
 
-[lints.clippy]
-type_complexity = "allow"
-too_many_arguments = "allow"
-
 [[bench]]
 name = "replication"
 harness = false
+
+[[test]]
+name = "stats"
+required-features = ["diagnostics"]
+
+[lints.clippy]
+type_complexity = "allow"
+too_many_arguments = "allow"
 
 # Removed until `bevy_renet` supports 0.14.0-rc.3.
 # [workspace]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 pub mod confirm_history;
+#[cfg(feature = "diagnostics")]
 pub mod diagnostics;
 pub mod events;
 pub mod replicon_client;
@@ -21,7 +22,6 @@ use crate::core::{
     Replicated,
 };
 use confirm_history::ConfirmHistory;
-use diagnostics::ClientStats;
 use replicon_client::RepliconClient;
 use server_entity_map::ServerEntityMap;
 
@@ -639,4 +639,24 @@ pub(super) struct BufferedUpdate {
 
     /// Update data.
     message: Bytes,
+}
+
+/// Replication stats during message processing.
+///
+/// Statistic will be collected only if the resource is present.
+/// The resource is not added by default.
+#[derive(Default, Resource, Debug)]
+pub struct ClientStats {
+    /// Incremented per entity that changes.
+    pub entities_changed: u32,
+    /// Incremented for every component that changes.
+    pub components_changed: u32,
+    /// Incremented per client mapping added.
+    pub mappings: u32,
+    /// Incremented per entity despawn.
+    pub despawns: u32,
+    /// Replication messages received.
+    pub messages: u32,
+    /// Replication bytes received in message payloads (without internal messaging plugin data).
+    pub bytes: u64,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -645,6 +645,9 @@ pub(super) struct BufferedUpdate {
 ///
 /// Statistic will be collected only if the resource is present.
 /// The resource is not added by default.
+///
+/// See also [`ClientDiagnosticsPlugin`](diagnostics::ClientDiagnosticsPlugin)
+/// for automatic integration with Bevy diagnostics.
 #[derive(Default, Resource, Debug)]
 pub struct ClientStats {
     /// Incremented per entity that changes.

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -6,67 +6,50 @@ use bevy::{
 };
 use std::time::Duration;
 
-/// Replication stats during message processing.
-///
-/// Flushed to Diagnostics system periodically.
-#[derive(Default, Resource, Debug)]
-pub struct ClientStats {
-    /// Incremented per entity that changes.
-    pub entities_changed: u32,
-    /// Incremented for every component that changes.
-    pub components_changed: u32,
-    /// Incremented per client mapping added.
-    pub mappings: u32,
-    /// Incremented per entity despawn.
-    pub despawns: u32,
-    /// Replication messages received.
-    pub messages: u32,
-    /// Replication bytes received in message payloads (without internal messaging plugin data).
-    pub bytes: u64,
-}
+use super::ClientStats;
 
-/// Plugin to write Diagnostics every second.
+/// Plugin to write [`Diagnostics`] based on [`ClientStats`] every second.
 ///
-/// Not added by default.
+/// Adds [`ClientStats`] resource and automatically resets it to get diagnostics per second.
 pub struct ClientDiagnosticsPlugin;
 
 impl Plugin for ClientDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
-            Update,
-            Self::add_measurements.run_if(on_timer(Duration::from_secs(1))),
-        )
-        .init_resource::<ClientStats>()
-        .register_diagnostic(
-            Diagnostic::new(Self::ENTITY_CHANGES)
-                .with_suffix("entities changed per second")
-                .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
-        )
-        .register_diagnostic(
-            Diagnostic::new(Self::COMPONENT_CHANGES)
-                .with_suffix("components changed per second")
-                .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
-        )
-        .register_diagnostic(
-            Diagnostic::new(Self::MAPPINGS)
-                .with_suffix("mappings added per second")
-                .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
-        )
-        .register_diagnostic(
-            Diagnostic::new(Self::DESPAWNS)
-                .with_suffix("despawns per second")
-                .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
-        )
-        .register_diagnostic(
-            Diagnostic::new(Self::MESSAGES)
-                .with_suffix("messages per second")
-                .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
-        )
-        .register_diagnostic(
-            Diagnostic::new(Self::BYTES)
-                .with_suffix("bytes per second")
-                .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
-        );
+        app.init_resource::<ClientStats>()
+            .add_systems(
+                Update,
+                Self::add_measurements.run_if(on_timer(Duration::from_secs(1))),
+            )
+            .register_diagnostic(
+                Diagnostic::new(Self::ENTITY_CHANGES)
+                    .with_suffix("entities changed per second")
+                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+            )
+            .register_diagnostic(
+                Diagnostic::new(Self::COMPONENT_CHANGES)
+                    .with_suffix("components changed per second")
+                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+            )
+            .register_diagnostic(
+                Diagnostic::new(Self::MAPPINGS)
+                    .with_suffix("mappings added per second")
+                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+            )
+            .register_diagnostic(
+                Diagnostic::new(Self::DESPAWNS)
+                    .with_suffix("despawns per second")
+                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+            )
+            .register_diagnostic(
+                Diagnostic::new(Self::MESSAGES)
+                    .with_suffix("messages per second")
+                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+            )
+            .register_diagnostic(
+                Diagnostic::new(Self::BYTES)
+                    .with_suffix("bytes per second")
+                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+            );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,10 +453,9 @@ pub mod prelude {
 
     pub use super::{
         client::{
-            diagnostics::{ClientDiagnosticsPlugin, ClientStats},
             events::ClientEventsPlugin,
             replicon_client::{RepliconClient, RepliconClientStatus},
-            ClientPlugin, ClientSet,
+            ClientPlugin, ClientSet, ClientStats,
         },
         core::{
             channels::{ChannelKind, RepliconChannel, RepliconChannels},
@@ -481,6 +480,9 @@ pub mod prelude {
         },
         RepliconPlugins,
     };
+
+    #[cfg(feature = "diagnostics")]
+    pub use super::client::diagnostics::ClientDiagnosticsPlugin;
 }
 
 pub use bincode;
@@ -493,12 +495,20 @@ pub struct RepliconPlugins;
 
 impl PluginGroup for RepliconPlugins {
     fn build(self) -> PluginGroupBuilder {
-        PluginGroupBuilder::start::<Self>()
+        let mut group = PluginGroupBuilder::start::<Self>();
+        group = group
             .add(RepliconCorePlugin)
             .add(ParentSyncPlugin)
             .add(ClientPlugin)
             .add(ServerPlugin::default())
             .add(ClientEventsPlugin)
-            .add(ServerEventsPlugin)
+            .add(ServerEventsPlugin);
+
+        #[cfg(feature = "diagnostics")]
+        {
+            group = group.add(ClientDiagnosticsPlugin);
+        }
+
+        group
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,6 +439,7 @@ To reduce packet size there are the following limits per replication update:
 - Up to [`u16::MAX`] entities that have removed components with up to [`u16::MAX`] bytes of component data.
 - Up to [`u16::MAX`] entities that were despawned.
 */
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod client;
 pub mod core;

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -3,7 +3,6 @@ use bevy_replicon::{
     core::channels::ReplicationChannel, prelude::*, server::server_tick::ServerTick,
     test_app::ServerTestAppExt,
 };
-use serde::{Deserialize, Serialize};
 
 #[test]
 fn client_to_server() {
@@ -203,67 +202,3 @@ fn server_inactive() {
 
     assert_eq!(app.world().resource::<ServerTick>().get(), 0);
 }
-
-#[test]
-fn client_stats() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                ..Default::default()
-            }),
-        ))
-        .replicate::<DummyComponent>();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let client_entity = client_app.world_mut().spawn_empty().id();
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, DummyComponent))
-        .id();
-
-    let client = client_app.world().resource::<RepliconClient>();
-    let client_id = client.id().unwrap();
-
-    let mut entity_map = server_app.world_mut().resource_mut::<ClientEntityMap>();
-    entity_map.insert(
-        client_id,
-        ClientMapping {
-            server_entity,
-            client_entity,
-        },
-    );
-
-    server_app.world_mut().spawn(Replicated).despawn();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    server_app
-        .world_mut()
-        .get_mut::<DummyComponent>(server_entity)
-        .unwrap()
-        .set_changed();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    let stats = client_app.world().resource::<ClientStats>();
-    assert_eq!(stats.entities_changed, 2);
-    assert_eq!(stats.components_changed, 2);
-    assert_eq!(stats.mappings, 1);
-    assert_eq!(stats.despawns, 1);
-    assert_eq!(stats.messages, 2);
-    assert_eq!(stats.bytes, 33);
-}
-
-#[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;

--- a/tests/other.rs
+++ b/tests/other.rs
@@ -205,7 +205,7 @@ fn server_inactive() {
 }
 
 #[test]
-fn diagnostics() {
+fn client_stats() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -218,7 +218,6 @@ fn diagnostics() {
         ))
         .replicate::<DummyComponent>();
     }
-    client_app.add_plugins(ClientDiagnosticsPlugin);
 
     server_app.connect_client(&mut client_app);
 

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -1,8 +1,5 @@
 use bevy::prelude::*;
-use bevy_replicon::{
-    prelude::*,
-    test_app::ServerTestAppExt,
-};
+use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 use serde::{Deserialize, Serialize};
 
 #[test]

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -1,0 +1,70 @@
+use bevy::prelude::*;
+use bevy_replicon::{
+    prelude::*,
+    test_app::ServerTestAppExt,
+};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn client_stats() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<DummyComponent>();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client_entity = client_app.world_mut().spawn_empty().id();
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
+
+    let client = client_app.world().resource::<RepliconClient>();
+    let client_id = client.id().unwrap();
+
+    let mut entity_map = server_app.world_mut().resource_mut::<ClientEntityMap>();
+    entity_map.insert(
+        client_id,
+        ClientMapping {
+            server_entity,
+            client_entity,
+        },
+    );
+
+    server_app.world_mut().spawn(Replicated).despawn();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app
+        .world_mut()
+        .get_mut::<DummyComponent>(server_entity)
+        .unwrap()
+        .set_changed();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let stats = client_app.world().resource::<ClientStats>();
+    assert_eq!(stats.entities_changed, 2);
+    assert_eq!(stats.components_changed, 2);
+    assert_eq!(stats.mappings, 1);
+    assert_eq!(stats.despawns, 1);
+    assert_eq!(stats.messages, 2);
+    assert_eq!(stats.bytes, 33);
+}
+
+#[derive(Component, Deserialize, Serialize)]
+struct DummyComponent;


### PR DESCRIPTION
And make it part of the `RepliconPlugins` group.

It makes it much more discoverable. Planning to put under features `scene`, `parent_sync`, `client` and `server` as well in next PRs. Like Bevy does. 