### PR TITLE
Make ReplicatedClients::new public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made `ReplicatedClients::new` public for use in testing contexts.
+
 ## [0.28.1] - 2024-09-04
 
 ### Fixed

--- a/src/core/replicated_clients.rs
+++ b/src/core/replicated_clients.rs
@@ -25,7 +25,10 @@ pub struct ReplicatedClients {
 }
 
 impl ReplicatedClients {
-    pub(crate) fn new(policy: VisibilityPolicy, replicate_after_connect: bool) -> Self {
+    /// Makes a new replicated clients struct.
+    ///
+    /// Generally you should not need this except in testing contexts.
+    pub fn new(policy: VisibilityPolicy, replicate_after_connect: bool) -> Self {
         Self {
             clients: Default::default(),
             policy,


### PR DESCRIPTION
Ran into this while updating tests in `bevy_girk`. I access `ReplicatedClients` in the `bevy_replicon_attributes` plugin, and need the attributes plugin in some barebones tests that use attributes to manage replicated components.