### PR TITLE
Make systems standalone functions

### DIFF
--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -17,122 +17,115 @@ impl Plugin for ClientDiagnosticsPlugin {
         app.init_resource::<ClientReplicationStats>()
             .add_systems(
                 PreUpdate,
-                Self::add_measurements
+                add_measurements
                     .in_set(ClientSet::Diagnostics)
                     .run_if(client_connected),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::RTT)
+                Diagnostic::new(RTT)
                     .with_suffix(" s")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::PACKET_LOSS)
+                Diagnostic::new(PACKET_LOSS)
                     .with_suffix(" %")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::SENT_BPS)
+                Diagnostic::new(SENT_BPS)
                     .with_suffix(" byte/s")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::RECEIVED_BPS)
+                Diagnostic::new(RECEIVED_BPS)
                     .with_suffix(" byte/s")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::ENTITIES_CHANGED)
+                Diagnostic::new(ENTITIES_CHANGED)
                     .with_suffix(" entities changed")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::COMPONENTS_CHANGED)
+                Diagnostic::new(COMPONENTS_CHANGED)
                     .with_suffix(" components changed")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::MAPPINGS)
+                Diagnostic::new(MAPPINGS)
                     .with_suffix(" mappings")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::DESPAWNS)
+                Diagnostic::new(DESPAWNS)
                     .with_suffix(" despawns")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::REPLICATION_MESSAGES)
+                Diagnostic::new(REPLICATION_MESSAGES)
                     .with_suffix(" replication messages")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             )
             .register_diagnostic(
-                Diagnostic::new(Self::REPLICATION_BYTES)
+                Diagnostic::new(REPLICATION_BYTES)
                     .with_suffix(" replication bytes")
-                    .with_max_history_length(Self::DIAGNOSTIC_HISTORY_LEN),
+                    .with_max_history_length(DIAGNOSTIC_HISTORY_LEN),
             );
     }
 }
 
