### PR TITLE
Improve connection triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `StartReplication` is now a trigger-event.
-- `ServerEvent` is now a trigger-event.
+- `ServerEvent` now split into `ClientConnected` and `ClientDisconnected` that are trigger-events.
+- `reason` field in `ClientDisconnected` now stores `DisconnectReason` enum.
 - Event serialization functions now accept `&mut Vec<u8>` instead of `&mut Cursor<Vec<u8>>`.
 - `RepliconChannels::create_server_channel` and `RepliconChannels::create_client_channel` now accept `impl Into<RepliconChannel>` instead of just `RepliconChannel`.
 - Use `debug!` instead of `trace!` for events. They are not very verbose.
-- Rename `ServerEvent::SendEvents` into `ServerEvent::TriggerServerEvents`.
+- Rename `ServerSet::SendEvents` into `ServerSet::TriggerConnectionEvents`.
 - Rename `core::event_registry` into `core::event`.
 - Rename `ClientEventsPlugin` into `ClientEventPlugin` (singular).
 - Rename `ServerEventsPlugin` into `ServerEventPlugin` (singular).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ all-features = true
 
 [dependencies]
 bevy = { version = "0.15", default-features = false, features = ["serialize"] }
+thiserror = "2.0"
 typeid = "1.0"
 bytes = "1.5"
 bincode = "1.3"

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,8 +9,11 @@ pub mod replicon_server;
 pub mod replicon_tick;
 pub mod server_entity_map;
 
+use std::error::Error;
+
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use channels::RepliconChannels;
 use event::event_registry::EventRegistry;
@@ -56,3 +59,20 @@ impl ClientId {
         self.0
     }
 }
+
+/// Possible reason for a disconnection.
+#[derive(Debug, Error)]
+pub enum DisconnectReason {
+    /// Connection was terminated by the client.
+    #[error("connection terminated by the client")]
+    DisconnectedByClient,
+    /// Connection was terminated by the server.
+    #[error("connection terminated by the server")]
+    DisconnectedByServer,
+    /// A reason defined by backend.
+    #[error(transparent)]
+    Backend(#[from] Box<BackendError>),
+}
+
+/// Alias for error inside [`DisconnectReason::Backend`].
+pub type BackendError = dyn Error + Send + Sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ We provide a [`prelude`] module, which exports most of the typically used traits
 The library doesn't provide any I/O, so you need to add a
 [messaging backend](https://github.com/projectharmonia/bevy_replicon#messaging-backends).
 If you want to write an integration for a messaging backend,
-see the documentation for [`RepliconServer`], [`RepliconClient`] and [`ServerEvent`].
+see the documentation for [`RepliconServer`], [`RepliconClient`], [`ClientConnected`] and [`ClientDisconnected`].
 You can also use `bevy_replicon_renet`, which we maintain, as a reference.
 
 Also depending on your game, you may want to use additional crates. For example, if your game
@@ -696,7 +696,7 @@ pub mod prelude {
             },
             replicon_client::{RepliconClient, RepliconClientStatus},
             replicon_server::RepliconServer,
-            ClientId, RepliconCorePlugin,
+            BackendError, ClientId, DisconnectReason, RepliconCorePlugin,
         },
         RepliconPlugins,
     };
@@ -710,7 +710,7 @@ pub mod prelude {
     pub use super::server::{
         client_entity_map::{ClientEntityMap, ClientMapping},
         event::ServerEventPlugin,
-        ServerEvent, ServerPlugin, ServerSet, StartReplication, TickPolicy,
+        ClientConnected, ClientDisconnected, ServerPlugin, ServerSet, StartReplication, TickPolicy,
     };
 
     #[cfg(feature = "client_diagnostics")]

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -5,9 +5,9 @@ use crate::{
         replication::replicated_clients::ReplicatedClients,
         replicon_client::{RepliconClient, RepliconClientStatus},
         replicon_server::RepliconServer,
-        ClientId,
+        ClientId, DisconnectReason,
     },
-    server::ServerEvent,
+    server::{ClientConnected, ClientDisconnected},
 };
 
 /**
@@ -110,8 +110,7 @@ impl ServerTestAppExt for App {
         let mut server = self.world_mut().resource_mut::<RepliconServer>();
         server.set_running(true);
 
-        self.world_mut()
-            .trigger(ServerEvent::ClientConnected { client_id });
+        self.world_mut().trigger(ClientConnected { client_id });
 
         self.update();
         client_app.update();
@@ -125,9 +124,9 @@ impl ServerTestAppExt for App {
 
         client.set_status(RepliconClientStatus::Disconnected);
 
-        self.world_mut().trigger(ServerEvent::ClientDisconnected {
+        self.world_mut().trigger(ClientDisconnected {
             client_id,
-            reason: "Disconnected by server".to_string(),
+            reason: DisconnectReason::DisconnectedByServer,
         });
 
         self.update();


### PR DESCRIPTION
- Split enum into 2 separate triggers. It makes them nicer to observe.
- Replace string-based `reason` with `DisconnectReason` enum.

I expect resources as entities land with Bevy 0.16 and planning to utilize `DisconnectReason` for `RepliconClientStatus::Disconnected` as well.
Right now I just can't provide a convenient API for backends to set it.
But with resources as entities backends will be able to utilize triggers to react on removals and update the `RepliconClientStatus` nicely.