### PR TITLE
Use trait for remote targets

### DIFF
--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -5,19 +5,4 @@ pub mod event_fns;
 pub(crate) mod event_registry;
 pub mod server_event;
 pub mod server_trigger;
-
-use bevy::prelude::*;
-
-/// An event that used under the hood for client and server triggers.
-///
-/// We can't just observe for triggers like we do for events since we need access to all its targets
-/// and we need to buffer them. This is why we just emit this event instead and after receive drain it
-/// to trigger regular events.
-///
-/// Traditional trigger interface is provided by [`ClientTriggerExt`](client_trigger::ClientTriggerExt)
-/// and [`ServerTriggerExt`](server_trigger::ServerTriggerExt).
-#[derive(Event)]
-struct RemoteTrigger<E> {
-    event: E,
-    targets: Vec<Entity>,
-}
+pub mod trigger;

--- a/src/core/event/client_trigger.rs
+++ b/src/core/event/client_trigger.rs
@@ -9,7 +9,7 @@ use super::{
     ctx::{ClientSendCtx, ServerReceiveCtx},
     event_fns::{EventDeserializeFn, EventFns, EventSerializeFn},
     event_registry::EventRegistry,
-    RemoteTrigger,
+    trigger::{RemoteTargets, RemoteTrigger},
 };
 use crate::core::{channels::RepliconChannel, entity_serde};
 
@@ -187,7 +187,7 @@ pub trait ClientTriggerExt {
 
     /// Like [`Self::client_trigger`], but allows you to specify target entities, similar to
     /// [`Commands::trigger_targets`].
-    fn client_trigger_targets(&mut self, event: impl Event, targets: impl Into<Vec<Entity>>);
+    fn client_trigger_targets(&mut self, event: impl Event, targets: impl RemoteTargets);
 }
 
 impl ClientTriggerExt for Commands<'_, '_> {
@@ -195,10 +195,10 @@ impl ClientTriggerExt for Commands<'_, '_> {
         self.client_trigger_targets(event, []);
     }
 
-    fn client_trigger_targets(&mut self, event: impl Event, targets: impl Into<Vec<Entity>>) {
+    fn client_trigger_targets(&mut self, event: impl Event, targets: impl RemoteTargets) {
         self.send_event(RemoteTrigger {
             event,
-            targets: targets.into(),
+            targets: targets.into_entities(),
         });
     }
 }
@@ -208,10 +208,10 @@ impl ClientTriggerExt for World {
         self.client_trigger_targets(event, []);
     }
 
-    fn client_trigger_targets(&mut self, event: impl Event, targets: impl Into<Vec<Entity>>) {
+    fn client_trigger_targets(&mut self, event: impl Event, targets: impl RemoteTargets) {
         self.send_event(RemoteTrigger {
             event,
-            targets: targets.into(),
+            targets: targets.into_entities(),
         });
     }
 }

--- a/src/core/event/server_trigger.rs
+++ b/src/core/event/server_trigger.rs
@@ -9,7 +9,7 @@ use super::{
     event_fns::{EventDeserializeFn, EventFns, EventSerializeFn},
     event_registry::EventRegistry,
     server_event::{self, ServerEvent, ToClients},
-    RemoteTrigger,
+    trigger::{RemoteTargets, RemoteTrigger},
 };
 use crate::core::{channels::RepliconChannel, entity_serde};
 
@@ -181,11 +181,7 @@ pub trait ServerTriggerExt {
 
     /// Like [`Self::server_trigger`], but allows you to specify target entities, similar to
     /// [`Commands::trigger_targets`].
-    fn server_trigger_targets(
-        &mut self,
-        event: ToClients<impl Event>,
-        targets: impl Into<Vec<Entity>>,
-    );
+    fn server_trigger_targets(&mut self, event: ToClients<impl Event>, targets: impl RemoteTargets);
 }
 
 impl ServerTriggerExt for Commands<'_, '_> {
@@ -196,13 +192,13 @@ impl ServerTriggerExt for Commands<'_, '_> {
     fn server_trigger_targets(
         &mut self,
         event: ToClients<impl Event>,
-        targets: impl Into<Vec<Entity>>,
+        targets: impl RemoteTargets,
     ) {
         self.send_event(ToClients {
             mode: event.mode,
             event: RemoteTrigger {
                 event: event.event,
-                targets: targets.into(),
+                targets: targets.into_entities(),
             },
         });
     }
@@ -216,13 +212,13 @@ impl ServerTriggerExt for World {
     fn server_trigger_targets(
         &mut self,
         event: ToClients<impl Event>,
-        targets: impl Into<Vec<Entity>>,
+        targets: impl RemoteTargets,
     ) {
         self.send_event(ToClients {
             mode: event.mode,
             event: RemoteTrigger {
                 event: event.event,
-                targets: targets.into(),
+                targets: targets.into_entities(),
             },
         });
     }

--- a/src/core/event/trigger.rs
+++ b/src/core/event/trigger.rs
@@ -1,0 +1,46 @@
+use bevy::prelude::*;
+
+/// An event that used under the hood for client and server triggers.
+///
+/// We can't just observe for triggers like we do for events since we need access to all its targets
+/// and we need to buffer them. This is why we just emit this event instead and after receive drain it
+/// to trigger regular events.
+///
+/// Traditional trigger interface is provided by [`ClientTriggerExt`](super::client_trigger::ClientTriggerExt)
+/// and [`ServerTriggerExt`](super::server_trigger::ServerTriggerExt).
+#[derive(Event)]
+pub(super) struct RemoteTrigger<E> {
+    pub(super) event: E,
+    pub(super) targets: Vec<Entity>,
+}
+
+/// Like [`TriggerTargets`](bevy::ecs::observer::TriggerTargets), but for remote triggers
+/// where targets can only be entities.
+pub trait RemoteTargets {
+    /// Entities the trigger should target.
+    fn into_entities(self) -> Vec<Entity>;
+}
+
+impl RemoteTargets for Entity {
+    fn into_entities(self) -> Vec<Entity> {
+        vec![self]
+    }
+}
+
+impl RemoteTargets for Vec<Entity> {
+    fn into_entities(self) -> Vec<Entity> {
+        self
+    }
+}
+
+impl<const N: usize> RemoteTargets for [Entity; N] {
+    fn into_entities(self) -> Vec<Entity> {
+        self.to_vec()
+    }
+}
+
+impl RemoteTargets for &[Entity] {
+    fn into_entities(self) -> Vec<Entity> {
+        self.to_vec()
+    }
+}

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -49,7 +49,7 @@ fn sending_receiving_with_target() {
 
     client_app
         .world_mut()
-        .client_trigger_targets(DummyEvent, [client_entity]);
+        .client_trigger_targets(DummyEvent, client_entity);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -67,7 +67,7 @@ fn sending_receiving_with_target() {
             mode: SendMode::Broadcast,
             event: DummyEvent,
         },
-        [server_entity],
+        server_entity,
     );
 
     server_app.update();


### PR DESCRIPTION
Bevy provides `TriggerTargets` to avoid placing extra `[]` for single entity.
In this PR I created a similar trait.
We can't re-use the one from Bevy because we don't support components as targets yet.