### PR TITLE
Do not send removals for hidden entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RTT, bytes per second and packet loss information for `RepliconClient` and `ConnectedClients`.
 - `ClientSet::Diagnostics` for systems that collect client diagnostics.
 
+### Fixed
+
+- Sending removals and despawns for hidden entities.
+
 ### Changed
 
 - Make `core::replication::replication_rules::ReplicationRules` public.

--- a/src/server.rs
+++ b/src/server.rs
@@ -294,7 +294,12 @@ impl ServerPlugin {
             &mut replicated_clients,
             &mut set.p5(),
         )?;
-        collect_removals(&mut messages, &mut serialized, &removal_buffer)?;
+        collect_removals(
+            &mut messages,
+            &mut serialized,
+            &replicated_clients,
+            &removal_buffer,
+        )?;
         collect_changes(
             &mut messages,
             &mut serialized,
@@ -441,14 +446,17 @@ fn collect_despawns(
 fn collect_removals(
     messages: &mut ReplicationMessages,
     serialized: &mut SerializedData,
+    replicated_clients: &ReplicatedClients,
     removal_buffer: &RemovalBuffer,
 ) -> bincode::Result<()> {
     for (&entity, remove_ids) in removal_buffer.iter() {
-        let entity = serialized.write_entity(entity)?;
+        let entity_range = serialized.write_entity(entity)?;
         let ids_len = remove_ids.len();
         let fn_ids = serialized.write_fn_ids(remove_ids.iter().map(|&(_, fns_id)| fns_id))?;
-        for (message, _) in messages.iter_mut() {
-            message.add_removals(entity.clone(), ids_len, fn_ids.clone());
+        for ((message, _), client) in messages.iter_mut().zip(replicated_clients.iter()) {
+            if client.visibility().is_visible(entity) {
+                message.add_removals(entity_range.clone(), ids_len, fn_ids.clone());
+            }
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -420,8 +420,7 @@ fn collect_despawns(
     for entity in despawn_buffer.drain(..) {
         let entity_range = serialized.write_entity(entity)?;
         for ((message, _), client) in messages.iter_mut().zip(replicated_clients.iter_mut()) {
-            let visibility = client.visibility().state(entity);
-            if visibility != Visibility::Hidden {
+            if client.visibility().is_visible(entity) {
                 message.add_despawn(entity_range.clone());
             }
             client.remove_despawned(entity);

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -489,6 +489,7 @@ fn hidden() {
         "client shouldn't know about hidden entity"
     );
 }
+
 #[derive(Component, Deserialize, Serialize)]
 struct DummyComponent;
 

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -378,6 +378,49 @@ fn with_despawn() {
     assert!(client_app.world().entities().is_empty());
 }
 
+#[test]
+fn hidden() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
+                ..Default::default()
+            }),
+        ))
+        .replicate::<DummyComponent>();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, DummyComponent))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .remove::<DummyComponent>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert!(
+        client_app.world().entities().is_empty(),
+        "client shouldn't know about hidden entity"
+    );
+}
+
 #[derive(Component, Deserialize, Serialize)]
 struct DummyComponent;
 


### PR DESCRIPTION
- Added a simple check and a test that now passes (fails without the fix).
- Added a similar test for despawns.
- Use `is_visible` helper for despawns.
