### PR TITLE
Construct event systems dynamically

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -1,4 +1,7 @@
-use bevy::prelude::*;
+use bevy::{
+    ecs::system::{FilteredResourcesMutParamBuilder, FilteredResourcesParamBuilder, ParamBuilder},
+    prelude::*,
+};
 
 use super::{server_tick::ServerTick, ServerPlugin, ServerSet};
 use crate::core::{
@@ -20,116 +23,158 @@ use crate::core::{
 pub struct ServerEventPlugin;
 
 impl Plugin for ServerEventPlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(
-            PreUpdate,
-            Self::receive
-                .in_set(ServerSet::Receive)
-                .run_if(server_running),
+    fn build(&self, _app: &mut App) {}
+
+    fn finish(&self, app: &mut App) {
+        // Construct systems dynamically after all plugins initialization
+        // because we need to access resources by registered IDs.
+        let event_registry = app
+            .world_mut()
+            .remove_resource::<EventRegistry>()
+            .expect("event registry should be initialized on app build");
+
+        let send_or_buffer = (
+            FilteredResourcesParamBuilder::new(|builder| {
+                for event in event_registry.iter_server_events() {
+                    builder.add_read_by_id(event.server_events_id());
+                }
+            }),
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
         )
-        .add_systems(
-            PostUpdate,
-            (
-                Self::send_or_buffer.run_if(server_running),
-                Self::send_buffered
-                    .run_if(server_running)
-                    .run_if(resource_changed::<ServerTick>),
-                Self::resend_locally.run_if(server_or_singleplayer),
+            .build_state(app.world_mut())
+            .build_system(Self::send_or_buffer);
+
+        let receive = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for event in event_registry.iter_client_events() {
+                    builder.add_write_by_id(event.client_events_id());
+                }
+            }),
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(Self::receive);
+
+        let resend_locally = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for event in event_registry.iter_server_events() {
+                    builder.add_write_by_id(event.server_events_id());
+                }
+            }),
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for event in event_registry.iter_server_events() {
+                    builder.add_write_by_id(event.events_id());
+                }
+            }),
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(Self::resend_locally);
+
+        app.insert_resource(event_registry)
+            .add_systems(
+                PreUpdate,
+                receive.in_set(ServerSet::Receive).run_if(server_running),
             )
