### PR TITLE
Fix client event buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix client event buffering.
+
 ## [0.28.0] - 2024-09-03
 
 ### Added


### PR DESCRIPTION
I rushed a little with removing generics.
We need to keep separate buffer for each event, otherwise events of
different types encoded in Bytes will be mixed together.

This commit is partial revert of e98a940a9f746cc5c3a2fd8bbb7a10506476b125.