### PR TITLE
Expose replication groups at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Make `core::replication::replication_rules::ReplicationRules` available
+- Make `core::replication::replication_rules::ReplicationRules` public.
 - Various optimizations for replication messages to use fewer bytes.
 - Accept `Vec<u8>` instead of `Cursor<Vec<u8>>` for serialization.
 - `ConnectedClients` now store `ConnectedClient` instead of `ClientId` with more information about the client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RTT and packet loss information for `RepliconClient` and `ConnectedClients`.
-- Made `core::replication::replication_rules::ReplicationRules` available
 
 ### Changed
 
+- Make `core::replication::replication_rules::ReplicationRules` available
 - Various optimizations for replication messages to use fewer bytes.
 - Accept `Vec<u8>` instead of `Cursor<Vec<u8>>` for serialization.
 - `ConnectedClients` now store `ConnectedClient` instead of `ClientId` with more information about the client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RTT and packet loss information for `RepliconClient` and `ConnectedClients`.
+- Made `core::replication::replication_rules::ReplicationRules` available
 
 ### Changed
 

--- a/src/core/replication/replication_rules.rs
+++ b/src/core/replication/replication_rules.rs
@@ -195,7 +195,7 @@ impl AppRuleExt for App {
 
 /// All registered rules for components replication.
 #[derive(Default, Deref, Resource)]
-pub(crate) struct ReplicationRules(Vec<ReplicationRule>);
+pub struct ReplicationRules(Vec<ReplicationRule>);
 
 impl ReplicationRules {
     /// Inserts a new rule, maintaining sorting by their priority in descending order.


### PR DESCRIPTION
Closes #362 

This makes `core::replication::replication_rules::ReplicationRules` public.
Unpublished changes have already made the `ComponentId` publicly accessible (the removal of `FnsInfo` from a quick look), so there's no longer any change required.
