### PR TITLE
Update `ReplicatedClients` immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `ReplicatedClients` immediately to let users set visibility on `ClientConnected` trigger.
+
 ## [0.30.0] - 2025-02-04
 
 ### Added

--- a/src/server.rs
+++ b/src/server.rs
@@ -176,15 +176,15 @@ pub fn increment_tick(mut server_tick: ResMut<ServerTick>) {
 
 fn handle_connects(
     trigger: Trigger<ClientConnected>,
-    mut commands: Commands,
     mut connected_clients: ResMut<ConnectedClients>,
-    replicated_clients: Res<ReplicatedClients>,
+    mut replicated_clients: ResMut<ReplicatedClients>,
     mut buffered_events: ResMut<BufferedServerEvents>,
+    mut client_buffers: ResMut<ClientBuffers>,
 ) {
     debug!("`{:?}` connected", trigger.client_id);
     connected_clients.add(trigger.client_id);
     if replicated_clients.replicate_after_connect() {
-        commands.trigger(StartReplication(trigger.client_id));
+        replicated_clients.add(&mut client_buffers, trigger.client_id);
     }
     buffered_events.exclude_client(trigger.client_id);
 }


### PR DESCRIPTION
To let users set visibility on `ClientConnected` trigger.