### PR TITLE
Minor `make_independent` refactor

### DIFF
--- a/src/core/event/event_registry.rs
+++ b/src/core/event/event_registry.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::component::ComponentId, prelude::*};
+use bevy::prelude::*;
 
 use super::{client_event::ClientEvent, server_event::ServerEvent};
 
@@ -18,15 +18,8 @@ impl EventRegistry {
         self.client.push(event_data);
     }
 
-    pub(super) fn make_independent(&mut self, events_id: ComponentId) {
-        let event = self
-            .server
-            .iter_mut()
-            .find(|event| event.events_id() == events_id)
-            .unwrap_or_else(|| {
-                panic!("event with ID {events_id:?} should be previously registered");
-            });
-        event.make_independent();
+    pub(crate) fn iter_server_events_mut(&mut self) -> impl Iterator<Item = &mut ServerEvent> {
+        self.server.iter_mut()
     }
 
     pub(crate) fn iter_server_events(&self) -> impl Iterator<Item = &ServerEvent> {


### PR DESCRIPTION
- Remove unnecessary `resource_scope`.
- Move iteration logic inside the extension trait to provide nicer error message and change the field directly.