### PR TITLE
Rework `DeferredEntity` creation

### DIFF
--- a/src/core/replication/replication_registry/test_fns.rs
+++ b/src/core/replication/replication_registry/test_fns.rs
@@ -123,12 +123,9 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
         self.world_scope(|world| {
             world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
                 world.resource_scope(|world, registry: Mut<ReplicationRegistry>| {
-                    let world_cell = world.as_unsafe_world_cell();
-                    // SAFETY: have write access and the cell used only to get entities.
-                    let mut entity = unsafe { DeferredEntity::new(world_cell, entity) };
                     let mut queue = CommandQueue::default();
-                    let mut commands =
-                        Commands::new_from_entities(&mut queue, world_cell.entities());
+                    let mut entity = DeferredEntity::new(world, entity);
+                    let mut commands = entity.commands(&mut queue);
 
                     let (component_id, component_fns, rule_fns) = registry.get(fns_id);
                     let mut cursor = Cursor::new(data);
@@ -163,11 +160,9 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
         let entity = self.id();
         self.world_scope(|world| {
             world.resource_scope(|world, registry: Mut<ReplicationRegistry>| {
-                let world_cell = world.as_unsafe_world_cell();
-                // SAFETY: have write access and the cell used only to get entities.
-                let mut entity = unsafe { DeferredEntity::new(world_cell, entity) };
                 let mut queue = CommandQueue::default();
-                let mut commands = Commands::new_from_entities(&mut queue, world_cell.entities());
+                let mut entity = DeferredEntity::new(world, entity);
+                let mut commands = entity.commands(&mut queue);
 
                 let (component_id, component_fns, _) = registry.get(fns_id);
                 let mut ctx = RemoveCtx {


### PR DESCRIPTION
I realized that it's possible to construct commands from the entity's world.
It lets me hide all unsafety in the constructor and re-use it in other places.

Requires #352, I will retarget to the master after the merge.