### PR TITLE
Export `core::entity_serde` with custom serde functions for entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `core::entity_serde` with custom serde functions for entity.
+
 ### Changed
 
 - `StartReplication` is now a trigger-event.

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,7 @@
 pub mod channels;
 pub mod common_conditions;
 pub mod connected_clients;
+pub mod entity_serde;
 pub mod event;
 pub mod replication;
 pub mod replicon_client;

--- a/src/core/entity_serde.rs
+++ b/src/core/entity_serde.rs
@@ -1,0 +1,42 @@
+//! Custom serialization for entity to pack it more efficiently.
+
+use bevy::prelude::*;
+use integer_encoding::{VarIntReader, VarIntWriter};
+
+/// Deserializes `entity` from compressed index and generation.
+///
+/// For details see [`serialize_entity`].
+pub fn deserialize_entity(reader: &mut impl VarIntReader) -> bincode::Result<Entity> {
+    let flagged_index: u64 = reader.read_varint()?;
+    let has_generation = (flagged_index & 1) > 0;
+    let generation = if has_generation {
+        reader.read_varint::<u32>()? + 1
+    } else {
+        1u32
+    };
+
+    let bits = (generation as u64) << 32 | (flagged_index >> 1);
+
+    Ok(Entity::from_bits(bits))
+}
+
+/// Serializes `entity` by writing its index and generation as separate varints.
+///
+/// The index is first prepended with a bit flag to indicate if the generation
+/// is serialized or not. It is not serialized if <= 1; note that generations are [`NonZeroU32`](std::num::NonZeroU32)
+/// and a value of zero is used in [`Option<Entity>`] to signify [`None`], so generation 1 is the first
+/// generation.
+///
+/// See also [`deserialize_entity`].
+pub fn serialize_entity(writer: &mut impl VarIntWriter, entity: Entity) -> bincode::Result<()> {
+    let mut flagged_index = (entity.index() as u64) << 1;
+    let flag = entity.generation() > 1;
+    flagged_index |= flag as u64;
+
+    writer.write_varint(flagged_index)?;
+    if flag {
+        writer.write_varint(entity.generation() - 1)?;
+    }
+
+    Ok(())
+}

--- a/src/server/replication_messages/serialized_data.rs
+++ b/src/server/replication_messages/serialized_data.rs
@@ -2,10 +2,10 @@ use std::ops::Range;
 
 use bevy::{prelude::*, ptr::Ptr};
 use bincode::{DefaultOptions, Options};
-use integer_encoding::VarIntWriter;
 
 use crate::{
     core::{
+        entity_serde,
         replication::replication_registry::{
             component_fns::ComponentFns, ctx::SerializeCtx, rule_fns::UntypedRuleFns, FnsId,
         },
@@ -81,14 +81,7 @@ impl SerializedData {
     pub(crate) fn write_entity(&mut self, entity: Entity) -> bincode::Result<Range<usize>> {
         let start = self.len();
 
-        let mut flagged_index = (entity.index() as u64) << 1;
-        let flag = entity.generation() > 1;
-        flagged_index |= flag as u64;
-
-        self.0.write_varint(flagged_index)?;
-        if flag {
-            self.0.write_varint(entity.generation() - 1)?;
-        }
+        entity_serde::serialize_entity(&mut self.0, entity)?;
 
         let end = self.len();
 


### PR DESCRIPTION
Looks nicer when placed in a single module. Also I need them for the upcoming networking triggers. I made them public since users might need them if they serialize manually.