### PR TITLE
Derive `Deref` and `DerefMut` for `ToClients` and `FromClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Derive `Debug` for `FnsId`.
+- Derive `Deref` and `DerefMut` to underlying event in `ToClients` and `FromClient`.
 
 ### Changed
 

--- a/bevy_replicon_example_backend/examples/tic_tac_toe.rs
+++ b/bevy_replicon_example_backend/examples/tic_tac_toe.rs
@@ -247,8 +247,8 @@ fn apply_pick(
     players: Query<(&Player, &Symbol)>,
 ) {
     // It's good to check the received data because client could be cheating.
-    if trigger.event.index > GRID_SIZE * GRID_SIZE {
-        debug!("received invalid cell index {:?}", trigger.event.index);
+    if trigger.index > GRID_SIZE * GRID_SIZE {
+        debug!("received invalid cell index {:?}", trigger.index);
         return;
     }
 
@@ -258,18 +258,15 @@ fn apply_pick(
     {
         debug!(
             "{:?} chose cell {:?} at wrong turn",
-            trigger.client_id, trigger.event.index
+            trigger.client_id, trigger.index
         );
         return;
     }
 
-    let Some((entity, _)) = cells
-        .iter()
-        .find(|(_, cell)| cell.index == trigger.event.index)
-    else {
+    let Some((entity, _)) = cells.iter().find(|(_, cell)| cell.index == trigger.index) else {
         debug!(
             "{:?} has chosen an already occupied cell {:?}",
-            trigger.client_id, trigger.event.index
+            trigger.client_id, trigger.index
         );
         return;
     };
@@ -333,7 +330,7 @@ fn init_client(
     server_symbol: Single<&Symbol, With<Player>>,
 ) {
     for (server_entity, cell) in &cells {
-        let Some(&client_entity) = trigger.event.get(&cell.index) else {
+        let Some(&client_entity) = trigger.get(&cell.index) else {
             error!("received cells missing index {}, disconnecting", cell.index);
             commands.set_state(GameState::Disconnected);
             return;

--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -401,9 +401,10 @@ impl<E: Event> FromWorld for ClientEventReader<E> {
 
 /// An event indicating that a message from client was received.
 /// Emitted only on server.
-#[derive(Clone, Copy, Event)]
+#[derive(Clone, Copy, Event, Deref, DerefMut)]
 pub struct FromClient<T> {
     pub client_id: ClientId,
+    #[deref]
     pub event: T,
 }
 

--- a/src/core/event/server_event.rs
+++ b/src/core/event/server_event.rs
@@ -814,9 +814,10 @@ impl BufferedServerEvents {
 }
 
 /// An event that will be send to client(s).
-#[derive(Clone, Copy, Debug, Event)]
+#[derive(Clone, Copy, Debug, Event, Deref, DerefMut)]
 pub struct ToClients<T> {
     pub mode: SendMode,
+    #[deref]
     pub event: T,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,7 @@ fn send_events(mut commands: Commands) {
 }
 
 fn receive_events(trigger: Trigger<FromClient<DummyEvent>>) {
-    info!("received event {:?} from {:?}", trigger.event, trigger.client_id);
+    info!("received event {:?} from {:?}", **trigger, trigger.client_id);
 }
 # #[derive(Event, Debug, Deserialize, Serialize)]
 # struct DummyEvent;
@@ -565,7 +565,7 @@ fn send_events(mut commands: Commands) {
 }
 
 fn receive_events(trigger: Trigger<DummyEvent>) {
-    info!("received event {:?} from server", trigger.event());
+    info!("received event {:?} from server", *trigger);
 }
 # #[derive(Event, Debug, Deserialize, Serialize)]
 # struct DummyEvent;

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -63,7 +63,7 @@ fn mapping_and_sending_receiving() {
         .world_mut()
         .resource_mut::<Events<FromClient<EntityEvent>>>()
         .drain()
-        .map(|event| event.event.0)
+        .map(|event| event.0)
         .collect();
     assert_eq!(mapped_entities, [server_entity]);
 }

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -88,7 +88,7 @@ fn mapping_and_sending_receiving() {
     server_app.update();
 
     let reader = server_app.world().resource::<TriggerReader<EntityEvent>>();
-    let mapped_entities: Vec<_> = reader.events.iter().map(|event| event.event.0).collect();
+    let mapped_entities: Vec<_> = reader.events.iter().map(|event| event.0).collect();
     assert_eq!(mapped_entities, [server_entity]);
 }
 


### PR DESCRIPTION
Bevy does the same for `Trigger` to access the event data directly.

Also trigger have `event()` method, which makes it confusing to see `trigger.event.field` because our wrappers have `event` field.
With this change we can access fields directly: `trigger.field`.