### PR TITLE
Rework `replicate_with` examples

### DIFF
--- a/src/core/replication/replication_rules.rs
+++ b/src/core/replication/replication_rules.rs
@@ -121,6 +121,11 @@ pub trait AppRuleExt {
     #     unimplemented!()
     # }
 
+    app.replicate_with(RuleFns::new(
+        serialize_mapped_component,
+        deserialize_mapped_component,
+    ));
+
     #[derive(Component, Deserialize, Serialize)]
     struct MappedComponent {
         entity: Entity,


### PR DESCRIPTION
Adds an example under replicate_with for custom replication of mapped entities