### PR TITLE
Use GitHub's warning about semver compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](
 
 ## Related Crates
 
-**Note:** Ensure that your `bevy_replicon` version is compatible with the used crate according to semantic versioning.
+> [!WARNING]
+> Ensure that your `bevy_replicon` version is compatible with the used crate according to semantic versioning.
 
 #### Messaging backends
 


### PR DESCRIPTION
See it in action: https://github.com/projectharmonia/bevy_replicon/tree/version-warning?tab=readme-ov-file#related-crates
Docs: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts