### PR TITLE
Depend on `renet` instead of `bevy_renet`

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -26,3 +26,5 @@ jobs:
 
       - name: Check dependencies
         uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          arguments: --workspace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Clippy
-        run: cargo clippy --benches --tests -- -D warnings
+        run: cargo clippy --workspace --benches --tests -- -D warnings
 
       - name: Rustdoc
-        run: cargo rustdoc --all-features -- -D warnings
+        run: |
+          cargo rustdoc --all-features -- -D warnings
+          cargo rustdoc -p bevy_replicon_renet -- -D warnings
 
   doctest:
     name: Doctest
@@ -66,7 +68,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Test doc
-        run: cargo test --all-features --doc
+        run: cargo test --workspace --all-features --doc
 
   feature-combinations:
     name: Feature combinations
@@ -109,7 +111,7 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Test
-        run: cargo tarpaulin --all-features --engine llvm --out lcov --exclude-files benches/* --exclude-files bevy_replicon_renet/*
+        run: cargo tarpaulin --all-features --workspace --engine llvm --out lcov --exclude-files benches/*
 
       - name: Upload code coverage results
         if: github.actor != 'dependabot[bot]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ServerEventsPlugin` and `ClientEventsPlugin` can be disabled on client-only and server-only apps respectively.
+- Depend on `renet` directly instead of `bevy_renet` in `bevy_replicon_renet`.
 - Put `ClientDiagnosticsPlugin` under `client_diagnostics` feature (disabled by default) and make it part of the `RepliconPlugins` group.
 - Put `scene` module under `scene` feature (enabled by default).
 - Put `parent_sync` module under `parent_sync` feature (enabled by default).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,5 @@ required-features = ["client", "server"]
 type_complexity = "allow"
 too_many_arguments = "allow"
 
-# Removed until `bevy_renet` supports 0.14.0-rc.3.
-# [workspace]
-# members = ["bevy_replicon_renet"]
+[workspace]
+members = ["bevy_replicon_renet"]

--- a/bevy_replicon_renet/Cargo.toml
+++ b/bevy_replicon_renet/Cargo.toml
@@ -21,17 +21,18 @@ license = "MIT OR Apache-2.0"
 include = ["/src", "/tests", "../LICENSE*"]
 
 [dependencies]
-bevy_replicon = { version = "0.26", path = ".." }
-bevy_renet = { version = "0.0.11", default-features = false }
-bevy = { version = "0.13", default-features = false }
+bevy_replicon = { version = "0.27.0-rc.2", path = ".." }
+renet = { version = "0.0.15", default-features = false }
+bevy = { version = "0.14.0-rc.3", default-features = false }
 
 [dev-dependencies]
 serde = "1.0"
 clap = { version = "4.1", features = ["derive"] }
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.14.0-rc.3", default-features = false, features = [
   "bevy_text",
   "bevy_ui",
   "bevy_gizmos",
+  "bevy_state",
   "x11",
   "default_font",
 ] }
@@ -40,8 +41,8 @@ bevy = { version = "0.13", default-features = false, features = [
 default = ["renet_serde", "renet_transport"]
 
 # Re-exports of renet features
-renet_serde = ["bevy_renet/serde"]
-renet_transport = ["bevy_renet/transport"]
+renet_serde = ["renet/serde"]
+renet_transport = ["renet/transport"]
 
 [[test]]
 name = "transport"

--- a/bevy_replicon_renet/examples/simple_box.rs
+++ b/bevy_replicon_renet/examples/simple_box.rs
@@ -8,17 +8,18 @@ use std::{
 };
 
 use bevy::{
+    color::palettes::css::GREEN,
     prelude::*,
     winit::{UpdateMode::Continuous, WinitSettings},
 };
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
+    bevy_renet::wrappers::{
+        NetcodeClientTransport, NetcodeServerTransport, RenetClient, RenetServer,
+    },
     renet::{
-        transport::{
-            ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport,
-            ServerAuthentication, ServerConfig,
-        },
-        ConnectionConfig, RenetClient, RenetServer,
+        transport::{ClientAuthentication, ServerAuthentication, ServerConfig},
+        ConnectionConfig,
     },
     RenetChannelsExt, RepliconRenetPlugins,
 };
@@ -75,7 +76,7 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(
                     ClientId::SERVER,
                     Vec2::ZERO,
-                    Color::GREEN,
+                    Color::from(GREEN),
                 ));
             }
             Cli::Server { port } => {
@@ -113,7 +114,7 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(
                     ClientId::SERVER,
                     Vec2::ZERO,
-                    Color::GREEN,
+                    Color::from(GREEN),
                 ));
             }
             Cli::Client { port, ip } => {
@@ -172,7 +173,7 @@ impl SimpleBoxPlugin {
                     commands.spawn(PlayerBundle::new(
                         *client_id,
                         Vec2::ZERO,
-                        Color::rgb(r, g, b),
+                        Color::srgb(r, g, b),
                     ));
                 }
                 ServerEvent::ClientDisconnected { client_id, reason } => {

--- a/bevy_replicon_renet/examples/tic_tac_toe.rs
+++ b/bevy_replicon_renet/examples/tic_tac_toe.rs
@@ -11,12 +11,12 @@ use std::{
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
 use bevy_replicon_renet::{
+    bevy_renet::wrappers::{
+        NetcodeClientTransport, NetcodeServerTransport, RenetClient, RenetServer,
+    },
     renet::{
-        transport::{
-            ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport,
-            ServerAuthentication, ServerConfig,
-        },
-        ConnectionConfig, RenetClient, RenetServer,
+        transport::{ClientAuthentication, ServerAuthentication, ServerConfig},
+        ConnectionConfig,
     },
     RenetChannelsExt, RepliconRenetPlugins,
 };
@@ -55,7 +55,7 @@ impl Plugin for TicTacToePlugin {
             .add_client_event::<CellPick>(ChannelKind::Ordered)
             .insert_resource(ClearColor(BACKGROUND_COLOR))
             .add_systems(
-                Startup,
+                PostStartup,
                 (Self::setup_ui, Self::read_cli.map(Result::unwrap)),
             )
             .add_systems(
@@ -92,7 +92,7 @@ impl Plugin for TicTacToePlugin {
 
 const GRID_SIZE: usize = 3;
 
-const BACKGROUND_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
+const BACKGROUND_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
 
 const PROTOCOL_ID: u64 = 0;
 
@@ -110,7 +110,7 @@ impl TicTacToePlugin {
         const LINE_THICKNESS: f32 = 10.0;
         const BOARD_SIZE: f32 = CELL_SIZE * GRID_SIZE as f32 + LINES_COUNT as f32 * LINE_THICKNESS;
 
-        const BOARD_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);
+        const BOARD_COLOR: Color = Color::srgb(0.8, 0.8, 0.8);
 
         for line in 0..LINES_COUNT {
             let position = -BOARD_SIZE / 2.0
@@ -149,7 +149,7 @@ impl TicTacToePlugin {
         const BUTTON_SIZE: f32 = CELL_SIZE / 1.2;
         const BUTTON_MARGIN: f32 = (CELL_SIZE + LINE_THICKNESS - BUTTON_SIZE) / 2.0;
 
-        const TEXT_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
+        const TEXT_COLOR: Color = Color::srgb(0.5, 0.5, 1.0);
         const FONT_SIZE: f32 = 40.0;
 
         commands
@@ -196,7 +196,7 @@ impl TicTacToePlugin {
                                             margin: UiRect::all(Val::Px(BUTTON_MARGIN)),
                                             ..Default::default()
                                         },
-                                        background_color: BACKGROUND_COLOR.into(),
+                                        image: UiImage::default().with_color(BACKGROUND_COLOR),
                                         ..Default::default()
                                     });
                                 }
@@ -378,7 +378,7 @@ impl TicTacToePlugin {
         children: Query<&Children>,
         mut pick_events: EventWriter<CellPick>,
     ) {
-        const HOVER_COLOR: Color = Color::rgb(0.85, 0.85, 0.85);
+        const HOVER_COLOR: Color = Color::srgb(0.85, 0.85, 0.85);
 
         for (button_entity, button_parent, interaction, mut background) in &mut buttons {
             match interaction {
@@ -599,8 +599,8 @@ impl Symbol {
 
     fn color(self) -> Color {
         match self {
-            Symbol::Cross => Color::rgb(1.0, 0.5, 0.5),
-            Symbol::Nought => Color::rgb(0.5, 0.5, 1.0),
+            Symbol::Cross => Color::srgb(1.0, 0.5, 0.5),
+            Symbol::Nought => Color::srgb(0.5, 0.5, 1.0),
         }
     }
 

--- a/bevy_replicon_renet/src/bevy_renet.rs
+++ b/bevy_replicon_renet/src/bevy_renet.rs
@@ -1,0 +1,127 @@
+//! Provides integration for [renet](https://github.com/lucaspoffo/renet) with Bevy.
+//! If you implement an integration for your own messaging backend and already have
+//! an integration with Bevy, you don't have to do the same.
+//!
+//! We decided to not depend on [`bevy_renet`](https://github.com/lucaspoffo/renet/tree/master/bevy_renet)
+//! directly only because the author is not very active and the crate is sometimes behind a Bevy version.
+
+#[cfg(feature = "renet_transport")]
+pub mod transport;
+pub mod wrappers;
+
+use bevy::prelude::*;
+use wrappers::{RenetClient, RenetServer, ServerEvent};
+
+/// This system set is where all transports receive messages
+///
+/// If you want to ensure data has arrived in the [`RenetClient`] or [`RenetServer`], then schedule your
+/// system after this set.
+///
+/// This system set runs in PreUpdate.
+#[derive(Debug, SystemSet, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RenetReceive;
+
+/// This system set is where all transports send messages
+///
+/// If you want to ensure your packets have been registered by the [`RenetClient`] or [`RenetServer`], then
+/// schedule your system before this set.
+///
+/// This system set runs in PostUpdate.
+#[derive(Debug, SystemSet, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RenetSend;
+
+pub struct RenetServerPlugin;
+
+pub struct RenetClientPlugin;
+
+impl Plugin for RenetServerPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<Events<ServerEvent>>();
+        app.add_systems(
+            PreUpdate,
+            Self::update_system.run_if(resource_exists::<RenetServer>),
+        );
+        app.add_systems(
+            PreUpdate,
+            Self::emit_server_events_system
+                .in_set(RenetReceive)
+                .run_if(resource_exists::<RenetServer>)
+                .after(Self::update_system),
+        );
+    }
+}
+
+impl RenetServerPlugin {
+    pub fn update_system(mut server: ResMut<RenetServer>, time: Res<Time>) {
+        server.update(time.delta());
+    }
+
+    pub fn emit_server_events_system(
+        mut server: ResMut<RenetServer>,
+        mut server_events: EventWriter<ServerEvent>,
+    ) {
+        while let Some(event) = server.get_event() {
+            server_events.send(event.into());
+        }
+    }
+}
+
+impl Plugin for RenetClientPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PreUpdate,
+            Self::update_system.run_if(resource_exists::<RenetClient>),
+        );
+    }
+}
+
+impl RenetClientPlugin {
+    pub fn update_system(mut client: ResMut<RenetClient>, time: Res<Time>) {
+        client.update(time.delta());
+    }
+}
+
+pub fn client_connected(client: Option<Res<RenetClient>>) -> bool {
+    match client {
+        Some(client) => client.is_connected(),
+        None => false,
+    }
+}
+
+pub fn client_disconnected(client: Option<Res<RenetClient>>) -> bool {
+    match client {
+        Some(client) => client.is_disconnected(),
+        None => true,
+    }
+}
+
+pub fn client_connecting(client: Option<Res<RenetClient>>) -> bool {
+    match client {
+        Some(client) => client.is_connecting(),
+        None => false,
+    }
+}
+
+pub fn client_just_connected(
+    mut last_connected: Local<bool>,
+    client: Option<Res<RenetClient>>,
+) -> bool {
+    let connected = client.map(|client| client.is_connected()).unwrap_or(false);
+
+    let just_connected = !*last_connected && connected;
+    *last_connected = connected;
+    just_connected
+}
+
+pub fn client_just_disconnected(
+    mut last_connected: Local<bool>,
+    client: Option<Res<RenetClient>>,
+) -> bool {
+    let disconnected = client
+        .map(|client| client.is_disconnected())
+        .unwrap_or(true);
+
+    let just_disconnected = *last_connected && disconnected;
+    *last_connected = !disconnected;
+    just_disconnected
+}

--- a/bevy_replicon_renet/src/bevy_renet.rs
+++ b/bevy_replicon_renet/src/bevy_renet.rs
@@ -70,6 +70,7 @@ impl Plugin for RenetClientPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             PreUpdate,
+            // Note: This runs before `RenetReceive`. See `NetcodeClientPlugin`.
             Self::update_system.run_if(resource_exists::<RenetClient>),
         );
     }

--- a/bevy_replicon_renet/src/bevy_renet/transport.rs
+++ b/bevy_replicon_renet/src/bevy_renet/transport.rs
@@ -1,0 +1,125 @@
+use bevy::{app::AppExit, prelude::*};
+
+use super::{
+    wrappers::{
+        NetcodeClientTransport, NetcodeServerTransport, NetcodeTransportError, RenetClient,
+        RenetServer,
+    },
+    RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin,
+};
+
+pub struct NetcodeServerPlugin;
+
+pub struct NetcodeClientPlugin;
+
+impl Plugin for NetcodeServerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<NetcodeTransportError>();
+
+        app.add_systems(
+            PreUpdate,
+            Self::update_system
+                .in_set(RenetReceive)
+                .run_if(resource_exists::<NetcodeServerTransport>)
+                .run_if(resource_exists::<RenetServer>)
+                .after(RenetServerPlugin::update_system)
+                .before(RenetServerPlugin::emit_server_events_system),
+        );
+
+        app.add_systems(
+            PostUpdate,
+            (
+                Self::send_packets.in_set(RenetSend),
+                Self::disconnect_on_exit,
+            )
+                .run_if(resource_exists::<NetcodeServerTransport>)
+                .run_if(resource_exists::<RenetServer>),
+        );
+    }
+}
+
+impl NetcodeServerPlugin {
+    pub fn update_system(
+        mut transport: ResMut<NetcodeServerTransport>,
+        mut server: ResMut<RenetServer>,
+        time: Res<Time>,
+        mut transport_errors: EventWriter<NetcodeTransportError>,
+    ) {
+        if let Err(e) = transport.update(time.delta(), &mut server) {
+            transport_errors.send(e.into());
+        }
+    }
+
+    pub fn send_packets(
+        mut transport: ResMut<NetcodeServerTransport>,
+        mut server: ResMut<RenetServer>,
+    ) {
+        transport.send_packets(&mut server);
+    }
+
+    pub fn disconnect_on_exit(
+        exit: EventReader<AppExit>,
+        mut transport: ResMut<NetcodeServerTransport>,
+        mut server: ResMut<RenetServer>,
+    ) {
+        if !exit.is_empty() {
+            transport.disconnect_all(&mut server);
+        }
+    }
+}
+
+impl Plugin for NetcodeClientPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<NetcodeTransportError>();
+
+        app.add_systems(
+            PreUpdate,
+            Self::update_system
+                .in_set(RenetReceive)
+                .run_if(resource_exists::<NetcodeClientTransport>)
+                .run_if(resource_exists::<RenetClient>)
+                .after(RenetClientPlugin::update_system),
+        );
+        app.add_systems(
+            PostUpdate,
+            (
+                Self::send_packets.in_set(RenetSend),
+                Self::disconnect_on_exit,
+            )
+                .run_if(resource_exists::<NetcodeClientTransport>)
+                .run_if(resource_exists::<RenetClient>),
+        );
+    }
+}
+
+impl NetcodeClientPlugin {
+    pub fn update_system(
+        mut transport: ResMut<NetcodeClientTransport>,
+        mut client: ResMut<RenetClient>,
+        time: Res<Time>,
+        mut transport_errors: EventWriter<NetcodeTransportError>,
+    ) {
+        if let Err(e) = transport.update(time.delta(), &mut client) {
+            transport_errors.send(e.into());
+        }
+    }
+
+    pub fn send_packets(
+        mut transport: ResMut<NetcodeClientTransport>,
+        mut client: ResMut<RenetClient>,
+        mut transport_errors: EventWriter<NetcodeTransportError>,
+    ) {
+        if let Err(e) = transport.send_packets(&mut client) {
+            transport_errors.send(e.into());
+        }
+    }
+
+    pub fn disconnect_on_exit(
+        exit: EventReader<AppExit>,
+        mut transport: ResMut<NetcodeClientTransport>,
+    ) {
+        if !exit.is_empty() {
+            transport.disconnect();
+        }
+    }
+}

--- a/bevy_replicon_renet/src/bevy_renet/wrappers.rs
+++ b/bevy_replicon_renet/src/bevy_renet/wrappers.rs
@@ -1,0 +1,106 @@
+//! Wrappers around renet types to provide integration with Bevy.
+//! We don't use `bevy` feature from `renet` because we don't want to depend on renet releases.
+
+use std::{net::UdpSocket, time::Duration};
+
+use bevy::prelude::*;
+#[cfg(feature = "renet_transport")]
+use renet::transport::{NetcodeError, ServerConfig};
+use renet::{transport::ClientAuthentication, ClientId, ConnectionConfig, DisconnectReason};
+
+/// Wrapper around [`renet::RenetClient`] to make it a resource.
+#[derive(Debug, Resource, Deref, DerefMut)]
+pub struct RenetClient(renet::RenetClient);
+
+impl RenetClient {
+    pub fn new(config: ConnectionConfig) -> Self {
+        Self(renet::RenetClient::new(config))
+    }
+}
+
+/// Wrapper around [`renet::RenetServer`] to make it a resource.
+#[derive(Debug, Resource, Deref, DerefMut)]
+pub struct RenetServer(renet::RenetServer);
+
+impl RenetServer {
+    pub fn new(connection_config: ConnectionConfig) -> Self {
+        Self(renet::RenetServer::new(connection_config))
+    }
+}
+
+/// Copies [`renet::ServerEvent`] to pass it in events.
+#[derive(Debug, PartialEq, Eq, Event)]
+pub enum ServerEvent {
+    ClientConnected {
+        client_id: ClientId,
+    },
+    ClientDisconnected {
+        client_id: ClientId,
+        reason: DisconnectReason,
+    },
+}
+
+impl From<renet::ServerEvent> for ServerEvent {
+    fn from(value: renet::ServerEvent) -> Self {
+        match value {
+            renet::ServerEvent::ClientConnected { client_id } => {
+                Self::ClientConnected { client_id }
+            }
+            renet::ServerEvent::ClientDisconnected { client_id, reason } => {
+                Self::ClientDisconnected { client_id, reason }
+            }
+        }
+    }
+}
+
+/// Wrapper around [`renet::transport::NetcodeClientTransport`] to make it a resource.
+#[cfg(feature = "renet_transport")]
+#[derive(Debug, Resource, Deref, DerefMut)]
+pub struct NetcodeClientTransport(renet::transport::NetcodeClientTransport);
+
+impl NetcodeClientTransport {
+    pub fn new(
+        current_time: Duration,
+        authentication: ClientAuthentication,
+        socket: UdpSocket,
+    ) -> Result<Self, NetcodeError> {
+        Ok(Self(renet::transport::NetcodeClientTransport::new(
+            current_time,
+            authentication,
+            socket,
+        )?))
+    }
+}
+
+/// Wrapper around [`renet::transport::NetcodeServerTransport`] to make it a resource.
+#[cfg(feature = "renet_transport")]
+#[derive(Debug, Resource, Deref, DerefMut)]
+pub struct NetcodeServerTransport(renet::transport::NetcodeServerTransport);
+
+impl NetcodeServerTransport {
+    pub fn new(server_config: ServerConfig, socket: UdpSocket) -> Result<Self, std::io::Error> {
+        Ok(Self(renet::transport::NetcodeServerTransport::new(
+            server_config,
+            socket,
+        )?))
+    }
+}
+
+/// Wrapper around [`renet::transport::NetcodeTransportError`] to pass it in events.
+#[cfg(feature = "renet_transport")]
+#[derive(Debug, Event)]
+pub enum NetcodeTransportError {
+    Netcode(NetcodeError),
+    Renet(DisconnectReason),
+    IO(std::io::Error),
+}
+
+impl From<renet::transport::NetcodeTransportError> for NetcodeTransportError {
+    fn from(value: renet::transport::NetcodeTransportError) -> Self {
+        match value {
+            renet::transport::NetcodeTransportError::Netcode(error) => Self::Netcode(error),
+            renet::transport::NetcodeTransportError::Renet(error) => Self::Renet(error),
+            renet::transport::NetcodeTransportError::IO(error) => Self::IO(error),
+        }
+    }
+}


### PR DESCRIPTION
[renet](https://github.com/lucaspoffo/renet) is not actively maintained and `bevy_renet` is often behind a Bevy version.

But since `bevy_renet` is very small (2 files), I decided to bundle it and depend on `renet` directly. The only downside is that in order use structs like `RenetServer` as a resource, I have to provide a wrapper. But it's just a few structs.

I also updated to `bevy_replicon_renet` to rc version and returned it to CI. All examples work.

For some reason I had to change `Startup` to `PostStartup` in Tic-Tac-Toe. Otherwise systems in `OnEnter` couldn't fine spawned UI nodes :thinking: 