### PR TITLE
Replace `varint-rs` with `integer-encoding`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bevy = { version = "0.14", default-features = false, features = ["serialize"] }
 bytes = "1.5"
 bincode = "1.3"
 serde = "1.0"
-varint-rs = "2.2"
+integer-encoding = "4.0"
 ordered-multimap = "0.7"
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@ use std::{io::Cursor, mem};
 use bevy::{ecs::world::CommandQueue, prelude::*};
 use bincode::{DefaultOptions, Options};
 use bytes::Bytes;
-use varint_rs::VarintReader;
+use integer_encoding::VarIntReader;
 
 use crate::core::{
     channels::{ReplicationChannel, RepliconChannels},
@@ -514,10 +514,10 @@ fn apply_update_components(
 /// For details see
 /// [`ReplicationBuffer::write_entity`](crate::server::replication_message::replication_buffer::write_entity).
 fn deserialize_entity(cursor: &mut Cursor<&[u8]>) -> bincode::Result<Entity> {
-    let flagged_index: u64 = cursor.read_u64_varint()?;
+    let flagged_index: u64 = cursor.read_varint()?;
     let has_generation = (flagged_index & 1) > 0;
     let generation = if has_generation {
-        cursor.read_u32_varint()? + 1
+        cursor.read_varint::<u32>()? + 1
     } else {
         1u32
     };

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -4,7 +4,7 @@ pub(super) mod update_message;
 use std::io::{Cursor, Write};
 
 use bevy::prelude::*;
-use varint_rs::VarintWriter;
+use integer_encoding::VarIntWriter;
 
 use init_message::InitMessage;
 use update_message::UpdateMessage;
@@ -93,9 +93,9 @@ fn serialize_entity(cursor: &mut Cursor<Vec<u8>>, entity: Entity) -> bincode::Re
     let flag = entity.generation() > 1;
     flagged_index |= flag as u64;
 
-    cursor.write_u64_varint(flagged_index)?;
+    cursor.write_varint(flagged_index)?;
     if flag {
-        cursor.write_u32_varint(entity.generation() - 1)?;
+        cursor.write_varint(entity.generation() - 1)?;
     }
 
     Ok(())


### PR DESCRIPTION
It's a bit more advanced, I need some of its features for the upcoming work. The encoding is the same.
Also `varint-rs` has not been updated in 4 years.