### PR TITLE
Order trigger events

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -98,7 +98,12 @@ impl Plugin for ServerPlugin {
             .init_resource::<BufferedServerEvents>()
             .configure_sets(
                 PreUpdate,
-                (ServerSet::ReceivePackets, ServerSet::Receive).chain(),
+                (
+                    ServerSet::ReceivePackets,
+                    ServerSet::TriggerServerEvents,
+                    ServerSet::Receive,
+                )
+                    .chain(),
             )
             .configure_sets(
                 PostUpdate,


### PR DESCRIPTION
In #384 I removed this variant, then restored, but forgot to restore its ordering.
Required for backends to function properly.