### PR TITLE
Remove mentions of the RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.27.0-rc.3] - 2024-06-29
-
 ### Changed
 
 - Update to Bevy `0.14.0-rc.4`.
@@ -32,12 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not divide values per seconds by the number of messages for `ClientDiagnosticsPlugin`.
 
-## [0.27.0-rc.2] - 2024-06-16
-
-### Changed
-
-- Update to Bevy `0.14.0-rc.3`.
-
 ## [0.26.3] - 2024-06-09
 
 ### Added
@@ -47,12 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Do not send empty ack messages from client.
-
-## [0.27.0-rc.1] - 2024-06-07
-
-### Changed
-
-- Update to Bevy `0.14.0-rc.2`.
 
 ## [0.26.2] - 2024-06-05
 
@@ -556,11 +542,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release after separation from [Project Harmonia](https://github.com/projectharmonia/project_harmonia).
 
-[unreleased]: https://github.com/projectharmonia/bevy_replicon/compare/v0.27.0-rc.3...HEAD
-[0.27.0-rc.3]: https://github.com/projectharmonia/bevy_replicon/compare/v0.27.0-rc.2...v0.27.0-rc.3
-[0.27.0-rc.2]: https://github.com/projectharmonia/bevy_replicon/compare/v0.27.0-rc.1...v0.27.0-rc.2
+[unreleased]: https://github.com/projectharmonia/bevy_replicon/compare/v0.26.3...HEAD
 [0.26.3]: https://github.com/projectharmonia/bevy_replicon/compare/v0.26.2...v0.26.3
-[0.27.0-rc.1]: https://github.com/projectharmonia/bevy_replicon/compare/v0.26.2...v0.27.0-rc.1
 [0.26.2]: https://github.com/projectharmonia/bevy_replicon/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/projectharmonia/bevy_replicon/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/projectharmonia/bevy_replicon/compare/v0.25.3...v0.26.0

--- a/README.md
+++ b/README.md
@@ -72,9 +72,6 @@ Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](
 
 | bevy        | bevy_replicon |
 | ----------- | ------------- |
-| 0.14.0-rc.4 | 0.27.0-rc.3   |
-| 0.14.0-rc.3 | 0.27.0-rc.2   |
-| 0.14.0-rc.2 | 0.27.0-rc.1   |
 | 0.13.0      | 0.23-0.26     |
 | 0.12.1      | 0.18-0.22     |
 | 0.11.0      | 0.6-0.17      |


### PR DESCRIPTION
Without it it will be quite hard to read the changelog (users will have to check  the changes from RC) or I will need to copy all changes from RC for the upcoming 0.27.0.

I also removed it from the compatibility table as suggested by @UkoeHB. I also don't think that they will be useful... Keeping them will make the table harder to read.
Another option would be to keep them, but put under a spoiler.

Please, advice :)