-                .chain()
-                .after(ServerPlugin::send_replication)
-                .in_set(ServerSet::Send),
-        );
+            .add_systems(
+                PostUpdate,
+                (
+                    send_or_buffer.run_if(server_running),
+                    Self::send_buffered
+                        .run_if(server_running)
+                        .run_if(resource_changed::<ServerTick>),
+                    resend_locally.run_if(server_or_singleplayer),
+                )
+                    .chain()
+                    .after(ServerPlugin::send_replication)
+                    .in_set(ServerSet::Send),
+            );
     }
 }
 
 impl ServerEventPlugin {
-    fn send_or_buffer(world: &mut World) {
-        world.resource_scope(|world, mut server: Mut<RepliconServer>| {
-            world.resource_scope(|world, mut buffered_events: Mut<BufferedServerEvents>| {
-                let registry = world.resource::<AppTypeRegistry>();
-                let mut ctx = ServerSendCtx {
-                    registry: &registry.read(),
-                };
-                let connected_clients = world.resource::<ConnectedClients>();
-                let event_registry = world.resource::<EventRegistry>();
+    fn send_or_buffer(
+        server_events: FilteredResources,
+        mut server: ResMut<RepliconServer>,
+        mut buffered_events: ResMut<BufferedServerEvents>,
+        registry: Res<AppTypeRegistry>,
+        connected_clients: Res<ConnectedClients>,
+        event_registry: Res<EventRegistry>,
+    ) {
+        buffered_events.start_tick();
+        let mut ctx = ServerSendCtx {
+            registry: &registry.read(),
+        };
 
-                buffered_events.start_tick();
+        for event_data in event_registry.iter_server_events() {
+            let server_events = server_events
+                .get_by_id(event_data.server_events_id())
+                .expect("server events resource should be accessible");
 
-                for event_data in event_registry.iter_server_events() {
-                    let server_events = world
-                        .get_resource_by_id(event_data.server_events_id())
-                        .expect("server events shouldn't be removed");
-
-                    // SAFETY: passed pointer was obtained using this event data.
-                    unsafe {
-                        event_data.send_or_buffer(
-                            &mut ctx,
-                            &server_events,
-                            &mut server,
-                            connected_clients,
-                            &mut buffered_events,
-                        );
-                    }
-                }
-            });
-        });
-    }
-
-    fn send_buffered(world: &mut World) {
-        world.resource_scope(|world, mut server: Mut<RepliconServer>| {
-            world.resource_scope(|world, mut buffered_events: Mut<BufferedServerEvents>| {
-                let replicated_clients = world.resource::<ReplicatedClients>();
-                buffered_events
-                    .send_all(&mut server, replicated_clients)
-                    .expect("buffered server events should send");
-            });
-        });
-    }
-
-    fn receive(world: &mut World) {
-        world.resource_scope(|world, mut server: Mut<RepliconServer>| {
-            world.resource_scope(|world, registry: Mut<AppTypeRegistry>| {
-                world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
-                    let mut ctx = ServerReceiveCtx {
-                        registry: &registry.read(),
-                    };
-
-                    for event_data in event_registry.iter_client_events() {
-                        let client_events = world
-                            .get_resource_mut_by_id(event_data.client_events_id())
-                            .expect("client events shouldn't be removed");
-
-                        // SAFETY: passed pointer was obtained using this event data.
-                        unsafe {
-                            event_data.receive(&mut ctx, client_events.into_inner(), &mut server)
-                        };
-                    }
-                });
-            });
-        });
-    }
-
-    fn resend_locally(world: &mut World) {
-        world.resource_scope(|world, event_registry: Mut<EventRegistry>| {
-            let world_cell = world.as_unsafe_world_cell();
-            for event_data in event_registry.iter_server_events() {
-                // SAFETY: both resources mutably borrowed uniquely.
-                let (server_events, events) = unsafe {
-                    let server_events = world_cell
-                        .get_resource_mut_by_id(event_data.server_events_id())
-                        .expect("server events shouldn't be removed");
-                    let events = world_cell
-                        .get_resource_mut_by_id(event_data.events_id())
-                        .expect("events shouldn't be removed");
-                    (server_events, events)
-                };
-
-                // SAFETY: passed pointers were obtained using this event data.
-                unsafe {
-                    event_data.resend_locally(server_events.into_inner(), events.into_inner())
-                };
+            // SAFETY: passed pointer was obtained using this event data.
+            unsafe {
+                event_data.send_or_buffer(
+                    &mut ctx,
+                    &server_events,
+                    &mut server,
+                    &connected_clients,
+                    &mut buffered_events,
+                );
             }
-        });
+        }
+    }
+
+    fn send_buffered(
+        mut server: ResMut<RepliconServer>,
+        mut buffered_events: ResMut<BufferedServerEvents>,
+        replicated_clients: Res<ReplicatedClients>,
+    ) {
+        buffered_events
+            .send_all(&mut server, &replicated_clients)
+            .expect("buffered server events should send");
+    }
+
+    fn receive(
+        mut client_events: FilteredResourcesMut,
+        mut server: ResMut<RepliconServer>,
+        registry: Res<AppTypeRegistry>,
+        event_registry: Res<EventRegistry>,
+    ) {
+        let mut ctx = ServerReceiveCtx {
+            registry: &registry.read(),
+        };
+
+        for event_data in event_registry.iter_client_events() {
+            let client_events = client_events
+                .get_mut_by_id(event_data.client_events_id())
+                .expect("client events shouldn't be removed");
+
+            // SAFETY: passed pointer was obtained using this event data.
+            unsafe { event_data.receive(&mut ctx, client_events.into_inner(), &mut server) };
+        }
+    }
+
+    fn resend_locally(
+        mut server_events: FilteredResourcesMut,
+        mut events: FilteredResourcesMut,
+        event_registry: Res<EventRegistry>,
+    ) {
+        for event_data in event_registry.iter_server_events() {
+            let server_events = server_events
+                .get_mut_by_id(event_data.server_events_id())
+                .expect("server events shouldn't be removed");
+            let events = events
+                .get_mut_by_id(event_data.events_id())
+                .expect("events shouldn't be removed");
+
+            // SAFETY: passed pointers were obtained using this event data.
+            unsafe { event_data.resend_locally(server_events.into_inner(), events.into_inner()) };
+        }
     }
 }

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -14,7 +14,8 @@ fn sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, RepliconPlugins))
-            .add_client_event::<DummyEvent>(ChannelKind::Ordered);
+            .add_client_event::<DummyEvent>(ChannelKind::Ordered)
+            .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -37,7 +38,8 @@ fn mapping_and_sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, RepliconPlugins))
-            .add_mapped_client_event::<MappedEvent>(ChannelKind::Ordered);
+            .add_mapped_client_event::<MappedEvent>(ChannelKind::Ordered)
+            .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -78,7 +80,8 @@ fn sending_receiving_without_plugins() {
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
-        .add_client_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_client_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     client_app
         .add_plugins((
             MinimalPlugins,
@@ -87,7 +90,8 @@ fn sending_receiving_without_plugins() {
                 .disable::<ServerPlugin>()
                 .disable::<ServerEventPlugin>(),
         ))
-        .add_client_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_client_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
 
     server_app.connect_client(&mut client_app);
 
@@ -107,7 +111,8 @@ fn sending_receiving_without_plugins() {
 fn local_resending() {
     let mut app = App::new();
     app.add_plugins((TimePlugin, RepliconPlugins))
-        .add_client_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_client_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
 
     app.world_mut().send_event(DummyEvent);
 

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -21,7 +21,8 @@ fn sending_receiving() {
                 ..Default::default()
             }),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -67,7 +68,8 @@ fn sending_receiving_and_mapping() {
                 ..Default::default()
             }),
         ))
