### PR TITLE
Fix server event race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Synchronize server events with init messages properly when `ServerTick` is not updated every app tick.
+
 ## [0.28.3] - 2024-09-13
 
 ### Changed

--- a/src/server/server_tick.rs
+++ b/src/server/server_tick.rs
@@ -32,3 +32,9 @@ impl ServerTick {
         self.increment_by(1)
     }
 }
+
+/// Stores the most recent [`ServerTick`] where at least one init message was sent to a client.
+///
+/// Used as an optimization during server event management.
+#[derive(Clone, Copy, Deref, Debug, Default, Resource)]
+pub struct ServerLastInitTick(pub(crate) RepliconTick);


### PR DESCRIPTION
Solution:
- Buffer pre-serialized server events until a tick when `ServerTick` changes.
- Server events are optimistically pre-serialized with the latest server tick where an init message was sent.
- Server events are filtered against clients that connected after an event was sent to ensure connection boundaries are respected.