### PR TITLE
Switch from bincode to postcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `ReplicatedClients` immediately to let users set visibility on `ClientConnected` trigger.
 
+### Changed
+
+- Replace `bincode` with `postcard`. It has more suitable variable integer encoding and potentially unlocks `no_std` support. If you use custom ser/de functions, replace `DefaultOptions::new().serialize_into(message, event)` with `postcard_utils::to_extend_mut(event, message)` and `DefaultOptions::new().deserialize_from(cursor)` with `postcard_utils::from_buf(message)`.
+- All serde methods now use `postcard::Result` instead of `bincode::Result`.
+- All deserialization methods now accept `Bytes` instead of `std::io::Cursor` because deserialization from `std::io::Read` requires a temporary buffer. `Bytes` already provide cursor-like functionality. The crate now re-exported under `bevy_replicon::bytes`.
+
 ## [0.30.0] - 2025-02-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,11 @@ serde = "1.0"
 bevy = { workspace = true, features = ["serialize"] }
 thiserror = "2.0"
 typeid = "1.0"
-bytes = "1.5"
-bincode = "1.3"
+bytes = "1.10"
 serde.workspace = true
-integer-encoding = "4.0"
 ordered-multimap = "0.7"
 bitflags = "2.6"
+postcard = { version = "1.1", default-features = false }
 
 [dev-dependencies]
 bevy = { workspace = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ typeid = "1.0"
 bytes = "1.10"
 serde.workspace = true
 ordered-multimap = "0.7"
-bitflags = "2.6"
+bitflags = { version = "2.6", features = ["serde"] }
 postcard = { version = "1.1", default-features = false }
 
 [dev-dependencies]

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,6 +3,7 @@ pub mod common_conditions;
 pub mod connected_clients;
 pub mod entity_serde;
 pub mod event;
+pub mod postcard_utils;
 pub mod replication;
 pub mod replicon_client;
 pub mod replicon_server;

--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -61,7 +61,7 @@ pub trait ClientEventAppExt {
     /**
     Same as [`Self::add_client_event`], but uses the specified functions for serialization and deserialization.
 
-    See also [`postcard_utils`](crate::core::postcard_utils) and
+    See also [`postcard_utils`] and
     [`ClientTriggerAppExt::add_client_trigger_with`](super::client_trigger::ClientTriggerAppExt::add_client_trigger_with)
 
     # Examples

--- a/src/core/event/event_fns.rs
+++ b/src/core/event/event_fns.rs
@@ -1,8 +1,9 @@
 use std::{
     any::{self, TypeId},
-    io::Cursor,
     mem,
 };
+
+use bytes::Bytes;
 
 /// Type-erased version of [`EventFns`].
 ///
@@ -157,12 +158,12 @@ impl<S, D, E, I> EventFns<S, D, E, I> {
         ctx: &mut S,
         event: &E,
         message: &mut Vec<u8>,
-    ) -> bincode::Result<()> {
+    ) -> postcard::Result<()> {
         (self.outer_serialize)(ctx, event, message, self.serialize)
     }
 
-    pub(super) fn deserialize(self, ctx: &mut D, cursor: &mut Cursor<&[u8]>) -> bincode::Result<E> {
-        (self.outer_deserialize)(ctx, cursor, self.deserialize)
+    pub(super) fn deserialize(self, ctx: &mut D, message: &mut Bytes) -> postcard::Result<E> {
+        (self.outer_deserialize)(ctx, message, self.deserialize)
     }
 }
 
@@ -171,28 +172,28 @@ fn default_outer_serialize<C, E>(
     event: &E,
     message: &mut Vec<u8>,
     serialize: EventSerializeFn<C, E>,
-) -> bincode::Result<()> {
+) -> postcard::Result<()> {
     (serialize)(ctx, event, message)
 }
 
 fn default_outer_deserialize<C, E>(
     ctx: &mut C,
-    cursor: &mut Cursor<&[u8]>,
+    message: &mut Bytes,
     deserialize: EventDeserializeFn<C, E>,
-) -> bincode::Result<E> {
-    (deserialize)(ctx, cursor)
+) -> postcard::Result<E> {
+    (deserialize)(ctx, message)
 }
 
 /// Signature of event serialization functions.
-pub type EventSerializeFn<C, E> = fn(&mut C, &E, &mut Vec<u8>) -> bincode::Result<()>;
+pub type EventSerializeFn<C, E> = fn(&mut C, &E, &mut Vec<u8>) -> postcard::Result<()>;
 
 /// Signature of event deserialization functions.
-pub type EventDeserializeFn<C, E> = fn(&mut C, &mut Cursor<&[u8]>) -> bincode::Result<E>;
+pub type EventDeserializeFn<C, E> = fn(&mut C, &mut Bytes) -> postcard::Result<E>;
 
 /// Signature of outer serialization functions.
 pub(super) type OuterSerializeFn<C, E, I> =
-    fn(&mut C, &E, &mut Vec<u8>, EventSerializeFn<C, I>) -> bincode::Result<()>;
+    fn(&mut C, &E, &mut Vec<u8>, EventSerializeFn<C, I>) -> postcard::Result<()>;
 
 /// Signature of outer deserialization functions.
 pub(super) type OuterDeserializeFn<C, E, I> =
-    fn(&mut C, &mut Cursor<&[u8]>, EventDeserializeFn<C, I>) -> bincode::Result<E>;
+    fn(&mut C, &mut Bytes, EventDeserializeFn<C, I>) -> postcard::Result<E>;

--- a/src/core/event/server_event.rs
+++ b/src/core/event/server_event.rs
@@ -63,7 +63,7 @@ pub trait ServerEventAppExt {
     /**
     Same as [`Self::add_server_event`], but uses the specified functions for serialization and deserialization.
 
-    See also [`postcard_utils`](crate::core::postcard_utils) and
+    See also [`postcard_utils`] and
     [`ServerTriggerAppExt::add_server_trigger_with`](super::server_trigger::ServerTriggerAppExt::add_server_trigger_with)
 
     # Examples

--- a/src/core/event/server_trigger.rs
+++ b/src/core/event/server_trigger.rs
@@ -1,7 +1,7 @@
-use std::{any, io::Cursor};
+use std::any;
 
 use bevy::{ecs::entity::MapEntities, prelude::*, ptr::PtrMut};
-use integer_encoding::{VarIntReader, VarIntWriter};
+use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{
@@ -11,7 +11,7 @@ use super::{
     server_event::{self, ServerEvent, ToClients},
     trigger::{RemoteTargets, RemoteTrigger},
 };
-use crate::core::{channels::RepliconChannel, entity_serde};
+use crate::core::{channels::RepliconChannel, entity_serde, postcard_utils};
 
 /// An extension trait for [`App`] for creating server triggers.
 ///
@@ -141,8 +141,8 @@ fn trigger_serialize<'a, E>(
     trigger: &RemoteTrigger<E>,
     message: &mut Vec<u8>,
     serialize: EventSerializeFn<ServerSendCtx<'a>, E>,
-) -> bincode::Result<()> {
-    message.write_varint(trigger.targets.len())?;
+) -> postcard::Result<()> {
+    postcard_utils::to_extend_mut(&trigger.targets.len(), message)?;
     for &entity in &trigger.targets {
         entity_serde::serialize_entity(message, entity)?;
     }
@@ -156,17 +156,17 @@ fn trigger_serialize<'a, E>(
 /// Used as outer function for [`EventFns`].
 fn trigger_deserialize<'a, E>(
     ctx: &mut ClientReceiveCtx<'a>,
-    cursor: &mut Cursor<&[u8]>,
+    message: &mut Bytes,
     deserialize: EventDeserializeFn<ClientReceiveCtx<'a>, E>,
-) -> bincode::Result<RemoteTrigger<E>> {
-    let len = cursor.read_varint()?;
+) -> postcard::Result<RemoteTrigger<E>> {
+    let len = postcard_utils::from_buf(message)?;
     let mut targets = Vec::with_capacity(len);
     for _ in 0..len {
-        let entity = entity_serde::deserialize_entity(cursor)?;
+        let entity = entity_serde::deserialize_entity(message)?;
         targets.push(ctx.map_entity(entity));
     }
 
-    let event = (deserialize)(ctx, cursor)?;
+    let event = (deserialize)(ctx, message)?;
 
     Ok(RemoteTrigger { event, targets })
 }

--- a/src/core/postcard_utils.rs
+++ b/src/core/postcard_utils.rs
@@ -1,0 +1,192 @@
+//! Extensions for postcard to make streaming serialization and deserialiation more ergonomic.
+
+use std::slice;
+
+use bytes::Buf;
+use postcard::{de_flavors::Flavor as DeFlavor, ser_flavors::Flavor as SerFlavor, Deserializer};
+use serde::{Deserialize, Serialize};
+
+// TODO: replace with https://github.com/jamesmunns/postcard/pull/210 after release.
+/// Serializes a value to an [`Extend`] writer.
+///
+/// Similar to [`postcard::to_extend`], but it takes the writer by reference instead of by value
+/// to remain in control of the writer.
+///
+/// See also [`from_buf`].
+///
+/// # Examples
+///
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_replicon::core::postcard_utils;
+///
+/// let transform = Transform::default();
+/// let mut message = Vec::new();
+/// postcard_utils::to_extend_mut(&transform, &mut message).unwrap();
+/// assert!(!message.is_empty());
+/// ```
+pub fn to_extend_mut<T: Serialize + ?Sized, W: Extend<u8>>(
+    value: &T,
+    writer: &mut W,
+) -> postcard::Result<()> {
+    postcard::serialize_with_flavor(value, ExtendMutFlavor::new(writer))
+}
+
+/// A serialization flavor for an [`Extend<u8>`].
+///
+/// It's similar to [`ExtendFlavor`](postcard::ser_flavors::ExtendFlavor), but accepts a mutable reference.
+///
+/// Most of the time you can use more convenient [`to_extend_mut`] helper, unless you need access to [`postcard::Serializer`].
+///
+/// # Examples
+///
+/// Serializing a reflected type:
+///
+/// ```
+/// use bevy::{
+///     prelude::*,
+///     reflect::{serde::ReflectSerializer, TypeRegistry},
+/// };
+/// use bevy_replicon::core::postcard_utils::ExtendMutFlavor;
+/// use postcard::Serializer;
+/// use serde::Serialize;
+///
+/// let mut registry = TypeRegistry::default();
+/// registry.register::<Transform>();
+/// let transform = Transform::default();
+/// let mut message = Vec::new();
+/// let mut serializer = Serializer { output: ExtendMutFlavor::new(&mut message) };
+/// ReflectSerializer::new(transform.as_partial_reflect(), &registry).serialize(&mut serializer).unwrap();
+/// assert!(!message.is_empty());
+/// ```
+pub struct ExtendMutFlavor<'a, T: Extend<u8>> {
+    bytes: &'a mut T,
+}
+
+impl<'a, T: Extend<u8>> ExtendMutFlavor<'a, T> {
+    /// Creates a new instance from the given collection.
+    pub fn new(bytes: &'a mut T) -> Self {
+        Self { bytes }
+    }
+}
+
+impl<T: Extend<u8>> SerFlavor for ExtendMutFlavor<'_, T> {
+    type Output = ();
+
+    fn try_push(&mut self, data: u8) -> postcard::Result<()> {
+        self.bytes.extend([data]);
+        Ok(())
+    }
+
+    fn try_extend(&mut self, data: &[u8]) -> postcard::Result<()> {
+        self.bytes.extend(data.iter().copied());
+        Ok(())
+    }
+
+    fn finalize(self) -> postcard::Result<Self::Output> {
+        Ok(())
+    }
+}
+
+/// Deserializes a message from a buffer.
+///
+/// Similar to [`postcard::take_from_bytes`], but accepts a sliding buffer
+/// avoiding the need for the caller to reassign the original slice with the returned unused portion.
+///
+/// See also [`to_extend_mut`].
+///
+/// # Examples
+///
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_replicon::{Bytes, core::postcard_utils};
+///
+/// # let transform = Transform::default();
+/// # let mut message = Vec::new();
+/// # postcard_utils::to_extend_mut(&transform, &mut message).unwrap();
+/// let mut message: Bytes = message.into();
+/// let new_transform: Transform = postcard_utils::from_buf(&mut message).unwrap();
+/// # assert_eq!(transform, new_transform);
+/// # assert!(message.is_empty());
+/// ```
+pub fn from_buf<'de, T: Deserialize<'de>, B: Buf>(buf: &'de mut B) -> postcard::Result<T> {
+    let mut deserializer = Deserializer::from_flavor(BufFlavor::new(buf));
+    T::deserialize(&mut deserializer)
+}
+
+/// A deserialization flavor for a borrowed buffer.
+///
+/// Unlike [`Slice`](postcard::de_flavors::Slice), deserialization advances buffer's cursor.
+///
+/// Most of the time you can use more convenient [`from_buf`] helper, unless you need access to [`postcard::Deserializer`].
+///
+/// # Examples
+///
+/// Deserializing a reflected type:
+///
+/// ```
+/// # use bevy::{prelude::*, reflect::{serde::ReflectSerializer, TypeRegistry}};
+/// # use bevy_replicon::{core::postcard_utils::ExtendMutFlavor};
+/// # use postcard::Serializer;
+/// # use serde::Serialize;
+/// use bevy::reflect::serde::ReflectDeserializer;
+/// use bevy_replicon::{bytes::Bytes, core::postcard_utils::BufFlavor};
+/// use postcard::Deserializer;
+/// use serde::de::DeserializeSeed;
+///
+/// # let mut registry = TypeRegistry::default();
+/// # registry.register::<Transform>();
+/// # let transform = Transform::default();
+/// # let mut message = Vec::new();
+/// # let mut serializer = Serializer { output: ExtendMutFlavor::new(&mut message) };
+/// # ReflectSerializer::new(transform.as_partial_reflect(), &registry).serialize(&mut serializer).unwrap();
+/// let mut message: Bytes = message.into();
+/// let mut deserializer = Deserializer::from_flavor(BufFlavor::new(&mut message));
+/// let reflect = ReflectDeserializer::new(&registry).deserialize(&mut deserializer).unwrap();
+/// # assert!(transform.reflect_partial_eq(&*reflect).unwrap());
+/// # assert!(message.is_empty());
+/// ```
+pub struct BufFlavor<'a, T: Buf> {
+    buf: &'a mut T,
+}
+
+impl<'a, T: Buf> BufFlavor<'a, T> {
+    /// Creates a new instance from a buffer.
+    pub fn new(buf: &'a mut T) -> Self {
+        Self { buf }
+    }
+}
+
+impl<'a, T: Buf> DeFlavor<'a> for BufFlavor<'a, T> {
+    type Remainder = ();
+    type Source = &'a [u8];
+
+    fn pop(&mut self) -> postcard::Result<u8> {
+        if self.buf.remaining() == 0 {
+            panic!("asdf");
+        }
+        self.buf
+            .try_get_u8()
+            .map_err(|_| postcard::Error::DeserializeUnexpectedEnd)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.buf.remaining())
+    }
+
+    fn try_take_n(&mut self, ct: usize) -> postcard::Result<&'a [u8]> {
+        if self.buf.remaining() < ct {
+            return Err(postcard::Error::DeserializeUnexpectedEnd);
+        }
+
+        // SAFETY: slice was validated and its lifetime is tied to the buffer.
+        let buf = unsafe { slice::from_raw_parts(self.buf.chunk().as_ptr(), ct) };
+        self.buf.advance(ct);
+
+        Ok(buf)
+    }
+
+    fn finalize(self) -> postcard::Result<Self::Remainder> {
+        Ok(())
+    }
+}

--- a/src/core/postcard_utils.rs
+++ b/src/core/postcard_utils.rs
@@ -99,7 +99,7 @@ impl<T: Extend<u8>> SerFlavor for ExtendMutFlavor<'_, T> {
 ///
 /// ```
 /// use bevy::prelude::*;
-/// use bevy_replicon::{Bytes, core::postcard_utils};
+/// use bevy_replicon::{bytes::Bytes, core::postcard_utils};
 ///
 /// # let transform = Transform::default();
 /// # let mut message = Vec::new();

--- a/src/core/replication.rs
+++ b/src/core/replication.rs
@@ -1,5 +1,6 @@
 pub mod command_markers;
 pub mod deferred_entity;
+pub(crate) mod mutate_index;
 pub mod replicated_clients;
 pub mod replication_registry;
 pub mod replication_rules;

--- a/src/core/replication/command_markers.rs
+++ b/src/core/replication/command_markers.rs
@@ -47,10 +47,9 @@ pub trait AppMarkerExt {
     Then [`Transform`] updates after that will be inserted to the history.
 
     ```
-    use std::io::Cursor;
-
     use bevy::{ecs::system::EntityCommands, prelude::*, utils::HashMap};
     use bevy_replicon::{
+        bytes::Bytes,
         core::{
             replication::{
                 command_markers::MarkerConfig,
@@ -78,9 +77,9 @@ pub trait AppMarkerExt {
         ctx: &mut WriteCtx,
         rule_fns: &RuleFns<C>,
         entity: &mut DeferredEntity,
-        cursor: &mut Cursor<&[u8]>,
-    ) -> bincode::Result<()> {
-        let component: C = rule_fns.deserialize(ctx, cursor)?;
+        message: &mut Bytes,
+    ) -> postcard::Result<()> {
+        let component: C = rule_fns.deserialize(ctx, message)?;
         if let Some(mut history) = entity.get_mut::<History<C>>() {
             history.insert(ctx.message_tick, component);
         } else {

--- a/src/core/replication/mutate_index.rs
+++ b/src/core/replication/mutate_index.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+/// Identifier for mutate messages.
+///
+/// Use for mutations acknowledgement.
+///
+/// Its serialization uses fixint encoding as serializing ticks as varints increases the average message size.
+/// A tick >= 2^14 will be [5 bytes](https://postcard.jamesmunns.com/wire-format.html#maximum-encoded-length)
+/// At 60 ticks/sec, that will happen after ~5 minutes. So any session over this time period would transmit
+/// more total bytes with varint encoding.
+#[derive(Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct MutateIndex(#[serde(with = "postcard::fixint::le")] u16);
+
+impl MutateIndex {
+    /// Returns the current value and increments `self` by 1.
+    ///
+    /// Wraps on overflow.
+    pub(crate) fn advance(&mut self) -> Self {
+        let next = *self;
+        self.0 = self.0.wrapping_add(1);
+        next
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance() {
+        let mut index = MutateIndex(u16::MAX - 1);
+
+        assert_eq!(index.advance(), MutateIndex(u16::MAX - 1));
+        assert_eq!(index, MutateIndex(u16::MAX));
+
+        assert_eq!(index.advance(), MutateIndex(u16::MAX));
+        assert_eq!(index, MutateIndex(0));
+    }
+}

--- a/src/core/replication/replication_registry/test_fns.rs
+++ b/src/core/replication/replication_registry/test_fns.rs
@@ -52,7 +52,7 @@ let mut entity = app.world_mut().spawn(DummyComponent);
 let data = entity.serialize(fns_id, tick);
 entity.remove::<DummyComponent>();
 
-entity.apply_write(&data, fns_id, tick);
+entity.apply_write(data, fns_id, tick);
 assert!(entity.contains::<DummyComponent>());
 
 entity.apply_remove(fns_id, tick);

--- a/src/core/replication/replication_registry/test_fns.rs
+++ b/src/core/replication/replication_registry/test_fns.rs
@@ -1,6 +1,5 @@
-use std::io::Cursor;
-
 use bevy::{ecs::world::CommandQueue, prelude::*};
+use bytes::Bytes;
 
 use super::{
     ctx::{DespawnCtx, RemoveCtx, SerializeCtx, WriteCtx},
@@ -78,7 +77,12 @@ pub trait TestFnsEntityExt {
     /// writes it into an entity using a write function based on markers.
     ///
     /// See also [`AppMarkerExt`](crate::core::replication::command_markers::AppMarkerExt).
-    fn apply_write(&mut self, data: &[u8], fns_id: FnsId, message_tick: RepliconTick) -> &mut Self;
+    fn apply_write(
+        &mut self,
+        bytes: impl Into<Bytes>,
+        fns_id: FnsId,
+        message_tick: RepliconTick,
+    ) -> &mut Self;
 
     /// Removes a component using a registered function for it.
     ///
@@ -115,7 +119,12 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
         message
     }
 
-    fn apply_write(&mut self, data: &[u8], fns_id: FnsId, message_tick: RepliconTick) -> &mut Self {
+    fn apply_write(
+        &mut self,
+        data: impl Into<Bytes>,
+        fns_id: FnsId,
+        message_tick: RepliconTick,
+    ) -> &mut Self {
         let mut entity_markers = self.world_scope(EntityMarkers::from_world);
         let command_markers = self.world().resource::<CommandMarkers>();
         entity_markers.read(command_markers, &*self);
@@ -129,7 +138,6 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
                     let mut commands = entity.commands(&mut queue);
 
                     let (component_id, component_fns, rule_fns) = registry.get(fns_id);
-                    let mut cursor = Cursor::new(data);
                     let mut ctx =
                         WriteCtx::new(&mut commands, &mut entity_map, component_id, message_tick);
 
@@ -140,7 +148,7 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
                                 rule_fns,
                                 &entity_markers,
                                 &mut entity,
-                                &mut cursor,
+                                &mut data.into(),
                             )
                             .expect("writing data into an entity shouldn't fail");
                     }

--- a/src/core/replication/replication_rules.rs
+++ b/src/core/replication/replication_rules.rs
@@ -271,7 +271,7 @@ Can be implemented on any struct to create a custom replication group.
 ```
 # use bevy::prelude::*;
 # use bevy_replicon::{
-#     bytes::Bytes
+#     bytes::Bytes,
 #     core::replication::{
 #         replication_registry::{
 #             ctx::{SerializeCtx, WriteCtx},

--- a/src/core/replication/update_message_flags.rs
+++ b/src/core/replication/update_message_flags.rs
@@ -1,10 +1,11 @@
 use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
 
 bitflags! {
     /// Types of data included in the update message if the bit is set.
     ///
     /// Serialized at the beginning of the message.
-    #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+    #[derive(Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
     pub(crate) struct UpdateMessageFlags: u8 {
         const MAPPINGS = 0b00000001;
         const DESPAWNS = 0b00000010;

--- a/src/core/replicon_tick.rs
+++ b/src/core/replicon_tick.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// See also [`ServerUpdateTick`](crate::client::ServerUpdateTick) and
 /// [`ServerTick`](crate::server::server_tick::ServerTick).
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct RepliconTick(u32);
+pub struct RepliconTick(#[serde(with = "postcard::fixint::le")] u32);
 
 impl RepliconTick {
     /// Creates a new instance wrapping the given value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ mapping. Therefore, to replicate such components properly, they need to implemen
 the [`MapEntities`](bevy::ecs::entity::MapEntities) trait and register
 using [`AppRuleExt::replicate_mapped()`].
 
-By default all components are serialized with [`bincode`] using [`DefaultOptions`](bincode::DefaultOptions).
+By default all components are serialized with [`postcard`].
 If your component doesn't implement serde traits or you want to serialize it partially
 (for example, only replicate the `translation` field from [`Transform`]),
 you can use [`AppRuleExt::replicate_with`].
@@ -719,7 +719,8 @@ pub mod prelude {
     pub use super::parent_sync::{ParentSync, ParentSyncPlugin};
 }
 
-pub use bincode;
+pub use bytes;
+pub use postcard;
 
 use bevy::{app::PluginGroupBuilder, prelude::*};
 use prelude::*;

--- a/src/server/replication_messages/component_changes.rs
+++ b/src/server/replication_messages/component_changes.rs
@@ -22,7 +22,7 @@ impl ComponentChanges {
 
     /// Like [`Self::size`], but uses components size instead of components count.
     ///
-    /// It usually consts more bytes (because the number is bigger),
+    /// It usually costs more bytes (because the number is bigger),
     /// but allows to skip data on deserialization.
     pub(super) fn size_with_components_size(&self) -> postcard::Result<usize> {
         let components_size = self.components_size();

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use bevy::{ecs::entity::MapEntities, prelude::*};
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
@@ -14,6 +12,7 @@ use bevy_replicon::{
     server::server_tick::ServerTick,
     test_app::ServerTestAppExt,
 };
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -596,9 +595,9 @@ fn replace(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<OriginalComponent>,
     entity: &mut DeferredEntity,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<()> {
-    rule_fns.deserialize(ctx, cursor)?;
+    message: &mut Bytes,
+) -> postcard::Result<()> {
+    rule_fns.deserialize(ctx, message)?;
     ctx.commands.entity(entity.id()).insert(ReplacedComponent);
 
     Ok(())

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use bevy::{ecs::entity::MapEntities, prelude::*, utils::Duration};
 use bevy_replicon::{
     client::{
@@ -18,6 +16,7 @@ use bevy_replicon::{
     server::server_tick::ServerTick,
     test_app::ServerTestAppExt,
 };
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -1036,9 +1035,9 @@ fn replace(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<OriginalComponent>,
     entity: &mut DeferredEntity,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<()> {
-    let component = rule_fns.deserialize(ctx, cursor)?;
+    message: &mut Bytes,
+) -> postcard::Result<()> {
+    let component = rule_fns.deserialize(ctx, message)?;
     ctx.commands
         .entity(entity.id())
         .insert(ReplacedComponent(component.0));
@@ -1051,9 +1050,9 @@ fn write_history(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<BoolComponent>,
     entity: &mut DeferredEntity,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<()> {
-    let component = rule_fns.deserialize(ctx, cursor)?;
+    message: &mut Bytes,
+) -> postcard::Result<()> {
+    let component = rule_fns.deserialize(ctx, message)?;
     if let Some(mut history) = entity.get_mut::<BoolHistory>() {
         history.push(component.0);
     } else {

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use bevy::prelude::*;
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
@@ -11,6 +9,7 @@ use bevy_replicon::{
     server::server_tick::ServerTick,
     test_app::ServerTestAppExt,
 };
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -521,9 +520,9 @@ fn replace(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<OriginalComponent>,
     entity: &mut DeferredEntity,
-    cursor: &mut Cursor<&[u8]>,
-) -> bincode::Result<()> {
-    rule_fns.deserialize(ctx, cursor)?;
+    message: &mut Bytes,
+) -> postcard::Result<()> {
+    rule_fns.deserialize(ctx, message)?;
     ctx.commands.entity(entity.id()).insert(ReplacedComponent);
 
     Ok(())

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -60,7 +60,7 @@ fn client_stats() {
     assert_eq!(stats.mappings, 1);
     assert_eq!(stats.despawns, 1);
     assert_eq!(stats.messages, 2);
-    assert_eq!(stats.bytes, 25);
+    assert_eq!(stats.bytes, 26);
 }
 
 #[derive(Component, Deserialize, Serialize)]


### PR DESCRIPTION
I recently discovered that deserialization from `std::io::Cursor` allocates because it needs a temporary buffer to read data into. [Here](https://docs.rs/bincode/latest/src/bincode/de/read.rs.html#37) is what `bincode` uses.

RC version of bincode provides a special [Reader](https://docs.rs/bincode/2.0.0-rc.3/bincode/de/read/trait.Reader.html) additionally to read from it. Unfortunately, I don't think bincode will be released soon, see [this](https://github.com/bincode-org/bincode/issues/674#issuecomment-2367237703) comment.

This is why I decided to try `postcard`. Difference from `bincode`
- [Variable integers](https://postcard.jamesmunns.com/wire-format.html#varint-encoded-integers) by default and It's encoded the way we want. So we don't need to use [integer-encoding](https://docs.rs/integer-encoding/) crate anymore and all integers inside components get this optimization (can be opt-out via attribute!).
- I like `postcard` API more. `DefaultOptions::new()` from `bincode` was always seemed off to me. In the latest RC they pass settings to each call which is even more verbose. `postcard` have a very flexible [Flavor](https://docs.rs/postcard/latest/postcard/#flavors) system.
- Potentially can work with `no_std`. Although, RC version of bincode also supports it.
- `postcard::Error` is not an alias for a boxed error, similar to `bincode` RC.

I compered the perfomance, we didn't get any improvements in our benchmarks, it's within the margin. But I think it's worth to switch.

To get `postcard` play nicely with streaming ser/de, I added Flavors and functions similar to what `postcard` provides.
- For serialization I implemented `ExtendFlavorMut`, which is similar to the provided `ExtendFlavor`, but accepts value by reference.
- For deserialization I implemented `BufFlavor` which works with any type that implements `bytes::Buf`. This allows me to read from `Bytes` directly without extra allocations or manually reassigning the value like with built-in `SliceFlavor`. I re-exported `Bytes` from the crate.

I also created a newtype for mutation indexes to mark it as fixint-serializable with `postcard`.

Since we have more suited variable integers, it might worth to discuss using varints for ticks. Previously, ticks started to use 5 bytes after 2^16 (which happens after ~18 minutes with 60 ticks/s).
But right now it's after 2^28 and with 60 ticks/s it starts to take 5 bytes after ~51 day.
If you agree, I will push it as a follow-up PR. This PR only swaps the API without any logical changes.