-        .add_mapped_server_event::<EntityEvent>(ChannelKind::Ordered);
+        .add_mapped_server_event::<EntityEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -113,7 +115,8 @@ fn sending_receiving_without_plugins() {
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     client_app
         .add_plugins((
             MinimalPlugins,
@@ -122,7 +125,8 @@ fn sending_receiving_without_plugins() {
                 .disable::<ServerPlugin>()
                 .disable::<ServerEventPlugin>(),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
 
     server_app.connect_client(&mut client_app);
 
@@ -165,7 +169,8 @@ fn local_resending() {
             ..Default::default()
         }),
     ))
-    .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+    .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+    .finish();
 
     const DUMMY_CLIENT_ID: ClientId = ClientId::new(1);
     for (mode, events_count) in [
@@ -206,7 +211,8 @@ fn event_buffering() {
                 ..Default::default()
             }),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -251,7 +257,8 @@ fn event_queue() {
                 ..Default::default()
             }),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -300,7 +307,8 @@ fn event_queue_and_mapping() {
                 ..Default::default()
             }),
         ))
-        .add_server_event::<EntityEvent>(ChannelKind::Ordered);
+        .add_server_event::<EntityEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -361,7 +369,8 @@ fn multiple_event_queues() {
             }),
         ))
         .add_server_event::<DummyEvent>(ChannelKind::Ordered)
-        .add_server_event::<EntityEvent>(ChannelKind::Ordered); // Use as a regular event with a different serialization size.
+        .add_server_event::<EntityEvent>(ChannelKind::Ordered) // Use as a regular event with a different serialization size.
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -422,7 +431,8 @@ fn independent() {
             }),
         ))
         .add_server_event::<DummyEvent>(ChannelKind::Ordered)
-        .make_independent::<DummyEvent>();
+        .make_independent::<DummyEvent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -484,7 +494,8 @@ fn before_started_replication() {
                 ..Default::default()
             }),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -520,7 +531,8 @@ fn independent_before_started_replication() {
             }),
         ))
         .add_server_event::<DummyEvent>(ChannelKind::Ordered)
-        .make_independent::<DummyEvent>();
+        .make_independent::<DummyEvent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -554,7 +566,8 @@ fn different_ticks() {
                 ..Default::default()
             }),
         ))
-        .add_server_event::<DummyEvent>(ChannelKind::Ordered);
+        .add_server_event::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
     }
 
     // Connect client 1 first.


### PR DESCRIPTION
To avoid creating several systems for each event type, we store the IDs of all event resources and process them at once.
This is similar to what Bevy does.
However, since we need access to resources by their IDs, we used exclusive systems with a lot of `resource_scope`.
Now, we can utilize `FilteredResources` and `FilteredResourcesMut` to define the required access and get rid of exclusive systems!