-impl ClientDiagnosticsPlugin {
-    /// Round-trip time.
-    pub const RTT: DiagnosticPath = DiagnosticPath::const_new("client/rtt");
-    /// The percent of packet loss.
-    pub const PACKET_LOSS: DiagnosticPath = DiagnosticPath::const_new("client/packet_loss");
-    /// How many messages sent per second.
-    pub const SENT_BPS: DiagnosticPath = DiagnosticPath::const_new("client/sent_bps");
-    /// How many bytes received per second.
-    pub const RECEIVED_BPS: DiagnosticPath = DiagnosticPath::const_new("client/received_bps");
+/// Round-trip time.
+pub const RTT: DiagnosticPath = DiagnosticPath::const_new("client/rtt");
+/// The percent of packet loss.
+pub const PACKET_LOSS: DiagnosticPath = DiagnosticPath::const_new("client/packet_loss");
+/// How many messages sent per second.
+pub const SENT_BPS: DiagnosticPath = DiagnosticPath::const_new("client/sent_bps");
+/// How many bytes received per second.
+pub const RECEIVED_BPS: DiagnosticPath = DiagnosticPath::const_new("client/received_bps");
 
-    /// How many entities changed by replication.
-    pub const ENTITIES_CHANGED: DiagnosticPath =
-        DiagnosticPath::const_new("client/replication/entities_changed");
-    /// How many components changed by replication.
-    pub const COMPONENTS_CHANGED: DiagnosticPath =
-        DiagnosticPath::const_new("client/replication/components_changed");
-    /// How many client-mappings added by replication.
-    pub const MAPPINGS: DiagnosticPath = DiagnosticPath::const_new("client/replication/mappings");
-    /// How many despawns applied by replication.
-    pub const DESPAWNS: DiagnosticPath = DiagnosticPath::const_new("client/replication/despawns");
-    /// How many replication messages received.
-    pub const REPLICATION_MESSAGES: DiagnosticPath =
-        DiagnosticPath::const_new("client/replication/messages");
-    /// How many replication bytes received.
-    pub const REPLICATION_BYTES: DiagnosticPath =
-        DiagnosticPath::const_new("client/replication/bytes");
+/// How many entities changed by replication.
+pub const ENTITIES_CHANGED: DiagnosticPath =
+    DiagnosticPath::const_new("client/replication/entities_changed");
+/// How many components changed by replication.
+pub const COMPONENTS_CHANGED: DiagnosticPath =
+    DiagnosticPath::const_new("client/replication/components_changed");
+/// How many client-mappings added by replication.
+pub const MAPPINGS: DiagnosticPath = DiagnosticPath::const_new("client/replication/mappings");
+/// How many despawns applied by replication.
+pub const DESPAWNS: DiagnosticPath = DiagnosticPath::const_new("client/replication/despawns");
+/// How many replication messages received.
+pub const REPLICATION_MESSAGES: DiagnosticPath =
+    DiagnosticPath::const_new("client/replication/messages");
+/// How many replication bytes received.
+pub const REPLICATION_BYTES: DiagnosticPath = DiagnosticPath::const_new("client/replication/bytes");
 
-    /// Max diagnostic history length.
-    pub const DIAGNOSTIC_HISTORY_LEN: usize = 60;
+/// Max diagnostic history length.
+pub const DIAGNOSTIC_HISTORY_LEN: usize = 60;
 
-    fn add_measurements(
-        mut diagnostics: Diagnostics,
-        stats: Res<ClientReplicationStats>,
-        mut last_stats: Local<ClientReplicationStats>,
-        client: Res<RepliconClient>,
-    ) {
-        diagnostics.add_measurement(&Self::RTT, || client.rtt());
-        diagnostics.add_measurement(&Self::PACKET_LOSS, || client.packet_loss());
-        diagnostics.add_measurement(&Self::SENT_BPS, || client.sent_bps());
-        diagnostics.add_measurement(&Self::RECEIVED_BPS, || client.received_bps());
+fn add_measurements(
+    mut diagnostics: Diagnostics,
+    stats: Res<ClientReplicationStats>,
+    mut last_stats: Local<ClientReplicationStats>,
+    client: Res<RepliconClient>,
+) {
+    diagnostics.add_measurement(&RTT, || client.rtt());
+    diagnostics.add_measurement(&PACKET_LOSS, || client.packet_loss());
+    diagnostics.add_measurement(&SENT_BPS, || client.sent_bps());
+    diagnostics.add_measurement(&RECEIVED_BPS, || client.received_bps());
 
-        diagnostics.add_measurement(&Self::ENTITIES_CHANGED, || {
-            (stats.entities_changed - last_stats.entities_changed) as f64
-        });
-        diagnostics.add_measurement(&Self::COMPONENTS_CHANGED, || {
-            (stats.components_changed - last_stats.components_changed) as f64
-        });
-        diagnostics.add_measurement(&Self::MAPPINGS, || {
-            (stats.mappings - last_stats.mappings) as f64
-        });
-        diagnostics.add_measurement(&Self::DESPAWNS, || {
-            (stats.despawns - last_stats.despawns) as f64
-        });
-        diagnostics.add_measurement(&Self::REPLICATION_MESSAGES, || {
-            (stats.messages - last_stats.messages) as f64
-        });
-        diagnostics.add_measurement(&Self::REPLICATION_BYTES, || {
-            (stats.bytes - last_stats.bytes) as f64
-        });
-        *last_stats = *stats;
-    }
+    diagnostics.add_measurement(&ENTITIES_CHANGED, || {
+        (stats.entities_changed - last_stats.entities_changed) as f64
+    });
+    diagnostics.add_measurement(&COMPONENTS_CHANGED, || {
+        (stats.components_changed - last_stats.components_changed) as f64
+    });
+    diagnostics.add_measurement(&MAPPINGS, || (stats.mappings - last_stats.mappings) as f64);
+    diagnostics.add_measurement(&DESPAWNS, || (stats.despawns - last_stats.despawns) as f64);
+    diagnostics.add_measurement(&REPLICATION_MESSAGES, || {
+        (stats.messages - last_stats.messages) as f64
+    });
+    diagnostics.add_measurement(&REPLICATION_BYTES, || {
+        (stats.bytes - last_stats.bytes) as f64
+    });
+    *last_stats = *stats;
 }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 /// Sending events from a client to the server.
 ///
-/// Requires [`ClientPlugin`].
+/// Requires [`ClientPlugin`](super::ClientPlugin).
 /// Can be disabled for apps that act only as servers.
 pub struct ClientEventPlugin;
 

--- a/src/server/despawn_buffer.rs
+++ b/src/server/despawn_buffer.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use super::{ServerPlugin, ServerSet};
+use super::ServerSet;
 use crate::core::{common_conditions::server_running, replication::Replicated};
 
 /// Treats removals of [`Replicated`] component as despawns and stores them into [`DespawnBuffer`] resource.
@@ -12,22 +12,20 @@ impl Plugin for DespawnBufferPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DespawnBuffer>().add_systems(
             PostUpdate,
-            Self::buffer_despawns
-                .before(ServerPlugin::send_replication)
+            buffer_despawns
+                .before(super::send_replication)
                 .in_set(ServerSet::Send)
                 .run_if(server_running),
         );
     }
 }
 
