### PR TITLE
Use varint for `RepliconTick`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `bincode` with `postcard`. It has more suitable variable integer encoding and potentially unlocks `no_std` support. If you use custom ser/de functions, replace `DefaultOptions::new().serialize_into(message, event)` with `postcard_utils::to_extend_mut(event, message)` and `DefaultOptions::new().deserialize_from(cursor)` with `postcard_utils::from_buf(message)`.
 - All serde methods now use `postcard::Result` instead of `bincode::Result`.
 - All deserialization methods now accept `Bytes` instead of `std::io::Cursor` because deserialization from `std::io::Read` requires a temporary buffer. `Bytes` already provide cursor-like functionality. The crate now re-exported under `bevy_replicon::bytes`.
+- Use varint for `RepliconTick` because `postcard` provides more efficient encoding for it.
 - Improve panic message for non-registered functions.
 
 ## [0.30.1] - 2025-02-07

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bytes = "1.10"
 serde.workspace = true
 ordered-multimap = "0.7"
 bitflags = { version = "2.6", features = ["serde"] }
-postcard = { version = "1.1", default-features = false }
+postcard = { version = "1.1", default-features = false, features = ["experimental-derive"]}
 
 [dev-dependencies]
 bevy = { workspace = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,9 @@ bytes = "1.10"
 serde.workspace = true
 ordered-multimap = "0.7"
 bitflags = { version = "2.6", features = ["serde"] }
-postcard = { version = "1.1", default-features = false, features = ["experimental-derive"]}
+postcard = { version = "1.1", default-features = false, features = [
+  "experimental-derive",
+] }
 
 [dev-dependencies]
 bevy = { workspace = true, features = [

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,10 +4,9 @@ pub mod diagnostics;
 pub mod event;
 pub mod server_mutate_ticks;
 
-use std::mem;
-
 use bevy::{ecs::world::CommandQueue, prelude::*};
 use bytes::{Buf, Bytes};
+use postcard::experimental::max_size::MaxSize;
 
 use crate::core::{
     channels::{ReplicationChannel, RepliconChannels},
@@ -182,7 +181,8 @@ fn apply_replication(
     // but skip outdated data per-entity by checking last received tick for it
     // (unless user requested history via marker).
     let update_tick = *world.resource::<ServerUpdateTick>();
-    let acks_size = mem::size_of::<u16>() * client.received_count(ReplicationChannel::Mutations);
+    let acks_size =
+        MutateIndex::POSTCARD_MAX_SIZE * client.received_count(ReplicationChannel::Mutations);
     if acks_size != 0 {
         let mut acks = Vec::with_capacity(acks_size);
         for message in client.receive(ReplicationChannel::Mutations) {

--- a/src/core/replication/mutate_index.rs
+++ b/src/core/replication/mutate_index.rs
@@ -1,3 +1,4 @@
+use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 
 /// Identifier for mutate messages.
@@ -8,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// A tick >= 2^14 will be [5 bytes](https://postcard.jamesmunns.com/wire-format.html#maximum-encoded-length)
 /// At 60 ticks/sec, that will happen after ~5 minutes. So any session over this time period would transmit
 /// more total bytes with varint encoding.
-#[derive(Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug, MaxSize)]
 pub(crate) struct MutateIndex(#[serde(with = "postcard::fixint::le")] u16);
 
 impl MutateIndex {

--- a/src/core/replicon_tick.rs
+++ b/src/core/replicon_tick.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
 
 /// Like [`Tick`](bevy::ecs::component::Tick), but for replication.
@@ -11,8 +12,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// See also [`ServerUpdateTick`](crate::client::ServerUpdateTick) and
 /// [`ServerTick`](crate::server::server_tick::ServerTick).
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct RepliconTick(#[serde(with = "postcard::fixint::le")] u32);
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize, MaxSize)]
+pub struct RepliconTick(u32);
 
 impl RepliconTick {
     /// Creates a new instance wrapping the given value.

--- a/src/server/replication_messages/mutate_message.rs
+++ b/src/server/replication_messages/mutate_message.rs
@@ -1,7 +1,7 @@
-use std::{mem, ops::Range, time::Duration};
+use std::{ops::Range, time::Duration};
 
 use bevy::{ecs::component::Tick, prelude::*};
-use postcard::experimental::serialized_size;
+use postcard::experimental::{max_size::MaxSize, serialized_size};
 
 use super::{component_changes::ComponentChanges, serialized_data::SerializedData};
 use crate::core::{
@@ -134,8 +134,8 @@ impl MutateMessage {
     ) -> postcard::Result<usize> {
         debug_assert_eq!(self.entities.len(), self.mutations.len());
 
-        const MAX_COUNT_SIZE: usize = mem::size_of::<usize>() + 1;
-        let mut tick_buffer = [0; mem::size_of::<RepliconTick>()];
+        const MAX_COUNT_SIZE: usize = usize::POSTCARD_MAX_SIZE;
+        let mut tick_buffer = [0; RepliconTick::POSTCARD_MAX_SIZE];
         let update_tick = postcard::to_slice(&client.update_tick(), &mut tick_buffer)?;
         let mut metadata_size = update_tick.len() + server_tick.len();
         if track_mutate_messages {

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -60,7 +60,7 @@ fn client_stats() {
     assert_eq!(stats.mappings, 1);
     assert_eq!(stats.despawns, 1);
     assert_eq!(stats.messages, 2);
-    assert_eq!(stats.bytes, 26);
+    assert_eq!(stats.bytes, 17);
 }
 
 #[derive(Component, Deserialize, Serialize)]


### PR DESCRIPTION
Because `postcard` provides more efficient encoding for it.
Partially reverts #371.