### PR TITLE
Implement remote triggers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ all-features = true
 
 [dependencies]
 bevy = { version = "0.15", default-features = false, features = ["serialize"] }
+typeid = "1.0"
 bytes = "1.5"
 bincode = "1.3"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ name = "client_event"
 required-features = ["client", "server"]
 
 [[test]]
+name = "client_trigger"
+required-features = ["client", "server"]
+
+[[test]]
 name = "connection"
 required-features = ["client", "server"]
 
@@ -101,6 +105,10 @@ required-features = ["scene"]
 
 [[test]]
 name = "server_event"
+required-features = ["client", "server"]
+
+[[test]]
+name = "server_trigger"
 required-features = ["client", "server"]
 
 [[test]]

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,4 +1,23 @@
 pub mod client_event;
+pub mod client_trigger;
 pub mod ctx;
+pub mod event_fns;
 pub(crate) mod event_registry;
 pub mod server_event;
+pub mod server_trigger;
+
+use bevy::prelude::*;
+
+/// An event that used under the hood for client and server triggers.
+///
+/// We can't just observe for triggers like we do for events since we need access to all its targets
+/// and we need to buffer them. This is why we just emit this event instead and after receive drain it
+/// to trigger regular events.
+///
+/// Traditional trigger interface is provided by [`ClientTriggerExt`](client_trigger::ClientTriggerExt)
+/// and [`ServerTriggerExt`](server_trigger::ServerTriggerExt).
+#[derive(Event)]
+struct RemoteTrigger<E> {
+    event: E,
+    targets: Vec<Entity>,
+}

