### PR TITLE
Better history API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -783,7 +783,7 @@ pub(super) struct BufferedMutate {
     /// The tick this mutations corresponds to.
     message_tick: RepliconTick,
 
-    /// Number of all mutate messages sent by server for this tick.
+    /// Total number of mutate messages sent by the server for this tick.
     ///
     /// May not be equal to the number of received messages.
     messages_count: usize,

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ use crate::core::{
     server_entity_map::ServerEntityMap,
 };
 use confirm_history::{ConfirmHistory, EntityReplicated};
-use server_mutate_ticks::{MutateTickConfirmed, ServerMutateTicks};
+use server_mutate_ticks::{MutateTickReceived, ServerMutateTicks};
 
 /// Client functionality and replication receiving.
 ///
@@ -44,7 +44,7 @@ impl Plugin for ClientPlugin {
             .init_resource::<ServerChangeTick>()
             .init_resource::<BufferedMutations>()
             .add_event::<EntityReplicated>()
-            .add_event::<MutateTickConfirmed>()
+            .add_event::<MutateTickReceived>()
             .configure_sets(
                 PreUpdate,
                 (
@@ -341,7 +341,7 @@ fn apply_mutate_messages(
 
         if let Some(mutate_ticks) = &mut params.mutate_ticks {
             if mutate_ticks.confirm(mutate.message_tick, mutate.messages_count) {
-                world.send_event(MutateTickConfirmed {
+                world.send_event(MutateTickReceived {
                     tick: mutate.message_tick,
                 });
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,12 +156,14 @@ impl ClientPlugin {
         mut change_tick: ResMut<ServerChangeTick>,
         mut entity_map: ResMut<ServerEntityMap>,
         mut buffered_mutations: ResMut<BufferedMutations>,
-        mut stats: ResMut<ClientReplicationStats>,
+        stats: Option<ResMut<ClientReplicationStats>>,
     ) {
         *change_tick = Default::default();
         entity_map.clear();
         buffered_mutations.clear();
-        *stats = Default::default();
+        if let Some(mut stats) = stats {
+            *stats = Default::default();
+        }
     }
 }
 

--- a/src/client/confirm_history.rs
+++ b/src/client/confirm_history.rs
@@ -9,7 +9,7 @@ use crate::core::replicon_tick::RepliconTick;
 /// For efficiency we store only the last received tick and
 /// a bitmask indicating whether the most recent 64 ticks were received.
 ///
-/// See also [`HistoryConfirmed`].
+/// See also [`EntityReplicated`].
 #[derive(Component)]
 pub struct ConfirmHistory {
     /// Previously confirmed ticks, including the last tick at position 0.
@@ -133,7 +133,7 @@ pub type Confirmed = ConfirmHistory;
 ///
 /// See also [`ConfirmHistory`].
 #[derive(Debug, Event, Clone, Copy)]
-pub struct HistoryConfirmed {
+pub struct EntityReplicated {
     /// Entity that received changes.
     pub entity: Entity,
 

--- a/src/client/confirm_history.rs
+++ b/src/client/confirm_history.rs
@@ -8,6 +8,8 @@ use crate::core::replicon_tick::RepliconTick;
 ///
 /// For efficiency we store only the last received tick and
 /// a bitmask indicating whether the most recent 64 ticks were received.
+///
+/// See also [`HistoryConfirmed`].
 #[derive(Component)]
 pub struct ConfirmHistory {
     /// Previously confirmed ticks, including the last tick at position 0.
@@ -126,6 +128,18 @@ impl ConfirmHistory {
 
 #[deprecated(note = "use `ConfirmHistory` instead")]
 pub type Confirmed = ConfirmHistory;
+
+/// Triggered for an entity when it receives changes for a tick.
+///
+/// See also [`ConfirmHistory`].
+#[derive(Debug, Event, Clone, Copy)]
+pub struct HistoryConfirmed {
+    /// Entity that received changes.
+    pub entity: Entity,
+
+    /// Message tick.
+    pub tick: RepliconTick,
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -92,7 +92,8 @@ impl ServerMutateTicks {
             .any(|tick| tick.all_received())
     }
 
-    /// Confirms a received message a tick and initializes the number of sent messages for it.
+    /// Confirms a message was received for a tick and initializes the number of sent
+    /// messages for it.
     ///
     /// Return `true` if the number of received messages matches `messages_count`.
     ///

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -14,7 +14,7 @@ use crate::core::replicon_tick::RepliconTick;
 /// [`TrackAppExt::track_mutate_messages`](crate::core::replication::track_mutate_messages::TrackAppExt::track_mutate_messages)
 /// were called.
 ///
-/// See also [`MutateTickConfirmed`] and [`ServerChangeTick`](super::ServerChangeTick).
+/// See also [`MutateTickReceived`] and [`ServerChangeTick`](super::ServerChangeTick).
 #[derive(Debug, Resource)]
 pub struct ServerMutateTicks {
     ticks: VecDeque<TickMessages>,
@@ -172,7 +172,7 @@ impl TickMessages {
 ///
 /// See also [`ServerMutateTicks`].
 #[derive(Debug, Event, Clone, Copy)]
-pub struct MutateTickConfirmed {
+pub struct MutateTickReceived {
     /// Message(s) tick.
     pub tick: RepliconTick,
 }

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -1,0 +1,335 @@
+use std::array;
+
+use bevy::prelude::*;
+
+use crate::core::replicon_tick::RepliconTick;
+
+/// Received ticks for mutate message from server.
+///
+/// For efficiency we store only the last received tick and
+/// an array indicating whether all mutate messages for the most
+/// recent 64 ticks were received.
+///
+/// Inserted to the world in [`ClientPlugin::finish`](super::ClientPlugin::finish) if
+/// [`TrackAppExt::track_mutate_messages`](crate::core::replication::track_mutate_messages::TrackAppExt::track_mutate_messages)
+/// were called.
+///
+/// See also [`MutateTickConfirmed`] and [`ServerChangeTick`](super::ServerChangeTick).
+#[derive(Debug, Resource)]
+pub struct ServerMutateTicks {
+    ticks: [TickMessages; 64],
+
+    /// The last received server tick with mutation.
+    last_tick: RepliconTick,
+}
+
+impl ServerMutateTicks {
+    /// Returns the last received tick.
+    pub fn last_tick(&self) -> RepliconTick {
+        self.last_tick
+    }
+
+    /// Returns a mask that represents the received ticks.
+    pub fn mask(&self) -> u64 {
+        let mut bitmask = 0;
+
+        for (i, tick) in self.ticks.iter().enumerate() {
+            if tick.all_received() {
+                bitmask |= 1 << i;
+            }
+        }
+
+        bitmask
+    }
+
+    /// Returns `true` if this tick is confirmed for an entity.
+    ///
+    /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
+    pub fn contains(&self, tick: RepliconTick) -> bool {
+        if tick > self.last_tick {
+            return false;
+        }
+
+        let ago = self.last_tick - tick;
+        if let Some(tick) = self.ticks.get(ago as usize) {
+            tick.all_received()
+        } else {
+            true
+        }
+    }
+
+    /// Returns `true` if any tick in the given range was confirmed for the entity with
+    /// this component.
+    ///
+    /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `debug_assertions` are enabled and
+    /// `start_tick` is greater then `end_tick`.
+    pub fn contains_any(&self, start_tick: RepliconTick, end_tick: RepliconTick) -> bool {
+        debug_assert!(start_tick <= end_tick);
+
+        if start_tick > self.last_tick {
+            return false;
+        }
+        if start_tick <= self.last_tick - self.ticks.len() as u32 {
+            return true;
+        }
+
+        let end_tick = if end_tick < self.last_tick {
+            end_tick
+        } else {
+            self.last_tick
+        };
+
+        // Start and end are reversed because ticks in the
+        // array are stored in decreasing order.
+        let end = (self.last_tick - start_tick) as usize;
+        let start = (self.last_tick - end_tick) as usize;
+        self.ticks[start..=end]
+            .iter()
+            .any(|tick| tick.all_received())
+    }
+
+    /// Confirms a received message a tick and initializes the number of sent messages for it.
+    ///
+    /// Return `true` if the number of received messages matches `messages_count`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `debug_assertions` are enabled and `messages_count` is different
+    /// from the last call or if the number of calls for the same tick exceeds `messages_count`.
+    pub fn confirm(&mut self, tick: RepliconTick, messages_count: usize) -> bool {
+        let len = self.ticks.len();
+        if tick > self.last_tick {
+            let ago = (tick - self.last_tick) as usize;
+            if ago >= len {
+                // If the difference exceeds the size, clear all ticks.
+                self.ticks.fill(Default::default());
+            } else {
+                // Shift all ticks.
+                self.ticks.copy_within(..len - ago, ago);
+                self.ticks[..ago].fill(Default::default());
+            }
+
+            self.last_tick = tick;
+            self.ticks[0].confirm(messages_count)
+        } else {
+            let ago = (self.last_tick - tick) as usize;
+            if ago < len {
+                self.ticks[ago].confirm(messages_count)
+            } else {
+                false
+            }
+        }
+    }
+}
+
+impl Default for ServerMutateTicks {
+    fn default() -> Self {
+        Self {
+            ticks: array::from_fn(|_| Default::default()),
+            last_tick: Default::default(),
+        }
+    }
+}
+
+/// Tracker for mutable messages received for a tick.
+#[derive(Clone, Copy, Debug, Default)]
+struct TickMessages {
+    /// Number of sent messages.
+    ///
+    /// If zero, we consider the tick as completely non-received.
+    messages_count: usize,
+
+    /// Number of received messages.
+    received: usize,
+}
+
+impl TickMessages {
+    fn confirm(&mut self, messages_count: usize) -> bool {
+        debug_assert!(messages_count != 0);
+        debug_assert!(self.messages_count == 0 || self.messages_count == messages_count);
+
+        self.messages_count = messages_count;
+        self.received += 1;
+
+        debug_assert!(self.received <= self.messages_count);
+
+        self.all_received()
+    }
+
+    fn all_received(&self) -> bool {
+        self.messages_count != 0 && self.messages_count == self.received
+    }
+}
+
+/// Triggered when all mutate messages are received for a tick.
+///
+/// See also [`ServerMutateTicks`].
+#[derive(Debug, Event, Clone, Copy)]
+pub struct MutateTickConfirmed {
+    /// Message(s) tick.
+    pub tick: RepliconTick,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(1), 1);
+
+        assert!(!ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(!ticks.contains(RepliconTick::new(2)));
+        assert!(!ticks.contains(RepliconTick::new(u32::MAX)));
+    }
+
+    #[test]
+    fn contains_with_wrapping() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(u64::BITS + 1), 1);
+
+        assert!(ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(!ticks.contains(RepliconTick::new(2)));
+
+        assert!(!ticks.contains(RepliconTick::new(u64::BITS)));
+        assert!(ticks.contains(RepliconTick::new(u64::BITS + 1)));
+        assert!(!ticks.contains(RepliconTick::new(u64::BITS + 2)));
+    }
+
+    #[test]
+    fn contains_any() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(1), 1);
+
+        assert!(ticks.contains_any(RepliconTick::new(0), RepliconTick::new(1)));
+        assert!(ticks.contains_any(RepliconTick::new(1), RepliconTick::new(1)));
+        assert!(ticks.contains_any(RepliconTick::new(1), RepliconTick::new(2)));
+        assert!(!ticks.contains_any(RepliconTick::new(2), RepliconTick::new(3)));
+        assert!(!ticks.contains_any(RepliconTick::new(u32::MAX), RepliconTick::new(0)));
+        assert!(ticks.contains_any(RepliconTick::new(u32::MAX), RepliconTick::new(1)));
+        assert!(ticks.contains_any(RepliconTick::new(0), RepliconTick::new(2)));
+        assert!(ticks.contains_any(RepliconTick::new(u32::MAX), RepliconTick::new(3)));
+    }
+
+    #[test]
+    fn contains_any_with_wrapping() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(u64::BITS + 1), 1);
+
+        assert!(ticks.contains_any(RepliconTick::new(0), RepliconTick::new(1)));
+        assert!(ticks.contains_any(RepliconTick::new(1), RepliconTick::new(2)));
+        assert!(!ticks.contains_any(RepliconTick::new(2), RepliconTick::new(3)));
+        assert!(ticks.contains_any(RepliconTick::new(0), RepliconTick::new(3)));
+
+        assert!(ticks.contains_any(
+            RepliconTick::new(u64::BITS),
+            RepliconTick::new(u64::BITS + 1)
+        ));
+        assert!(ticks.contains_any(
+            RepliconTick::new(u64::BITS + 1),
+            RepliconTick::new(u64::BITS + 2)
+        ));
+        assert!(!ticks.contains_any(
+            RepliconTick::new(u64::BITS + 2),
+            RepliconTick::new(u64::BITS + 3)
+        ));
+        assert!(ticks.contains_any(
+            RepliconTick::new(u64::BITS),
+            RepliconTick::new(u64::BITS + 3)
+        ));
+    }
+
+    #[test]
+    fn contains_any_with_older() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(1), 1);
+        assert_eq!(ticks.mask(), 0b1);
+
+        ticks.confirm(RepliconTick::new(u32::MAX), 1);
+        assert_eq!(ticks.mask(), 0b101);
+
+        assert!(ticks.contains_any(RepliconTick::new(0), RepliconTick::new(1)));
+        assert!(ticks.contains_any(RepliconTick::new(1), RepliconTick::new(2)));
+        assert!(!ticks.contains_any(RepliconTick::new(2), RepliconTick::new(3)));
+        assert!(ticks.contains_any(RepliconTick::new(u32::MAX), RepliconTick::new(0)));
+        assert!(ticks.contains_any(RepliconTick::new(0), RepliconTick::new(2)));
+        assert!(ticks.contains_any(RepliconTick::new(u32::MAX), RepliconTick::new(3)));
+        assert!(ticks.contains_any(RepliconTick::new(u32::MAX - 1), RepliconTick::new(u32::MAX)));
+        assert!(!ticks.contains_any(
+            RepliconTick::new(u32::MAX - 2),
+            RepliconTick::new(u32::MAX - 1)
+        ));
+    }
+
+    #[test]
+    fn confirm_newer() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(1), 1);
+        ticks.confirm(RepliconTick::new(2), 1);
+        assert_eq!(ticks.mask(), 0b11);
+
+        assert!(!ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(ticks.contains(RepliconTick::new(2)));
+    }
+
+    #[test]
+    fn confirm_older() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(1), 1);
+        ticks.confirm(RepliconTick::new(0), 1);
+        assert_eq!(ticks.mask(), 0b11);
+
+        assert!(ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(!ticks.contains(RepliconTick::new(2)));
+    }
+
+    #[test]
+    fn confirm_same() {
+        let mut ticks = ServerMutateTicks::default();
+        assert!(!ticks.confirm(RepliconTick::new(1), 2));
+        assert_eq!(ticks.mask(), 0b0);
+        assert!(ticks.confirm(RepliconTick::new(1), 2));
+        assert_eq!(ticks.mask(), 0b1);
+
+        assert!(!ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(!ticks.contains(RepliconTick::new(2)));
+    }
+
+    #[test]
+    fn confirm_with_wrapping() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(1), 1);
+        ticks.confirm(RepliconTick::new(u64::BITS + 1), 1);
+        assert_eq!(ticks.mask(), 0b1);
+
+        assert!(ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(!ticks.contains(RepliconTick::new(2)));
+        assert!(!ticks.contains(RepliconTick::new(u64::BITS)));
+        assert!(ticks.contains(RepliconTick::new(u64::BITS + 1)));
+        assert!(!ticks.contains(RepliconTick::new(u64::BITS + 2)));
+    }
+
+    #[test]
+    fn confirm_with_overflow() {
+        let mut ticks = ServerMutateTicks::default();
+        ticks.confirm(RepliconTick::new(u32::MAX), 1);
+        ticks.confirm(RepliconTick::new(1), 1);
+        assert_eq!(ticks.mask(), 0b101);
+
+        assert!(!ticks.contains(RepliconTick::new(0)));
+        assert!(ticks.contains(RepliconTick::new(1)));
+        assert!(!ticks.contains(RepliconTick::new(3)));
+        assert!(ticks.contains(RepliconTick::new(u32::MAX)));
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -15,14 +15,16 @@ use channels::RepliconChannels;
 use event_registry::EventRegistry;
 use replication::{
     command_markers::CommandMarkers, replication_registry::ReplicationRegistry,
-    replication_rules::ReplicationRules, Replicated,
+    replication_rules::ReplicationRules, track_mutate_messages::TrackMutateMessages, Replicated,
 };
 
+/// Initializes types and resources needed for both client and server.
 pub struct RepliconCorePlugin;
 
 impl Plugin for RepliconCorePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Replicated>()
+            .init_resource::<TrackMutateMessages>()
             .init_resource::<RepliconChannels>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<ReplicationRules>()

--- a/src/core/replication.rs
+++ b/src/core/replication.rs
@@ -4,6 +4,7 @@ pub mod deferred_entity;
 pub mod replicated_clients;
 pub mod replication_registry;
 pub mod replication_rules;
+pub mod track_mutate_messages;
 
 use bevy::prelude::*;
 

--- a/src/core/replication/track_mutate_messages.rs
+++ b/src/core/replication/track_mutate_messages.rs
@@ -1,0 +1,27 @@
+use bevy::prelude::*;
+
+pub trait TrackAppExt {
+    /// Enables mutate messages tracking.
+    ///
+    /// Server will start sending mutate messages each tick even if they empty
+    /// and include the amount of the messages for each header.
+    ///
+    /// Client will track the received messages using
+    /// [`ServerMutateTicks`](crate::client::server_mutate_ticks::ServerMutateTicks).
+    ///
+    /// Needs to be called by rollback crates to assume that the entity value didn't change
+    /// on a tick if all updates were received and
+    /// [`ConfirmHistory`](crate::client::confirm_history::ConfirmHistory)
+    /// don't have this tick confirmed.
+    fn track_mutate_messages(&mut self) -> &mut Self;
+}
+
+impl TrackAppExt for App {
+    fn track_mutate_messages(&mut self) -> &mut Self {
+        self.world_mut().resource_mut::<TrackMutateMessages>().0 = true;
+        self
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, Resource, Deref)]
+pub(crate) struct TrackMutateMessages(bool);

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,7 @@ use crate::core::{
             ReplicationRegistry,
         },
         replication_rules::ReplicationRules,
+        track_mutate_messages::TrackMutateMessages,
     },
     replicon_server::RepliconServer,
     replicon_tick::RepliconTick,
@@ -268,6 +269,7 @@ impl ServerPlugin {
             ResMut<DespawnBuffer>,
             ResMut<RepliconServer>,
         )>,
+        track_mutate_messages: Res<TrackMutateMessages>,
         registry: Res<ReplicationRegistry>,
         rules: Res<ReplicationRules>,
         server_tick: Res<ServerTick>,
@@ -313,6 +315,7 @@ impl ServerPlugin {
             &mut replicated_clients,
             &mut set.p6(),
             **server_tick,
+            **track_mutate_messages,
             &mut serialized,
             &mut client_buffers,
             change_tick,
@@ -347,6 +350,7 @@ fn send_messages(
     replicated_clients: &mut ReplicatedClients,
     server: &mut RepliconServer,
     server_tick: RepliconTick,
+    track_mutate_messages: bool,
     serialized: &mut SerializedData,
     client_buffers: &mut ClientBuffers,
     change_tick: SystemChangeTick,
@@ -366,7 +370,7 @@ fn send_messages(
             trace!("no changes to send for {:?}", client.id());
         }
 
-        if !mutate_message.is_empty() {
+        if !mutate_message.is_empty() || track_mutate_messages {
             let server_tick = write_tick_cached(&mut server_tick_range, serialized, server_tick)?;
 
             let messages_count = mutate_message.send(
@@ -374,6 +378,7 @@ fn send_messages(
                 client,
                 client_buffers,
                 serialized,
+                track_mutate_messages,
                 server_tick,
                 change_tick.this_run(),
                 time.elapsed(),

--- a/src/server/replication_messages/mutate_message.rs
+++ b/src/server/replication_messages/mutate_message.rs
@@ -172,6 +172,7 @@ impl MutateMessage {
         }
         if !mutations_range.is_empty() || track_mutate_messages {
             // When the loop ends, pack all leftovers into a message.
+            // Or create an empty message if tracking mutate messages is enabled.
             self.messages.push((
                 mutate_index,
                 body_size + header_size,

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 
 use bevy::{ecs::entity::MapEntities, prelude::*};
 use bevy_replicon::{
+    client::confirm_history::{ConfirmHistory, HistoryConfirmed},
     core::{
         replication::{
             deferred_entity::DeferredEntity,
@@ -10,6 +11,7 @@ use bevy_replicon::{
         server_entity_map::ServerEntityMap,
     },
     prelude::*,
+    server::server_tick::ServerTick,
     test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
@@ -499,6 +501,65 @@ fn after_started_replication() {
         .world_mut()
         .query_filtered::<(), With<DummyComponent>>()
         .single(client_app.world());
+}
+
+#[test]
+fn confirm_history() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<DummyComponent>();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(DummyComponent);
+
+    // Clear previous events.
+    client_app
+        .world_mut()
+        .resource_mut::<Events<HistoryConfirmed>>()
+        .clear();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let tick = **server_app.world().resource::<ServerTick>();
+
+    let (client_entity, confirm_history) = client_app
+        .world_mut()
+        .query::<(Entity, &ConfirmHistory)>()
+        .single(client_app.world());
+    assert!(confirm_history.contains(tick));
+
+    let mut history_events = client_app
+        .world_mut()
+        .resource_mut::<Events<HistoryConfirmed>>();
+    let [event] = history_events
+        .drain()
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    assert_eq!(event.entity, client_entity);
+    assert_eq!(event.tick, tick);
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use bevy::{ecs::entity::MapEntities, prelude::*};
 use bevy_replicon::{
-    client::confirm_history::{ConfirmHistory, HistoryConfirmed},
+    client::confirm_history::{ConfirmHistory, EntityReplicated},
     core::{
         replication::{
             deferred_entity::DeferredEntity,
@@ -535,7 +535,7 @@ fn confirm_history() {
     // Clear previous events.
     client_app
         .world_mut()
-        .resource_mut::<Events<HistoryConfirmed>>()
+        .resource_mut::<Events<EntityReplicated>>()
         .clear();
 
     server_app.update();
@@ -550,10 +550,10 @@ fn confirm_history() {
         .single(client_app.world());
     assert!(confirm_history.contains(tick));
 
-    let mut history_events = client_app
+    let mut replicated_events = client_app
         .world_mut()
-        .resource_mut::<Events<HistoryConfirmed>>();
-    let [event] = history_events
+        .resource_mut::<Events<EntityReplicated>>();
+    let [event] = replicated_events
         .drain()
         .collect::<Vec<_>>()
         .try_into()

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::server_mutate_ticks::{MutateTickConfirmed, ServerMutateTicks},
+    client::server_mutate_ticks::{MutateTickReceived, ServerMutateTicks},
     core::replication::track_mutate_messages::TrackAppExt,
     prelude::*,
     server::server_tick::ServerTick,
@@ -34,7 +34,7 @@ fn without_changes() {
 
     let events_count = client_app
         .world_mut()
-        .resource_mut::<Events<MutateTickConfirmed>>()
+        .resource_mut::<Events<MutateTickReceived>>()
         .drain()
         .count();
     assert_eq!(
@@ -72,11 +72,11 @@ fn one_message() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut mutate_events = client_app
+    let mut tick_events = client_app
         .world_mut()
-        .resource_mut::<Events<MutateTickConfirmed>>();
+        .resource_mut::<Events<MutateTickReceived>>();
     assert_eq!(
-        mutate_events.drain().count(),
+        tick_events.drain().count(),
         2,
         "should receive one event for connection and one for spawn"
     );
@@ -91,7 +91,7 @@ fn one_message() {
     // Clear previous events.
     client_app
         .world_mut()
-        .resource_mut::<Events<MutateTickConfirmed>>()
+        .resource_mut::<Events<MutateTickReceived>>()
         .clear();
 
     server_app.update();
@@ -100,14 +100,10 @@ fn one_message() {
 
     let tick = **server_app.world().resource::<ServerTick>();
 
-    let mut mutate_events = client_app
+    let mut tick_events = client_app
         .world_mut()
-        .resource_mut::<Events<MutateTickConfirmed>>();
-    let [event] = mutate_events
-        .drain()
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap();
+        .resource_mut::<Events<MutateTickReceived>>();
+    let [event] = tick_events.drain().collect::<Vec<_>>().try_into().unwrap();
     assert_eq!(event.tick, tick);
 
     let mutate_ticks = client_app.world().resource::<ServerMutateTicks>();
@@ -146,11 +142,11 @@ fn multiple_messages() {
 
     assert_eq!(client_app.world().entities().len(), ENTITIES_COUNT);
 
-    let mut mutate_events = client_app
+    let mut tick_events = client_app
         .world_mut()
-        .resource_mut::<Events<MutateTickConfirmed>>();
+        .resource_mut::<Events<MutateTickReceived>>();
     assert_eq!(
-        mutate_events.drain().count(),
+        tick_events.drain().count(),
         2,
         "should receive one event for connection and one for spawns"
     );
@@ -169,14 +165,10 @@ fn multiple_messages() {
 
     let tick = **server_app.world().resource::<ServerTick>();
 
-    let mut mutate_events = client_app
+    let mut tick_events = client_app
         .world_mut()
-        .resource_mut::<Events<MutateTickConfirmed>>();
-    let [event] = mutate_events
-        .drain()
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap();
+        .resource_mut::<Events<MutateTickReceived>>();
+    let [event] = tick_events.drain().collect::<Vec<_>>().try_into().unwrap();
     assert_eq!(event.tick, tick);
 
     let mutate_ticks = client_app.world().resource::<ServerMutateTicks>();

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -1,0 +1,187 @@
+use bevy::prelude::*;
+use bevy_replicon::{
+    client::server_mutate_ticks::{MutateTickConfirmed, ServerMutateTicks},
+    core::replication::track_mutate_messages::TrackAppExt,
+    prelude::*,
+    server::server_tick::ServerTick,
+    test_app::ServerTestAppExt,
+};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn without_changes() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .track_mutate_messages()
+        .replicate::<BoolComponent>();
+    }
+    client_app.finish();
+
+    server_app.connect_client(&mut client_app);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let events_count = client_app
+        .world_mut()
+        .resource_mut::<Events<MutateTickConfirmed>>()
+        .drain()
+        .count();
+    assert_eq!(
+        events_count, 2,
+        "should receive one event for connection and one for the exchange"
+    );
+}
+
+#[test]
+fn one_message() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .track_mutate_messages()
+        .replicate::<BoolComponent>();
+    }
+    client_app.finish();
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, BoolComponent(false)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut mutate_events = client_app
+        .world_mut()
+        .resource_mut::<Events<MutateTickConfirmed>>();
+    assert_eq!(
+        mutate_events.drain().count(),
+        2,
+        "should receive one event for connection and one for spawn"
+    );
+
+    // Change value.
+    let mut component = server_app
+        .world_mut()
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap();
+    component.0 = true;
+
+    // Clear previous events.
+    client_app
+        .world_mut()
+        .resource_mut::<Events<MutateTickConfirmed>>()
+        .clear();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let tick = **server_app.world().resource::<ServerTick>();
+
+    let mut mutate_events = client_app
+        .world_mut()
+        .resource_mut::<Events<MutateTickConfirmed>>();
+    let [event] = mutate_events
+        .drain()
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    assert_eq!(event.tick, tick);
+
+    let mutate_ticks = client_app.world().resource::<ServerMutateTicks>();
+    assert!(mutate_ticks.contains(tick));
+}
+
+#[test]
+fn multiple_messages() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .track_mutate_messages()
+        .replicate::<BoolComponent>();
+    }
+    client_app.finish();
+
+    server_app.connect_client(&mut client_app);
+
+    // Spawn many entities to cover message splitting.
+    const ENTITIES_COUNT: u32 = 300;
+    server_app
+        .world_mut()
+        .spawn_batch([(Replicated, BoolComponent(false)); ENTITIES_COUNT as usize]);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    assert_eq!(client_app.world().entities().len(), ENTITIES_COUNT);
+
+    let mut mutate_events = client_app
+        .world_mut()
+        .resource_mut::<Events<MutateTickConfirmed>>();
+    assert_eq!(
+        mutate_events.drain().count(),
+        2,
+        "should receive one event for connection and one for spawns"
+    );
+
+    for mut component in server_app
+        .world_mut()
+        .query::<&mut BoolComponent>()
+        .iter_mut(server_app.world_mut())
+    {
+        component.0 = true;
+    }
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let tick = **server_app.world().resource::<ServerTick>();
+
+    let mut mutate_events = client_app
+        .world_mut()
+        .resource_mut::<Events<MutateTickConfirmed>>();
+    let [event] = mutate_events
+        .drain()
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    assert_eq!(event.tick, tick);
+
+    let mutate_ticks = client_app.world().resource::<ServerMutateTicks>();
+    assert!(mutate_ticks.contains(tick));
+}
+
+#[derive(Clone, Component, Copy, Deserialize, Serialize)]
+struct BoolComponent(bool);

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use bevy::{ecs::entity::MapEntities, prelude::*, utils::Duration};
 use bevy_replicon::{
     client::{
-        confirm_history::{ConfirmHistory, HistoryConfirmed},
+        confirm_history::{ConfirmHistory, EntityReplicated},
         ServerChangeTick,
     },
     core::{
@@ -965,7 +965,7 @@ fn confirm_history() {
     // Clear previous events.
     client_app
         .world_mut()
-        .resource_mut::<Events<HistoryConfirmed>>()
+        .resource_mut::<Events<EntityReplicated>>()
         .clear();
 
     server_app.update();
@@ -980,10 +980,10 @@ fn confirm_history() {
         .single(client_app.world());
     assert!(confirm_history.contains(tick));
 
-    let mut history_events = client_app
+    let mut replicated_events = client_app
         .world_mut()
-        .resource_mut::<Events<HistoryConfirmed>>();
-    let [event] = history_events
+        .resource_mut::<Events<EntityReplicated>>();
+    let [event] = replicated_events
         .drain()
         .collect::<Vec<_>>()
         .try_into()

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -2,7 +2,10 @@ use std::io::Cursor;
 
 use bevy::{ecs::entity::MapEntities, prelude::*, utils::Duration};
 use bevy_replicon::{
-    client::{confirm_history::ConfirmHistory, ServerChangeTick},
+    client::{
+        confirm_history::{ConfirmHistory, HistoryConfirmed},
+        ServerChangeTick,
+    },
     core::{
         replication::{
             command_markers::MarkerConfig,
@@ -922,6 +925,71 @@ fn acknowledgment() {
         tick3.get(),
         "client shouldn't receive acked mutation"
     );
+}
+
+#[test]
+fn confirm_history() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<BoolComponent>();
+    }
+    client_app.finish();
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, BoolComponent(false)))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    // Change value.
+    let mut component = server_app
+        .world_mut()
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap();
+    component.0 = true;
+
+    // Clear previous events.
+    client_app
+        .world_mut()
+        .resource_mut::<Events<HistoryConfirmed>>()
+        .clear();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let tick = **server_app.world().resource::<ServerTick>();
+
+    let (client_entity, confirm_history) = client_app
+        .world_mut()
+        .query::<(Entity, &ConfirmHistory)>()
+        .single(client_app.world());
+    assert!(confirm_history.contains(tick));
+
+    let mut history_events = client_app
+        .world_mut()
+        .resource_mut::<Events<HistoryConfirmed>>();
+    let [event] = history_events
+        .drain()
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+    assert_eq!(event.entity, client_entity);
+    assert_eq!(event.tick, tick);
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use bevy::prelude::*;
 use bevy_replicon::{
-    client::confirm_history::{ConfirmHistory, HistoryConfirmed},
+    client::confirm_history::{ConfirmHistory, EntityReplicated},
     core::replication::{
         deferred_entity::DeferredEntity,
         replication_registry::{command_fns, ctx::WriteCtx, rule_fns::RuleFns},
@@ -420,7 +420,7 @@ fn confirm_history() {
     // Clear previous events.
     client_app
         .world_mut()
-        .resource_mut::<Events<HistoryConfirmed>>()
+        .resource_mut::<Events<EntityReplicated>>()
         .clear();
 
     server_app.update();
@@ -435,10 +435,10 @@ fn confirm_history() {
         .unwrap();
     assert!(confirm_history.contains(tick));
 
-    let mut history_events = client_app
+    let mut replicated_events = client_app
         .world_mut()
-        .resource_mut::<Events<HistoryConfirmed>>();
-    let [event] = history_events
+        .resource_mut::<Events<EntityReplicated>>();
+    let [event] = replicated_events
         .drain()
         .collect::<Vec<_>>()
         .try_into()


### PR DESCRIPTION
Implements the proposal from #338:

* `HistoryConfirmed` event for `ConfirmHistory`.
* `ServerMutateTicks` resource that provides an API similar to `HistoryConfirmed`, but for received mutate messages. To activate it, third-party crate needs to call `TrackAppExt::track_mutate_messages`. I decided on an app extension method to avoid require user to set it in the plugin. And not via resource since it's something that should be configured before the app starts.
* `MutateTickConfirmed` for the added `ServerMutateTicks`.

Requires #356, I will retarget to the master after the merge.