### PR TITLE
Move `check_type` to upper functions

### DIFF
--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -270,6 +270,8 @@ impl ClientEvent {
         reader: PtrMut,
         client: &mut RepliconClient,
     ) {
+        self.check_type::<E>();
+
         let reader: &mut ClientEventReader<E> = reader.deref_mut();
         for event in reader.read(events.deref()) {
             let mut message = Vec::new();
@@ -308,6 +310,8 @@ impl ClientEvent {
         events: PtrMut,
         server: &mut RepliconServer,
     ) {
+        self.check_type::<E>();
+
         let events: &mut Events<FromClient<E>> = events.deref_mut();
         for (client_id, message) in server.receive(self.channel_id) {
             let mut cursor = Cursor::new(&*message);
@@ -391,7 +395,6 @@ impl ClientEvent {
         event: &E,
         message: &mut Vec<u8>,
     ) -> bincode::Result<()> {
-        self.check_type::<E>();
         let serialize: SerializeFn<E> = std::mem::transmute(self.serialize);
         (serialize)(ctx, event, message)
     }
@@ -406,7 +409,6 @@ impl ClientEvent {
         ctx: &mut ServerReceiveCtx,
         cursor: &mut Cursor<&[u8]>,
     ) -> bincode::Result<E> {
-        self.check_type::<E>();
         let deserialize: DeserializeFn<E> = std::mem::transmute(self.deserialize);
         (deserialize)(ctx, cursor)
     }

--- a/src/core/event/server_event.rs
+++ b/src/core/event/server_event.rs
@@ -339,6 +339,8 @@ impl ServerEvent {
         connected_clients: &ConnectedClients,
         buffered_events: &mut BufferedServerEvents,
     ) {
+        self.check_type::<E>();
+
         let events: &Events<ToClients<E>> = server_events.deref();
         // For server events we don't track read events because
         // all of them will always be drained in the local resending system.
@@ -468,6 +470,8 @@ impl ServerEvent {
         client: &mut RepliconClient,
         update_tick: RepliconTick,
     ) {
+        self.check_type::<E>();
+
         let events: &mut Events<E> = events.deref_mut();
         let queue: &mut ServerEventQueue<E> = queue.deref_mut();
 
@@ -603,7 +607,6 @@ impl ServerEvent {
         event: &E,
         message: &mut Vec<u8>,
     ) -> bincode::Result<()> {
-        self.check_type::<E>();
         let serialize: SerializeFn<E> = std::mem::transmute(self.serialize);
         (serialize)(ctx, event, message)
     }
@@ -618,7 +621,6 @@ impl ServerEvent {
         ctx: &mut ClientReceiveCtx,
         cursor: &mut Cursor<&[u8]>,
     ) -> bincode::Result<E> {
-        self.check_type::<E>();
         let deserialize: DeserializeFn<E> = std::mem::transmute(self.deserialize);
         let event = (deserialize)(ctx, cursor);
         if ctx.invalid_entities.is_empty() {


### PR DESCRIPTION
Call it only at the top level `_typed` functions.
I think it makes more sense then debug-check it at each serialize/deserialize call.