--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -26,8 +26,8 @@ pub trait ClientEventAppExt {
     ///
     /// The API matches [`ClientTriggerAppExt::add_client_trigger`](super::client_trigger::ClientTriggerAppExt::add_client_trigger):
     /// [`FromClient<E>`] will be emitted on the server after sending `E` event on client.
-    /// When [`RepliconClient`](crate::core::replicon_client::RepliconClient) is inactive, the event
-    /// will be drained right after sending and re-emitted locally as [`FromClient<E>`] with [`ClientId::SERVER`](crate::core::ClientId::SERVER).
+    /// When [`RepliconClient`] is inactive, the event will be drained right after sending and re-emitted
+    /// locally as [`FromClient<E>`] with [`ClientId::SERVER`](crate::core::ClientId::SERVER).
     ///
     /// Can be called for events that were registered with [add_event](bevy::app::App::add_event).
     /// A duplicate registration for `E` won't be created.

--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -1,15 +1,7 @@
-use std::{
-    any::{self, TypeId},
-    io::Cursor,
-    mem,
-};
+use std::{any, io::Cursor};
 
 use bevy::{
-    ecs::{
-        component::{ComponentId, Components},
-        entity::MapEntities,
-        event::EventCursor,
-    },
+    ecs::{component::ComponentId, entity::MapEntities, event::EventCursor},
     prelude::*,
     ptr::{Ptr, PtrMut},
 };
@@ -18,6 +10,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::{
     ctx::{ClientSendCtx, ServerReceiveCtx},
+    event_fns::{EventDeserializeFn, EventFns, EventSerializeFn, UntypedEventFns},
     event_registry::EventRegistry,
 };
 use crate::core::{
@@ -31,9 +24,10 @@ use crate::core::{
 pub trait ClientEventAppExt {
     /// Registers [`FromClient<E>`] and `E` events.
     ///
+    /// The API matches [`ClientTriggerAppExt::add_client_trigger`](super::client_trigger::ClientTriggerAppExt::add_client_trigger):
     /// [`FromClient<E>`] will be emitted on the server after sending `E` event on client.
-    /// In listen-server mode `E` will be drained right after sending and re-emitted as
-    /// [`FromClient<E>`] with [`ClientId::SERVER`](crate::core::ClientId::SERVER).
+    /// When [`RepliconClient`](crate::core::replicon_client::RepliconClient) is inactive, the event
+    /// will be drained right after sending and re-emitted locally as [`FromClient<E>`] with [`ClientId::SERVER`](crate::core::ClientId::SERVER).
     ///
     /// Can be called for events that were registered with [add_event](bevy::app::App::add_event).
     /// A duplicate registration for `E` won't be created.
@@ -52,7 +46,6 @@ pub trait ClientEventAppExt {
     /// Same as [`Self::add_client_event`], but additionally maps client entities to server inside the event before sending.
     ///
     /// Always use it for events that contain entities.
-    /// See also [`Self::add_client_event`].
     fn add_mapped_client_event<E: Event + Serialize + DeserializeOwned + MapEntities + Clone>(
         &mut self,
         channel: impl Into<RepliconChannel>,
@@ -66,6 +59,8 @@ pub trait ClientEventAppExt {
 
     /**
     Same as [`Self::add_client_event`], but uses the specified functions for serialization and deserialization.
+
+    See also [`ClientTriggerAppExt::add_client_trigger`](super::client_trigger::ClientTriggerAppExt::add_client_trigger).
 
     # Examples
 
@@ -118,8 +113,8 @@ pub trait ClientEventAppExt {
     fn add_client_event_with<E: Event>(
         &mut self,
         channel: impl Into<RepliconChannel>,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
+        serialize: EventSerializeFn<ClientSendCtx, E>,
+        deserialize: EventDeserializeFn<ServerReceiveCtx, E>,
     ) -> &mut Self;
 }
 
@@ -127,29 +122,15 @@ impl ClientEventAppExt for App {
     fn add_client_event_with<E: Event>(
         &mut self,
         channel: impl Into<RepliconChannel>,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
+        serialize: EventSerializeFn<ClientSendCtx, E>,
+        deserialize: EventDeserializeFn<ServerReceiveCtx, E>,
     ) -> &mut Self {
         debug!("registering event `{}`", any::type_name::<E>());
 
-        self.add_event::<E>()
-            .add_event::<FromClient<E>>()
-            .init_resource::<ClientEventReader<E>>();
-
-        let channel_id = self
-            .world_mut()
-            .resource_mut::<RepliconChannels>()
-            .create_client_channel(channel);
-
-        self.world_mut()
-            .resource_scope(|world, mut event_registry: Mut<EventRegistry>| {
-                event_registry.register_client_event(ClientEvent::new(
-                    world.components(),
-                    channel_id,
-                    serialize,
-                    deserialize,
-                ));
-            });
+        let event_fns = EventFns::new(serialize, deserialize);
+        let event = ClientEvent::new(self, channel, event_fns);
+        let mut event_registry = self.world_mut().resource_mut::<EventRegistry>();
+        event_registry.register_client_event(event);
 
         self
     }
@@ -159,16 +140,13 @@ impl ClientEventAppExt for App {
 ///
 /// Needed so events of different types can be processed together.
 pub(crate) struct ClientEvent {
-    event_id: TypeId,
-    event_name: &'static str,
-
     /// ID of [`Events<E>`] resource.
     events_id: ComponentId,
 
     /// ID of [`ClientEventReader<E>`] resource.
     reader_id: ComponentId,
 
-    /// ID of [`Events<ToClients<E>>`] resource.
+    /// ID of [`Events<FromClient<E>>`] resource.
     client_events_id: ComponentId,
 
     /// Used channel.
@@ -178,54 +156,38 @@ pub(crate) struct ClientEvent {
     receive: ReceiveFn,
     resend_locally: ResendLocallyFn,
     reset: ResetFn,
-    serialize: unsafe fn(),
-    deserialize: unsafe fn(),
+    event_fns: UntypedEventFns,
 }
 
 impl ClientEvent {
-    fn new<E: Event>(
-        components: &Components,
-        channel_id: u8,
-        serialize: SerializeFn<E>,
-        deserialize: DeserializeFn<E>,
+    pub(super) fn new<E: Event, I: 'static>(
+        app: &mut App,
+        channel: impl Into<RepliconChannel>,
+        event_fns: EventFns<ClientSendCtx, ServerReceiveCtx, E, I>,
     ) -> Self {
-        let events_id = components.resource_id::<Events<E>>().unwrap_or_else(|| {
-            panic!(
-                "event `{}` should be previously registered",
-                any::type_name::<E>()
-            )
-        });
-        let client_events_id = components
-            .resource_id::<Events<FromClient<E>>>()
-            .unwrap_or_else(|| {
-                panic!(
-                    "event `{}` should be previously registered",
-                    any::type_name::<FromClient<E>>()
-                )
-            });
-        let reader_id = components
-            .resource_id::<ClientEventReader<E>>()
-            .unwrap_or_else(|| {
-                panic!(
-                    "resource `{}` should be previously inserted",
-                    any::type_name::<ClientEventReader<E>>()
-                )
-            });
+        let channel_id = app
+            .world_mut()
+            .resource_mut::<RepliconChannels>()
+            .create_client_channel(channel);
+
+        app.add_event::<E>()
+            .add_event::<FromClient<E>>()
+            .init_resource::<ClientEventReader<E>>();
+
+        let events_id = app.world().resource_id::<Events<E>>().unwrap();
+        let client_events_id = app.world().resource_id::<Events<FromClient<E>>>().unwrap();
+        let reader_id = app.world().resource_id::<ClientEventReader<E>>().unwrap();
 
         Self {
-            event_id: TypeId::of::<E>(),
-            event_name: any::type_name::<E>(),
             events_id,
             reader_id,
             client_events_id,
             channel_id,
-            send: Self::send_typed::<E>,
-            receive: Self::receive_typed::<E>,
+            send: Self::send_typed::<E, I>,
+            receive: Self::receive_typed::<E, I>,
             resend_locally: Self::resend_locally_typed::<E>,
             reset: Self::reset_typed::<E>,
-            // SAFETY: these functions won't be called until the type is restored.
-            serialize: unsafe { mem::transmute::<SerializeFn<E>, unsafe fn()>(serialize) },
-            deserialize: unsafe { mem::transmute::<DeserializeFn<E>, unsafe fn()>(deserialize) },
+            event_fns: event_fns.into(),
         }
     }
 
@@ -261,21 +223,19 @@ impl ClientEvent {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `events` is [`Events<FromClient<E>>`], `reader` is [`ClientEventReader<E>`],
-    /// and this instance was created for `E`.
-    unsafe fn send_typed<E: Event>(
+    /// The caller must ensure that `events` is [`Events<E>`], `reader` is [`ClientEventReader<E>`],
+    /// and this instance was created for `E` and `I`.
+    unsafe fn send_typed<E: Event, I: 'static>(
         &self,
         ctx: &mut ClientSendCtx,
         events: &Ptr,
         reader: PtrMut,
         client: &mut RepliconClient,
     ) {
-        self.check_type::<E>();
-
         let reader: &mut ClientEventReader<E> = reader.deref_mut();
         for event in reader.read(events.deref()) {
             let mut message = Vec::new();
-            self.serialize(ctx, event, &mut message)
+            self.serialize::<E, I>(ctx, event, &mut message)
                 .expect("client event should be serializable");
 
             debug!("sending event `{}`", any::type_name::<E>());
@@ -303,25 +263,23 @@ impl ClientEvent {
     /// # Safety
     ///
     /// The caller must ensure that `client_events` is [`Events<FromClient<E>>`]
-    /// and this instance was created for `E`.
-    unsafe fn receive_typed<E: Event>(
+    /// and this instance was created for `E` and `I`.
+    unsafe fn receive_typed<E: Event, I: 'static>(
         &self,
         ctx: &mut ServerReceiveCtx,
-        events: PtrMut,
+        client_events: PtrMut,
         server: &mut RepliconServer,
     ) {
-        self.check_type::<E>();
-
-        let events: &mut Events<FromClient<E>> = events.deref_mut();
+        let client_events: &mut Events<FromClient<E>> = client_events.deref_mut();
         for (client_id, message) in server.receive(self.channel_id) {
             let mut cursor = Cursor::new(&*message);
-            match self.deserialize(ctx, &mut cursor) {
+            match self.deserialize::<E, I>(ctx, &mut cursor) {
                 Ok(event) => {
                     debug!(
                         "applying event `{}` from `{client_id:?}`",
                         any::type_name::<E>()
                     );
-                    events.send(FromClient { client_id, event });
+                    client_events.send(FromClient { client_id, event });
                 }
                 Err(e) => debug!(
                     "ignoring event `{}` from {client_id:?} that failed to deserialize: {e}",
@@ -346,8 +304,8 @@ impl ClientEvent {
     /// # Safety
     ///
     /// The caller must ensure that `events` is [`Events<E>`] and `server_events` is [`Events<ToClients<E>>`].
-    unsafe fn resend_locally_typed<E: Event>(client_events: PtrMut, events: PtrMut) {
-        let client_events: &mut Events<FromClient<E>> = client_events.deref_mut();
+    unsafe fn resend_locally_typed<E: Event>(server_events: PtrMut, events: PtrMut) {
+        let client_events: &mut Events<FromClient<E>> = server_events.deref_mut();
         let events: &mut Events<E> = events.deref_mut();
         if !events.is_empty() {
             debug!(
@@ -389,47 +347,33 @@ impl ClientEvent {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that this instance was created for `E`.
-    unsafe fn serialize<E: Event>(
+    /// The caller must ensure that this instance was created for `E` and `I`.
+    unsafe fn serialize<E: 'static, I: 'static>(
         &self,
         ctx: &mut ClientSendCtx,
         event: &E,
         message: &mut Vec<u8>,
     ) -> bincode::Result<()> {
-        let serialize: SerializeFn<E> = std::mem::transmute(self.serialize);
-        (serialize)(ctx, event, message)
+        self.event_fns
+            .typed::<ClientSendCtx, ServerReceiveCtx, E, I>()
+            .serialize(ctx, event, message)
     }
 
     /// Deserializes an event from a cursor.
     ///
     /// # Safety
     ///
-    /// The caller must ensure that this instance was created for `E`.
-    unsafe fn deserialize<E: Event>(
+    /// The caller must ensure that this instance was created for `E` and `I`.
+    unsafe fn deserialize<E: 'static, I: 'static>(
         &self,
         ctx: &mut ServerReceiveCtx,
         cursor: &mut Cursor<&[u8]>,
     ) -> bincode::Result<E> {
-        let deserialize: DeserializeFn<E> = std::mem::transmute(self.deserialize);
-        (deserialize)(ctx, cursor)
-    }
-
-    fn check_type<E: Event>(&self) {
-        debug_assert_eq!(
-            self.event_id,
-            TypeId::of::<E>(),
-            "trying to call event functions with `{}`, but they were created with `{}`",
-            any::type_name::<E>(),
-            self.event_name,
-        );
+        self.event_fns
+            .typed::<ClientSendCtx, ServerReceiveCtx, E, I>()
+            .deserialize(ctx, cursor)
     }
 }
-
-/// Signature of client event serialization functions.
-pub type SerializeFn<E> = fn(&mut ClientSendCtx, &E, &mut Vec<u8>) -> bincode::Result<()>;
-
-/// Signature of client event deserialization functions.
-pub type DeserializeFn<E> = fn(&mut ServerReceiveCtx, &mut Cursor<&[u8]>) -> bincode::Result<E>;
 
 /// Signature of client event sending functions.
 type SendFn = unsafe fn(&ClientEvent, &mut ClientSendCtx, &Ptr, PtrMut, &mut RepliconClient);

--- a/src/core/event/event_fns.rs
+++ b/src/core/event/event_fns.rs
@@ -1,0 +1,198 @@
+use std::{
+    any::{self, TypeId},
+    io::Cursor,
+    mem,
+};
+
+/// Type-erased version of [`EventFns`].
+///
+/// Stored inside events after their creation.
+#[derive(Clone, Copy)]
+pub(super) struct UntypedEventFns {
+    serialize_ctx_id: TypeId,
+    serialize_ctx_name: &'static str,
+    deserialize_ctx_id: TypeId,
+    deserialize_ctx_name: &'static str,
+    event_id: TypeId,
+    event_name: &'static str,
+    inner_id: TypeId,
+    inner_name: &'static str,
+
+    outer_serialize: unsafe fn(),
+    outer_deserialize: unsafe fn(),
+    serialize: unsafe fn(),
+    deserialize: unsafe fn(),
+}
+
+impl UntypedEventFns {
+    /// Restores the original [`EventFns`] from which this type was created.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the function is called with the same generics with which this instance was created.
+    pub(super) unsafe fn typed<S, D, E: 'static, I: 'static>(self) -> EventFns<S, D, E, I> {
+        // `TypeId` can only be obtained for `'static` types, but we can't impose this requirement because our context has a lifetime.
+        // So, we use the `typeid` crate for non-static `TypeId`, as we don't care about the lifetime and only need to check the type.
+        // This crate is already used by `erased_serde`, so we don't add an extra dependency.
+        debug_assert_eq!(
+            self.serialize_ctx_id,
+            typeid::of::<S>(),
+            "trying to call event functions with serialize context `{}`, but they were created with `{}`",
+            any::type_name::<S>(),
+            self.serialize_ctx_name,
+        );
+        debug_assert_eq!(
+            self.deserialize_ctx_id,
+            typeid::of::<D>(),
+            "trying to call event functions with deserialize context `{}`, but they were created with `{}`",
+            any::type_name::<D>(),
+            self.deserialize_ctx_name,
+        );
+        debug_assert_eq!(
+            self.event_id,
+            TypeId::of::<E>(),
+            "trying to call event functions with event `{}`, but they were created with `{}`",
+            any::type_name::<E>(),
+            self.event_name,
+        );
+        debug_assert_eq!(
+            self.inner_id,
+            TypeId::of::<I>(),
+            "trying to call event functions with inner type `{}`, but they were created with `{}`",
+            any::type_name::<I>(),
+            self.inner_name,
+        );
+
+        EventFns {
+            outer_serialize: unsafe {
+                mem::transmute::<unsafe fn(), OuterSerializeFn<S, E, I>>(self.outer_serialize)
+            },
+            outer_deserialize: unsafe {
+                mem::transmute::<unsafe fn(), OuterDeserializeFn<D, E, I>>(self.outer_deserialize)
+            },
+            serialize: unsafe {
+                mem::transmute::<unsafe fn(), EventSerializeFn<S, I>>(self.serialize)
+            },
+            deserialize: unsafe {
+                mem::transmute::<unsafe fn(), EventDeserializeFn<D, I>>(self.deserialize)
+            },
+        }
+    }
+}
+
+impl<S, D, E: 'static, I: 'static> From<EventFns<S, D, E, I>> for UntypedEventFns {
+    fn from(value: EventFns<S, D, E, I>) -> Self {
+        // SAFETY: these functions won't be called until the type is restored.
+        Self {
+            serialize_ctx_id: typeid::of::<S>(),
+            serialize_ctx_name: any::type_name::<S>(),
+            deserialize_ctx_id: typeid::of::<D>(),
+            deserialize_ctx_name: any::type_name::<D>(),
+            event_id: TypeId::of::<E>(),
+            event_name: any::type_name::<E>(),
+            inner_id: TypeId::of::<I>(),
+            inner_name: any::type_name::<I>(),
+            outer_serialize: unsafe {
+                mem::transmute::<OuterSerializeFn<S, E, I>, unsafe fn()>(value.outer_serialize)
+            },
+            outer_deserialize: unsafe {
+                mem::transmute::<OuterDeserializeFn<D, E, I>, unsafe fn()>(value.outer_deserialize)
+            },
+            serialize: unsafe {
+                mem::transmute::<EventSerializeFn<S, I>, unsafe fn()>(value.serialize)
+            },
+            deserialize: unsafe {
+                mem::transmute::<EventDeserializeFn<D, I>, unsafe fn()>(value.deserialize)
+            },
+        }
+    }
+}
+
+/// Serialization and deserialization functions for an event.
+///
+/// For triggers, we want to allow users to customize these functions, but it would be inconvenient
+/// to write serialization and deserialization logic for trigger target entities every time.
+/// Since closures can't be used, we provide outer functions that accept regular serialization functions.
+/// By default, these outer functions simply call the inner function, but they can be overridden
+/// to write common serde logic.
+pub(super) struct EventFns<S, D, E, I = E> {
+    outer_serialize: OuterSerializeFn<S, E, I>,
+    outer_deserialize: OuterDeserializeFn<D, E, I>,
+    serialize: EventSerializeFn<S, I>,
+    deserialize: EventDeserializeFn<D, I>,
+}
+
+impl<S, D, E> EventFns<S, D, E, E> {
+    /// Creates a new instance with default outer functions.
+    pub(super) fn new(
+        serialize: EventSerializeFn<S, E>,
+        deserialize: EventDeserializeFn<D, E>,
+    ) -> Self {
+        Self {
+            outer_serialize: default_outer_serialize::<S, E>,
+            outer_deserialize: default_outer_deserialize::<D, E>,
+            serialize,
+            deserialize,
+        }
+    }
+}
+
+impl<S, D, E, I> EventFns<S, D, E, I> {
+    /// Overrides current outer functions.
+    pub(super) fn with_outer<T>(
+        self,
+        outer_serialize: OuterSerializeFn<S, T, I>,
+        outer_deserialize: OuterDeserializeFn<D, T, I>,
+    ) -> EventFns<S, D, T, I> {
+        EventFns {
+            outer_serialize,
+            outer_deserialize,
+            serialize: self.serialize,
+            deserialize: self.deserialize,
+        }
+    }
+
+    pub(super) fn serialize(
+        self,
+        ctx: &mut S,
+        event: &E,
+        message: &mut Vec<u8>,
+    ) -> bincode::Result<()> {
+        (self.outer_serialize)(ctx, event, message, self.serialize)
+    }
+
+    pub(super) fn deserialize(self, ctx: &mut D, cursor: &mut Cursor<&[u8]>) -> bincode::Result<E> {
+        (self.outer_deserialize)(ctx, cursor, self.deserialize)
+    }
+}
+
+fn default_outer_serialize<C, E>(
+    ctx: &mut C,
+    event: &E,
+    message: &mut Vec<u8>,
+    serialize: EventSerializeFn<C, E>,
+) -> bincode::Result<()> {
+    (serialize)(ctx, event, message)
+}
+
+fn default_outer_deserialize<C, E>(
+    ctx: &mut C,
+    cursor: &mut Cursor<&[u8]>,
+    deserialize: EventDeserializeFn<C, E>,
+) -> bincode::Result<E> {
+    (deserialize)(ctx, cursor)
+}
+
+/// Signature of event serialization functions.
+pub type EventSerializeFn<C, E> = fn(&mut C, &E, &mut Vec<u8>) -> bincode::Result<()>;
+
+/// Signature of event deserialization functions.
+pub type EventDeserializeFn<C, E> = fn(&mut C, &mut Cursor<&[u8]>) -> bincode::Result<E>;
+
+/// Signature of outer serialization functions.
+pub(super) type OuterSerializeFn<C, E, I> =
+    fn(&mut C, &E, &mut Vec<u8>, EventSerializeFn<C, I>) -> bincode::Result<()>;
+
+/// Signature of outer deserialization functions.
+pub(super) type OuterDeserializeFn<C, E, I> =
+    fn(&mut C, &mut Cursor<&[u8]>, EventDeserializeFn<C, I>) -> bincode::Result<E>;

--- a/src/core/event/event_registry.rs
+++ b/src/core/event/event_registry.rs
@@ -1,32 +1,64 @@
 use bevy::prelude::*;
 
-use super::{client_event::ClientEvent, server_event::ServerEvent};
+use super::{
+    client_event::ClientEvent, client_trigger::ClientTrigger, server_event::ServerEvent,
+    server_trigger::ServerTrigger,
+};
 
 /// Registered server and client events.
+///
+/// We use store triggers separately for quick iteration over them,
+/// but they are events under the hood.
 #[derive(Resource, Default)]
 pub(crate) struct EventRegistry {
-    server: Vec<ServerEvent>,
-    client: Vec<ClientEvent>,
+    server_events: Vec<ServerEvent>,
+    client_events: Vec<ClientEvent>,
+    server_triggers: Vec<ServerTrigger>,
+    client_triggers: Vec<ClientTrigger>,
 }
 
 impl EventRegistry {
-    pub(super) fn register_server_event(&mut self, event_data: ServerEvent) {
-        self.server.push(event_data);
+    pub(super) fn register_server_event(&mut self, event: ServerEvent) {
+        self.server_events.push(event);
     }
 
-    pub(super) fn register_client_event(&mut self, event_data: ClientEvent) {
-        self.client.push(event_data);
+    pub(super) fn register_client_event(&mut self, event: ClientEvent) {
+        self.client_events.push(event);
+    }
+
+    pub(super) fn register_server_trigger(&mut self, trigger: ServerTrigger) {
+        self.server_triggers.push(trigger);
+    }
+
+    pub(super) fn register_client_trigger(&mut self, trigger: ClientTrigger) {
+        self.client_triggers.push(trigger);
     }
 
     pub(crate) fn iter_server_events_mut(&mut self) -> impl Iterator<Item = &mut ServerEvent> {
-        self.server.iter_mut()
+        self.server_events.iter_mut().chain(
+            self.server_triggers
+                .iter_mut()
+                .map(|trigger| trigger.event_mut()),
+        )
     }
 
     pub(crate) fn iter_server_events(&self) -> impl Iterator<Item = &ServerEvent> {
-        self.server.iter()
+        self.server_events
+            .iter()
+            .chain(self.server_triggers.iter().map(|trigger| trigger.event()))
     }
 
     pub(crate) fn iter_client_events(&self) -> impl Iterator<Item = &ClientEvent> {
-        self.client.iter()
+        self.client_events
+            .iter()
+            .chain(self.client_triggers.iter().map(|trigger| trigger.event()))
+    }
+
+    pub(crate) fn iter_server_triggers(&self) -> impl Iterator<Item = &ServerTrigger> {
+        self.server_triggers.iter()
+    }
+
+    pub(crate) fn iter_client_triggers(&self) -> impl Iterator<Item = &ClientTrigger> {
+        self.client_triggers.iter()
     }
 }

--- a/src/core/event/server_trigger.rs
+++ b/src/core/event/server_trigger.rs
@@ -1,0 +1,229 @@
+use std::{any, io::Cursor};
+
+use bevy::{ecs::entity::MapEntities, prelude::*, ptr::PtrMut};
+use integer_encoding::{VarIntReader, VarIntWriter};
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::{
+    ctx::{ClientReceiveCtx, ServerSendCtx},
+    event_fns::{EventDeserializeFn, EventFns, EventSerializeFn},
+    event_registry::EventRegistry,
+    server_event::{self, ServerEvent, ToClients},
+    RemoteTrigger,
+};
+use crate::core::{channels::RepliconChannel, entity_serde};
+
+/// An extension trait for [`App`] for creating server triggers.
+///
+/// See also [`ServerTriggerExt`].
+pub trait ServerTriggerAppExt {
+    /// Registers an event that can be triggered using [`ServerTriggerExt::server_trigger`].
+    ///
+    /// The API matches [`ServerEventAppExt::add_server_event`](super::server_event::ServerEventAppExt::add_server_event):
+    /// `E` will be triggered on the client after triggering [`ToClients<E>`] event on server.
+    /// If [`ClientId::SERVER`](crate::core::ClientId::SERVER) is a recipient of the event, then `E` events will be emitted on the server
+    /// as well.
+    ///
+    /// See also [`Self::add_server_trigger_with`] and the [corresponding section](../index.html#from-server-to-client)
+    /// from the quick start guide.
+    fn add_server_trigger<E: Event + Serialize + DeserializeOwned>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+    ) -> &mut Self {
+        self.add_server_trigger_with(
+            channel,
+            server_event::default_serialize::<E>,
+            server_event::default_deserialize::<E>,
+        )
+    }
+
+    /// Same as [`Self::add_server_trigger`], but additionally maps client entities to server inside the event before receiving.
+    ///
+    /// Always use it for events that contain entities.
+    fn add_mapped_server_trigger<E: Event + Serialize + DeserializeOwned + MapEntities>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+    ) -> &mut Self {
+        self.add_server_trigger_with(
+            channel,
+            server_event::default_serialize::<E>,
+            server_event::default_deserialize_mapped::<E>,
+        )
+    }
+
+    /// Same as [`Self::add_server_trigger`], but uses the specified functions for serialization and deserialization.
+    ///
+    /// See also [`ServerEventAppExt::add_server_event_with`](super::server_event::ServerEventAppExt::add_server_event_with).
+    fn add_server_trigger_with<E: Event>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+        serialize: EventSerializeFn<ServerSendCtx, E>,
+        deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
+    ) -> &mut Self;
+}
+
+impl ServerTriggerAppExt for App {
+    fn add_server_trigger_with<E: Event>(
+        &mut self,
+        channel: impl Into<RepliconChannel>,
+        serialize: EventSerializeFn<ServerSendCtx, E>,
+        deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
+    ) -> &mut Self {
+        debug!("registering trigger `{}`", any::type_name::<E>());
+
+        let event_fns = EventFns::new(serialize, deserialize)
+            .with_outer(trigger_serialize, trigger_deserialize);
+        let trigger = ServerTrigger::new(self, channel, event_fns);
+        let mut event_registry = self.world_mut().resource_mut::<EventRegistry>();
+        event_registry.register_server_trigger(trigger);
+
+        self
+    }
+}
+
+/// Small abstraction on top of [`ServerEvent`] that stores a function to trigger them.
+pub(crate) struct ServerTrigger {
+    trigger: TriggerFn,
+    event: ServerEvent,
+}
+
+impl ServerTrigger {
+    fn new<E: Event>(
+        app: &mut App,
+        channel: impl Into<RepliconChannel>,
+        event_fns: EventFns<ServerSendCtx, ClientReceiveCtx, RemoteTrigger<E>, E>,
+    ) -> Self {
+        let event = ServerEvent::new(app, channel, event_fns);
+        Self {
+            trigger: Self::trigger_typed::<E>,
+            event,
+        }
+    }
+
+    pub(crate) fn trigger(&self, commands: &mut Commands, events: PtrMut) {
+        unsafe {
+            (self.trigger)(commands, events);
+        }
+    }
+
+    /// Drains received [`RemoteTrigger<E>`] events and triggers them as `E`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `events` is [`Events<RemoteTrigger<E>>`]
+    /// and this instance was created for `E`.
+    unsafe fn trigger_typed<E: Event>(commands: &mut Commands, events: PtrMut) {
+        let events: &mut Events<RemoteTrigger<E>> = events.deref_mut();
+        for trigger in events.drain() {
+            debug!("triggering `{}`", any::type_name::<E>());
+            commands.trigger_targets(trigger.event, trigger.targets);
+        }
+    }
+
+    pub(crate) fn event(&self) -> &ServerEvent {
+        &self.event
+    }
+
+    pub(super) fn event_mut(&mut self) -> &mut ServerEvent {
+        &mut self.event
+    }
+}
+
+/// Signature of server trigger functions.
+type TriggerFn = unsafe fn(&mut Commands, PtrMut);
+
+/// Serializes targets for [`RemoteTrigger`] and delegates the event
+/// serialiaztion to `serialize`.
+///
+/// Used as outer function for [`EventFns`].
+fn trigger_serialize<'a, E>(
+    ctx: &mut ServerSendCtx<'a>,
+    trigger: &RemoteTrigger<E>,
+    message: &mut Vec<u8>,
+    serialize: EventSerializeFn<ServerSendCtx<'a>, E>,
+) -> bincode::Result<()> {
+    message.write_varint(trigger.targets.len())?;
+    for &entity in &trigger.targets {
+        entity_serde::serialize_entity(message, entity)?;
+    }
+
+    (serialize)(ctx, &trigger.event, message)
+}
+
+/// Deserializes targets for [`RemoteTrigger`] and delegates the event
+/// deserialiaztion to `deserialize`.
+///
+/// Used as outer function for [`EventFns`].
+fn trigger_deserialize<'a, E>(
+    ctx: &mut ClientReceiveCtx<'a>,
+    cursor: &mut Cursor<&[u8]>,
+    deserialize: EventDeserializeFn<ClientReceiveCtx<'a>, E>,
+) -> bincode::Result<RemoteTrigger<E>> {
+    let len = cursor.read_varint()?;
+    let mut targets = Vec::with_capacity(len);
+    for _ in 0..len {
+        let entity = entity_serde::deserialize_entity(cursor)?;
+        targets.push(ctx.map_entity(entity));
+    }
+
+    let event = (deserialize)(ctx, cursor)?;
+
+    Ok(RemoteTrigger { event, targets })
+}
+
+/// Extension trait for triggering server events.
+///
+/// See also [`ServerTriggerAppExt`].
+pub trait ServerTriggerExt {
+    /// Like [`Commands::trigger`], but triggers [`E`] on server and locally
+    /// if [`ClientId::SERVER`](crate::core::ClientId::SERVER) is a recipient of the event).
+    fn server_trigger(&mut self, event: ToClients<impl Event>);
+
+    /// Like [`Self::server_trigger`], but allows you to specify target entities, similar to
+    /// [`Commands::trigger_targets`].
+    fn server_trigger_targets(
+        &mut self,
+        event: ToClients<impl Event>,
+        targets: impl Into<Vec<Entity>>,
+    );
+}
+
+impl ServerTriggerExt for Commands<'_, '_> {
+    fn server_trigger(&mut self, event: ToClients<impl Event>) {
+        self.server_trigger_targets(event, []);
+    }
+
+    fn server_trigger_targets(
+        &mut self,
+        event: ToClients<impl Event>,
+        targets: impl Into<Vec<Entity>>,
+    ) {
+        self.send_event(ToClients {
+            mode: event.mode,
+            event: RemoteTrigger {
+                event: event.event,
+                targets: targets.into(),
+            },
+        });
+    }
+}
+
+impl ServerTriggerExt for World {
+    fn server_trigger(&mut self, event: ToClients<impl Event>) {
+        self.server_trigger_targets(event, []);
+    }
+
+    fn server_trigger_targets(
+        &mut self,
+        event: ToClients<impl Event>,
+        targets: impl Into<Vec<Entity>>,
+    ) {
+        self.send_event(ToClients {
+            mode: event.mode,
+            event: RemoteTrigger {
+                event: event.event,
+                targets: targets.into(),
+            },
+        });
+    }
+}

--- a/src/core/event/server_trigger.rs
+++ b/src/core/event/server_trigger.rs
@@ -175,7 +175,7 @@ fn trigger_deserialize<'a, E>(
 ///
 /// See also [`ServerTriggerAppExt`].
 pub trait ServerTriggerExt {
-    /// Like [`Commands::trigger`], but triggers [`E`] on server and locally
+    /// Like [`Commands::trigger`], but triggers `E` on server and locally
     /// if [`ClientId::SERVER`](crate::core::ClientId::SERVER) is a recipient of the event).
     fn server_trigger(&mut self, event: ToClients<impl Event>);
 

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -38,7 +38,7 @@ fn mapping_and_sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, RepliconPlugins))
-            .add_mapped_client_event::<MappedEvent>(ChannelKind::Ordered)
+            .add_mapped_client_event::<EntityEvent>(ChannelKind::Ordered)
             .finish();
     }
 
@@ -53,7 +53,7 @@ fn mapping_and_sending_receiving() {
 
     client_app
         .world_mut()
-        .send_event(MappedEvent(client_entity));
+        .send_event(EntityEvent(client_entity));
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -61,7 +61,7 @@ fn mapping_and_sending_receiving() {
 
     let mapped_entities: Vec<_> = server_app
         .world_mut()
-        .resource_mut::<Events<FromClient<MappedEvent>>>()
+        .resource_mut::<Events<FromClient<EntityEvent>>>()
         .drain()
         .map(|event| event.event.0)
         .collect();
@@ -129,9 +129,9 @@ fn local_resending() {
 struct DummyEvent;
 
 #[derive(Deserialize, Event, Serialize, Clone)]
-struct MappedEvent(Entity);
+struct EntityEvent(Entity);
 
-impl MapEntities for MappedEvent {
+impl MapEntities for EntityEvent {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
         self.0 = entity_mapper.map_entity(self.0);
     }

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -93,6 +93,7 @@ fn mapping_and_sending_receiving() {
 }
 
 #[test]
+#[ignore = "fail on CI, but passes locally, needs investigation"]
 fn sending_receiving_without_plugins() {
     let mut server_app = App::new();
     let mut client_app = App::new();

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -93,21 +93,26 @@ fn mapping_and_sending_receiving() {
 }
 
 #[test]
-#[ignore = "fail on CI, but passes locally, needs investigation"]
 fn sending_receiving_without_plugins() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     server_app
         .add_plugins((
             MinimalPlugins,
-            RepliconPlugins.build().disable::<ClientPlugin>(),
+            RepliconPlugins
+                .build()
+                .disable::<ClientPlugin>()
+                .disable::<ClientEventPlugin>(),
         ))
         .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
         .finish();
     client_app
         .add_plugins((
             MinimalPlugins,
-            RepliconPlugins.build().disable::<ServerPlugin>(),
+            RepliconPlugins
+                .build()
+                .disable::<ServerPlugin>()
+                .disable::<ServerEventPlugin>(),
         ))
         .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
         .finish();

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -1,0 +1,178 @@
+use bevy::{ecs::entity::MapEntities, prelude::*, time::TimePlugin};
+use bevy_replicon::{
+    core::server_entity_map::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
+};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn sending_receiving() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, RepliconPlugins))
+            .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
+            .finish();
+    }
+    server_app.init_resource::<TriggerReader<DummyEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    client_app.world_mut().client_trigger(DummyEvent);
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let reader = server_app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities, [Entity::PLACEHOLDER]);
+}
+
+#[test]
+fn sending_receiving_with_target() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, RepliconPlugins))
+            .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
+            .finish();
+    }
+    server_app.init_resource::<TriggerReader<DummyEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    let client_entity = Entity::from_raw(0);
+    let server_entity = Entity::from_raw(client_entity.index() + 1);
+    client_app
+        .world_mut()
+        .resource_mut::<ServerEntityMap>()
+        .insert(server_entity, client_entity);
+
+    client_app
+        .world_mut()
+        .client_trigger_targets(DummyEvent, [client_entity]);
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let reader = server_app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities, [server_entity]);
+}
+
+#[test]
+fn mapping_and_sending_receiving() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, RepliconPlugins))
+            .add_mapped_client_trigger::<EntityEvent>(ChannelKind::Ordered)
+            .finish();
+    }
+    server_app.init_resource::<TriggerReader<EntityEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    let client_entity = Entity::from_raw(0);
+    let server_entity = Entity::from_raw(client_entity.index() + 1);
+    client_app
+        .world_mut()
+        .resource_mut::<ServerEntityMap>()
+        .insert(server_entity, client_entity);
+
+    client_app
+        .world_mut()
+        .client_trigger(EntityEvent(client_entity));
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let reader = server_app.world().resource::<TriggerReader<EntityEvent>>();
+    let mapped_entities: Vec<_> = reader.events.iter().map(|event| event.event.0).collect();
+    assert_eq!(mapped_entities, [server_entity]);
+}
+
+#[test]
+fn sending_receiving_without_plugins() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    server_app
+        .add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.build().disable::<ClientPlugin>(),
+        ))
+        .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    client_app
+        .add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.build().disable::<ServerPlugin>(),
+        ))
+        .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    server_app.init_resource::<TriggerReader<DummyEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    client_app.world_mut().client_trigger(DummyEvent);
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let reader = server_app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities.len(), 1);
+}
+
+#[test]
+fn local_resending() {
+    let mut app = App::new();
+    app.add_plugins((TimePlugin, RepliconPlugins))
+        .add_client_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    app.init_resource::<TriggerReader<DummyEvent>>();
+
+    app.world_mut().client_trigger(DummyEvent);
+
+    // Requires 2 updates because local resending runs
+    // in `PostUpdate` and triggering runs in `PreUpdate`.
+    app.update();
+    app.update();
+
+    let reader = app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities.len(), 1);
+}
+
+#[derive(Deserialize, Event, Serialize, Clone)]
+struct DummyEvent;
+
+#[derive(Deserialize, Event, Serialize, Clone)]
+struct EntityEvent(Entity);
+
+impl MapEntities for EntityEvent {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+        self.0 = entity_mapper.map_entity(self.0);
+    }
+}
+
+#[derive(Resource)]
+struct TriggerReader<E: Event> {
+    events: Vec<FromClient<E>>,
+    entities: Vec<Entity>,
+}
+
+impl<E: Event + Clone> FromWorld for TriggerReader<E> {
+    fn from_world(world: &mut World) -> Self {
+        world.add_observer(
+            |trigger: Trigger<FromClient<E>>, mut counter: ResMut<Self>| {
+                counter.events.push(trigger.event().clone());
+                counter.entities.push(trigger.entity());
+            },
+        );
+
+        Self {
+            events: Default::default(),
+            entities: Default::default(),
+        }
+    }
+}

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -1,0 +1,224 @@
+use bevy::{ecs::entity::MapEntities, prelude::*, time::TimePlugin};
+use bevy_replicon::{
+    core::server_entity_map::ServerEntityMap, prelude::*, test_app::ServerTestAppExt,
+};
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn sending_receiving() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .add_server_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    }
+    client_app.init_resource::<TriggerReader<DummyEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    server_app.world_mut().server_trigger(ToClients {
+        mode: SendMode::Broadcast,
+        event: DummyEvent,
+    });
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let reader = client_app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities, [Entity::PLACEHOLDER]);
+}
+
+#[test]
+fn sending_receiving_with_target() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .add_server_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    }
+    client_app.init_resource::<TriggerReader<DummyEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    let client_entity = Entity::from_raw(0);
+    let server_entity = Entity::from_raw(client_entity.index() + 1);
+    client_app
+        .world_mut()
+        .resource_mut::<ServerEntityMap>()
+        .insert(server_entity, client_entity);
+
+    server_app.world_mut().server_trigger_targets(
+        ToClients {
+            mode: SendMode::Broadcast,
+            event: DummyEvent,
+        },
+        [server_entity],
+    );
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let reader = client_app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities, [client_entity]);
+}
+
+#[test]
+fn sending_receiving_and_mapping() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .add_mapped_server_trigger::<EntityEvent>(ChannelKind::Ordered)
+        .finish();
+    }
+    client_app.init_resource::<TriggerReader<EntityEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    let client_entity = Entity::from_raw(0);
+    let server_entity = Entity::from_raw(client_entity.index() + 1);
+    client_app
+        .world_mut()
+        .resource_mut::<ServerEntityMap>()
+        .insert(server_entity, client_entity);
+
+    server_app.world_mut().server_trigger(ToClients {
+        mode: SendMode::Broadcast,
+        event: EntityEvent(server_entity),
+    });
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let reader = client_app.world().resource::<TriggerReader<EntityEvent>>();
+    let mapped_entities: Vec<_> = reader.events.iter().map(|event| event.0).collect();
+    assert_eq!(mapped_entities, [client_entity]);
+}
+
+#[test]
+fn sending_receiving_without_plugins() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    server_app
+        .add_plugins((
+            MinimalPlugins,
+            RepliconPlugins
+                .build()
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                })
+                .disable::<ClientPlugin>()
+                .disable::<ClientEventPlugin>(),
+        ))
+        .add_server_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    client_app
+        .add_plugins((
+            MinimalPlugins,
+            RepliconPlugins
+                .build()
+                .disable::<ServerPlugin>()
+                .disable::<ServerEventPlugin>(),
+        ))
+        .add_server_trigger::<DummyEvent>(ChannelKind::Ordered)
+        .finish();
+    client_app.init_resource::<TriggerReader<DummyEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    server_app.world_mut().server_trigger(ToClients {
+        mode: SendMode::Broadcast,
+        event: DummyEvent,
+    });
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let reader = client_app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities.len(), 1);
+}
+
+#[test]
+fn local_resending() {
+    let mut app = App::new();
+    app.add_plugins((
+        TimePlugin,
+        RepliconPlugins.set(ServerPlugin {
+            tick_policy: TickPolicy::EveryFrame,
+            ..Default::default()
+        }),
+    ))
+    .add_server_trigger::<DummyEvent>(ChannelKind::Ordered)
+    .finish();
+    app.init_resource::<TriggerReader<DummyEvent>>();
+
+    app.world_mut().server_trigger(ToClients {
+        mode: SendMode::Broadcast,
+        event: DummyEvent,
+    });
+
+    // Requires 2 updates because local resending runs
+    // in `PostUpdate` and triggering runs in `PreUpdate`.
+    app.update();
+    app.update();
+
+    let reader = app.world().resource::<TriggerReader<DummyEvent>>();
+    assert_eq!(reader.entities.len(), 1);
+}
+
+#[derive(Event, Serialize, Deserialize, Clone)]
+struct DummyEvent;
+
+#[derive(Event, Deserialize, Serialize, Clone)]
+struct EntityEvent(Entity);
+
+impl MapEntities for EntityEvent {
+    fn map_entities<T: EntityMapper>(&mut self, entity_mapper: &mut T) {
+        self.0 = entity_mapper.map_entity(self.0);
+    }
+}
+
+#[derive(Resource)]
+struct TriggerReader<E: Event> {
+    events: Vec<E>,
+    entities: Vec<Entity>,
+}
+
+impl<E: Event + Clone> FromWorld for TriggerReader<E> {
+    fn from_world(world: &mut World) -> Self {
+        world.add_observer(|trigger: Trigger<E>, mut counter: ResMut<Self>| {
+            counter.events.push(trigger.event().clone());
+            counter.entities.push(trigger.entity());
+        });
+
+        Self {
+            events: Default::default(),
+            entities: Default::default(),
+        }
+    }
+}

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -119,6 +119,7 @@ fn sending_receiving_and_mapping() {
 }
 
 #[test]
+#[ignore = "fail on CI, but passes locally, needs investigation"]
 fn sending_receiving_without_plugins() {
     let mut server_app = App::new();
     let mut client_app = App::new();

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -119,7 +119,6 @@ fn sending_receiving_and_mapping() {
 }
 
 #[test]
-#[ignore = "fail on CI, but passes locally, needs investigation"]
 fn sending_receiving_without_plugins() {
     let mut server_app = App::new();
     let mut client_app = App::new();


### PR DESCRIPTION
I decided to implement remote triggers on top of events to reuse existing logic.

Unlike events, we can't simply observe and re-trigger, as we need
access to all targets. To address this, we provide a special `RemoteTrigger` and
extension traits for sending these events internally. Both global and targeted
triggers are supported. But we don't support component-based targets yet, only entity-based.

To allow users to override serialization without manually writing it for
for event targets, I replaced the bare serialization functions with an abstraction
similar to component rules. Additionally, I updated how `ClientEvent` is created
internally to cleanly reuse this logic for triggers.

For API examples see documentation changes in `lib.rs`.