### PR TITLE
fix(client): diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Report bevy diagnostics correctly as a delta since last measurement collection.
+
 ## [0.29.0] - 2024-12-02
 
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -801,7 +801,7 @@ pub(super) struct BufferedMutate {
 ///
 /// See also [`ClientDiagnosticsPlugin`](diagnostics::ClientDiagnosticsPlugin)
 /// for automatic integration with Bevy diagnostics.
-#[derive(Default, Resource, Debug)]
+#[derive(Clone, Copy, Default, Resource, Debug)]
 pub struct ClientReplicationStats {
     /// Incremented per entity that changes.
     pub entities_changed: usize,

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -107,6 +107,7 @@ impl ClientDiagnosticsPlugin {
     fn add_measurements(
         mut diagnostics: Diagnostics,
         stats: Res<ClientReplicationStats>,
+        mut last_stats: Local<ClientReplicationStats>,
         client: Res<RepliconClient>,
     ) {
         diagnostics.add_measurement(&Self::RTT, || client.rtt());
@@ -114,13 +115,24 @@ impl ClientDiagnosticsPlugin {
         diagnostics.add_measurement(&Self::SENT_BPS, || client.sent_bps());
         diagnostics.add_measurement(&Self::RECEIVED_BPS, || client.received_bps());
 
-        diagnostics.add_measurement(&Self::ENTITIES_CHANGED, || stats.entities_changed as f64);
-        diagnostics.add_measurement(&Self::COMPONENTS_CHANGED, || {
-            stats.components_changed as f64
+        diagnostics.add_measurement(&Self::ENTITIES_CHANGED, || {
+            stats.entities_changed - last_stats.entities_changed as f64
         });
-        diagnostics.add_measurement(&Self::MAPPINGS, || stats.mappings as f64);
-        diagnostics.add_measurement(&Self::DESPAWNS, || stats.despawns as f64);
-        diagnostics.add_measurement(&Self::REPLICATION_MESSAGES, || stats.messages as f64);
-        diagnostics.add_measurement(&Self::REPLICATION_BYTES, || stats.bytes as f64);
+        diagnostics.add_measurement(&Self::COMPONENTS_CHANGED, || {
+            stats.components_changed - last_stats.components_changed as f64
+        });
+        diagnostics.add_measurement(&Self::MAPPINGS, || {
+            stats.mappings - last_stats.mappings as f64
+        });
+        diagnostics.add_measurement(&Self::DESPAWNS, || {
+            stats.despawns - last_stats.despawns as f64
+        });
+        diagnostics.add_measurement(&Self::REPLICATION_MESSAGES, || {
+            stats.messages - last_stats.messages as f64
+        });
+        diagnostics.add_measurement(&Self::REPLICATION_BYTES, || {
+            stats.bytes - last_stats.bytes as f64
+        });
+        *last_stats = *stats;
     }
 }

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -116,22 +116,22 @@ impl ClientDiagnosticsPlugin {
         diagnostics.add_measurement(&Self::RECEIVED_BPS, || client.received_bps());
 
         diagnostics.add_measurement(&Self::ENTITIES_CHANGED, || {
-            stats.entities_changed - last_stats.entities_changed as f64
+            (stats.entities_changed - last_stats.entities_changed) as f64
         });
         diagnostics.add_measurement(&Self::COMPONENTS_CHANGED, || {
-            stats.components_changed - last_stats.components_changed as f64
+            (stats.components_changed - last_stats.components_changed) as f64
         });
         diagnostics.add_measurement(&Self::MAPPINGS, || {
-            stats.mappings - last_stats.mappings as f64
+            (stats.mappings - last_stats.mappings) as f64
         });
         diagnostics.add_measurement(&Self::DESPAWNS, || {
-            stats.despawns - last_stats.despawns as f64
+            (stats.despawns - last_stats.despawns) as f64
         });
         diagnostics.add_measurement(&Self::REPLICATION_MESSAGES, || {
-            stats.messages - last_stats.messages as f64
+            (stats.messages - last_stats.messages) as f64
         });
         diagnostics.add_measurement(&Self::REPLICATION_BYTES, || {
-            stats.bytes - last_stats.bytes as f64
+            (stats.bytes - last_stats.bytes) as f64
         });
         *last_stats = *stats;
     }


### PR DESCRIPTION
Bevy diagnostics (measurements) should only record the change in the value since the last time the measurements were collected. _Not_ the life-time total to my understanding. Using current implementation with bevy's `LogDiagnosticsPlugin` results in logs such as:
```
2024-12-15T21:42:03.238223Z  INFO bevy diagnostic: client/replication/components_changed: 14058.416209 components changed (avg 14005.266667 components changed)
```
with ever-increasing number.