-impl DespawnBufferPlugin {
-    fn buffer_despawns(
-        mut removed_replications: RemovedComponents<Replicated>,
-        mut despawn_buffer: ResMut<DespawnBuffer>,
-    ) {
-        for entity in removed_replications.read() {
-            despawn_buffer.push(entity);
-        }
+fn buffer_despawns(
+    mut removed_replications: RemovedComponents<Replicated>,
+    mut despawn_buffer: ResMut<DespawnBuffer>,
+) {
+    for entity in removed_replications.read() {
+        despawn_buffer.push(entity);
     }
 }
 

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -18,7 +18,7 @@ use crate::core::{
 
 /// Sending events from the server to clients.
 ///
-/// Requires [`ServerPlugin`].
+/// Requires [`ServerPlugin`](super::ServerPlugin).
 /// Can be disabled for apps that act only as clients.
 pub struct ServerEventPlugin;
 

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::*,
 };
 
-use super::{server_tick::ServerTick, ServerPlugin, ServerSet};
+use super::{server_tick::ServerTick, ServerSet};
 use crate::core::{
     common_conditions::*,
     connected_clients::ConnectedClients,
@@ -46,7 +46,7 @@ impl Plugin for ServerEventPlugin {
             ParamBuilder,
         )
             .build_state(app.world_mut())
-            .build_system(Self::send_or_buffer);
+            .build_system(send_or_buffer);
 
         let receive = (
             FilteredResourcesMutParamBuilder::new(|builder| {
@@ -59,7 +59,7 @@ impl Plugin for ServerEventPlugin {
             ParamBuilder,
         )
             .build_state(app.world_mut())
-            .build_system(Self::receive);
+            .build_system(receive);
 
         let trigger = (
             FilteredResourcesMutParamBuilder::new(|builder| {
@@ -71,7 +71,7 @@ impl Plugin for ServerEventPlugin {
             ParamBuilder,
         )
             .build_state(app.world_mut())
-            .build_system(Self::trigger);
+            .build_system(trigger);
 
         let resend_locally = (
             FilteredResourcesMutParamBuilder::new(|builder| {
@@ -87,7 +87,7 @@ impl Plugin for ServerEventPlugin {
             ParamBuilder,
         )
             .build_state(app.world_mut())
-            .build_system(Self::resend_locally);
+            .build_system(resend_locally);
 
         app.insert_resource(event_registry)
             .add_systems(
@@ -103,108 +103,106 @@ impl Plugin for ServerEventPlugin {
                 PostUpdate,
                 (
                     send_or_buffer.run_if(server_running),
-                    Self::send_buffered
+                    send_buffered
                         .run_if(server_running)
                         .run_if(resource_changed::<ServerTick>),
                     resend_locally.run_if(server_or_singleplayer),
                 )
                     .chain()
-                    .after(ServerPlugin::send_replication)
+                    .after(super::send_replication)
                     .in_set(ServerSet::Send),
             );
     }
 }
 
-impl ServerEventPlugin {
-    fn send_or_buffer(
-        server_events: FilteredResources,
-        mut server: ResMut<RepliconServer>,
-        mut buffered_events: ResMut<BufferedServerEvents>,
-        registry: Res<AppTypeRegistry>,
-        connected_clients: Res<ConnectedClients>,
-        event_registry: Res<EventRegistry>,
-    ) {
-        buffered_events.start_tick();
-        let mut ctx = ServerSendCtx {
-            registry: &registry.read(),
-        };
+fn send_or_buffer(
+    server_events: FilteredResources,
+    mut server: ResMut<RepliconServer>,
+    mut buffered_events: ResMut<BufferedServerEvents>,
+    registry: Res<AppTypeRegistry>,
+    connected_clients: Res<ConnectedClients>,
+    event_registry: Res<EventRegistry>,
+) {
+    buffered_events.start_tick();
+    let mut ctx = ServerSendCtx {
+        registry: &registry.read(),
+    };
 
-        for event in event_registry.iter_server_events() {
-            let server_events = server_events
-                .get_by_id(event.server_events_id())
-                .expect("server events resource should be accessible");
+    for event in event_registry.iter_server_events() {
+        let server_events = server_events
+            .get_by_id(event.server_events_id())
+            .expect("server events resource should be accessible");
 
-            // SAFETY: passed pointer was obtained using this event data.
-            unsafe {
-                event.send_or_buffer(
-                    &mut ctx,
-                    &server_events,
-                    &mut server,
-                    &connected_clients,
-                    &mut buffered_events,
-                );
-            }
+        // SAFETY: passed pointer was obtained using this event data.
+        unsafe {
+            event.send_or_buffer(
+                &mut ctx,
+                &server_events,
+                &mut server,
+                &connected_clients,
+                &mut buffered_events,
+            );
         }
     }
+}
 
-    fn send_buffered(
-        mut server: ResMut<RepliconServer>,
-        mut buffered_events: ResMut<BufferedServerEvents>,
-        replicated_clients: Res<ReplicatedClients>,
-    ) {
-        buffered_events
-            .send_all(&mut server, &replicated_clients)
-            .expect("buffered server events should send");
+fn send_buffered(
+    mut server: ResMut<RepliconServer>,
+    mut buffered_events: ResMut<BufferedServerEvents>,
+    replicated_clients: Res<ReplicatedClients>,
+) {
+    buffered_events
+        .send_all(&mut server, &replicated_clients)
+        .expect("buffered server events should send");
+}
+
+fn receive(
+    mut client_events: FilteredResourcesMut,
+    mut server: ResMut<RepliconServer>,
+    registry: Res<AppTypeRegistry>,
+    event_registry: Res<EventRegistry>,
+) {
+    let mut ctx = ServerReceiveCtx {
+        registry: &registry.read(),
+    };
+
+    for event in event_registry.iter_client_events() {
+        let client_events = client_events
+            .get_mut_by_id(event.client_events_id())
+            .expect("client events resource should be accessible");
+
+        // SAFETY: passed pointer was obtained using this event data.
+        unsafe { event.receive(&mut ctx, client_events.into_inner(), &mut server) };
     }
+}
 
-    fn receive(
-        mut client_events: FilteredResourcesMut,
-        mut server: ResMut<RepliconServer>,
-        registry: Res<AppTypeRegistry>,
-        event_registry: Res<EventRegistry>,
-    ) {
-        let mut ctx = ServerReceiveCtx {
-            registry: &registry.read(),
-        };
-
-        for event in event_registry.iter_client_events() {
-            let client_events = client_events
-                .get_mut_by_id(event.client_events_id())
-                .expect("client events resource should be accessible");
-
-            // SAFETY: passed pointer was obtained using this event data.
-            unsafe { event.receive(&mut ctx, client_events.into_inner(), &mut server) };
-        }
+fn trigger(
+    mut client_events: FilteredResourcesMut,
+    mut commands: Commands,
+    event_registry: Res<EventRegistry>,
+) {
+    for trigger in event_registry.iter_client_triggers() {
+        let client_events = client_events
+            .get_mut_by_id(trigger.event().client_events_id())
+            .expect("client events resource should be accessible");
+        trigger.trigger(&mut commands, client_events.into_inner());
     }
+}
 
-    fn trigger(
-        mut client_events: FilteredResourcesMut,
-        mut commands: Commands,
-        event_registry: Res<EventRegistry>,
-    ) {
-        for trigger in event_registry.iter_client_triggers() {
-            let client_events = client_events
-                .get_mut_by_id(trigger.event().client_events_id())
-                .expect("client events resource should be accessible");
-            trigger.trigger(&mut commands, client_events.into_inner());
-        }
-    }
+fn resend_locally(
+    mut server_events: FilteredResourcesMut,
+    mut events: FilteredResourcesMut,
+    event_registry: Res<EventRegistry>,
+) {
+    for event in event_registry.iter_server_events() {
+        let server_events = server_events
+            .get_mut_by_id(event.server_events_id())
+            .expect("server events resource should be accessible");
+        let events = events
+            .get_mut_by_id(event.events_id())
+            .expect("events resource should be accessible");
 
-    fn resend_locally(
-        mut server_events: FilteredResourcesMut,
-        mut events: FilteredResourcesMut,
-        event_registry: Res<EventRegistry>,
-    ) {
-        for event in event_registry.iter_server_events() {
-            let server_events = server_events
-                .get_mut_by_id(event.server_events_id())
-                .expect("server events resource should be accessible");
-            let events = events
-                .get_mut_by_id(event.events_id())
-                .expect("events resource should be accessible");
-
-            // SAFETY: passed pointers were obtained using this event data.
-            unsafe { event.resend_locally(server_events.into_inner(), events.into_inner()) };
-        }
+        // SAFETY: passed pointers were obtained using this event data.
+        unsafe { event.resend_locally(server_events.into_inner(), events.into_inner()) };
     }
 }


### PR DESCRIPTION
I used to put systems under plugin impls to clarify that the system belongs to a plugin.
But looks like in Bevy using standalone systems is more common. I think it's especially makes sense now with observers. Let's follow this pattern.