### PR TITLE
Accept `Into<RepliconChannel>` for channel creation for `RepliconChannel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `StartReplication` is now a trigger-event.
 - `ServerEvent` is now a trigger-event.
 - Event serialization functions now accept `&mut Vec<u8>` instead of `&mut Cursor<Vec<u8>>`.
+- `RepliconChannels::create_server_channel` and `RepliconChannels::create_client_channel` not accept `impl Into<RepliconChannel>` instead of just `RepliconChannel`.
 - Use `debug!` instead of `trace!` for events. They are not very verbose.
 - Rename `ServerEvent::SendEvents` into `ServerEvent::TriggerServerEvents`.
 - Rename `core::event_registry` into `core::event`.

--- a/src/core/channels.rs
+++ b/src/core/channels.rs
@@ -76,12 +76,12 @@ impl RepliconChannels {
     /// # Panics
     ///
     /// Panics if the number of events exceeds [`u8::MAX`].
-    pub fn create_server_channel(&mut self, channel: RepliconChannel) -> u8 {
+    pub fn create_server_channel(&mut self, channel: impl Into<RepliconChannel>) -> u8 {
         if self.server.len() == u8::MAX as usize {
             panic!("number of server channels shouldn't exceed `u8::MAX`");
         }
 
-        self.server.push(channel);
+        self.server.push(channel.into());
         let id = self.server.len() as u8 - 1;
         debug!("creating a server channel with ID {id}");
 
@@ -93,12 +93,12 @@ impl RepliconChannels {
     /// # Panics
     ///
     /// Panics if the number of events exceeds [`u8::MAX`].
-    pub fn create_client_channel(&mut self, channel: RepliconChannel) -> u8 {
+    pub fn create_client_channel(&mut self, channel: impl Into<RepliconChannel>) -> u8 {
         if self.client.len() == u8::MAX as usize {
             panic!("number of client channels shouldn't exceed `u8::MAX`");
         }
 
-        self.client.push(channel);
+        self.client.push(channel.into());
         let id = self.client.len() as u8 - 1;
         debug!("creating a client channel with ID {id}");
 

--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -139,7 +139,7 @@ impl ClientEventAppExt for App {
         let channel_id = self
             .world_mut()
             .resource_mut::<RepliconChannels>()
-            .create_client_channel(channel.into());
+            .create_client_channel(channel);
 
         self.world_mut()
             .resource_scope(|world, mut event_registry: Mut<EventRegistry>| {

--- a/src/core/event/server_event.rs
+++ b/src/core/event/server_event.rs
@@ -165,7 +165,7 @@ impl ServerEventAppExt for App {
         let channel_id = self
             .world_mut()
             .resource_mut::<RepliconChannels>()
-            .create_server_channel(channel.into());
+            .create_server_channel(channel);
 
         self.world_mut()
             .resource_scope(|world, mut event_registry: Mut<EventRegistry>| {


### PR DESCRIPTION
For consistency with other places. Also more convenient.