### PR TITLE
Make example backend publishable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = [
 ]
 categories = ["game-development", "network-programming"]
 license = "MIT OR Apache-2.0"
-include = ["/benches", "/src", "/tests", "/LICENSE*"]
+include = ["/src", "/LICENSE*"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
@@ -27,16 +27,12 @@ all-features = true
 [workspace]
 members = ["bevy_replicon_example_backend"]
 
-[workspace.dependencies]
-bevy = { version = "0.15", default-features = false }
-serde = "1.0"
-
 [dependencies]
-bevy = { workspace = true, features = ["serialize"] }
+bevy = { version = "0.15", features = ["serialize"] }
 thiserror = "2.0"
 typeid = "1.0"
 bytes = "1.10"
-serde.workspace = true
+serde = "1.0"
 ordered-multimap = "0.7"
 bitflags = { version = "2.6", features = ["serde"] }
 postcard = { version = "1.1", default-features = false, features = [
@@ -44,7 +40,7 @@ postcard = { version = "1.1", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { workspace = true, features = [
+bevy = { version = "0.15", features = [
   "serialize",
   "bevy_asset",
   "bevy_scene",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 members = ["bevy_replicon_example_backend"]
 
 [dependencies]
-bevy = { version = "0.15", features = ["serialize"] }
+bevy = { version = "0.15", default-features = false, features = ["serialize"] }
 thiserror = "2.0"
 typeid = "1.0"
 bytes = "1.10"
@@ -40,7 +40,7 @@ postcard = { version = "1.1", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.15", features = [
+bevy = { version = "0.15", default-features = false, features = [
   "serialize",
   "bevy_asset",
   "bevy_scene",

--- a/bevy_replicon_example_backend/Cargo.toml
+++ b/bevy_replicon_example_backend/Cargo.toml
@@ -1,17 +1,31 @@
 [package]
 name = "bevy_replicon_example_backend"
-version = "0.1.0"
-description = "A simple transport intended only for examples"
+version = "0.30.1"
+authors = [
+  "Hennadii Chernyshchyk <genaloner@gmail.com>",
+  "koe <ukoe@protonmail.com>",
+]
 edition = "2021"
+description = "A simple transport intended only for examples"
+readme = "README.md"
+repository = "https://github.com/projectharmonia/bevy_replicon"
+keywords = [
+  "bevy",
+  "multiplayer",
+  "netcode",
+  "replication",
+  "server-authoritative",
+]
+categories = ["game-development", "network-programming"]
 license = "MIT OR Apache-2.0"
-publish = false
+include = ["/src", "../LICENSE*"]
 
 [dependencies]
-bevy.workspace = true
-bevy_replicon = { path = "..", default-features = false }
+bevy = { version = "0.15", default-features = false }
+bevy_replicon = { path = "..", version = "0.30", default-features = false }
 
 [dev-dependencies]
-bevy = { workspace = true, features = [
+bevy = { version = "0.15", features = [
   "bevy_text",
   "bevy_ui",
   "bevy_gizmos",
@@ -20,7 +34,7 @@ bevy = { workspace = true, features = [
   "x11",
   "default_font",
 ] }
-serde.workspace = true
+serde = "1.0"
 clap = { version = "4.1", features = ["derive"] }
 
 [features]

--- a/bevy_replicon_example_backend/Cargo.toml
+++ b/bevy_replicon_example_backend/Cargo.toml
@@ -25,7 +25,7 @@ bevy = { version = "0.15", default-features = false }
 bevy_replicon = { path = "..", version = "0.30", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.15", features = [
+bevy = { version = "0.15", default-features = false, features = [
   "bevy_text",
   "bevy_ui",
   "bevy_gizmos",

--- a/bevy_replicon_example_backend/src/lib.rs
+++ b/bevy_replicon_example_backend/src/lib.rs
@@ -1,6 +1,7 @@
 //! A simple transport intended only for examples.
 //! This transport does not implement any reliability or security features.
 //! DO NOT USE in a real project
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "client")]
 mod client;


### PR DESCRIPTION
We need to publish it to let third-party crates reuse it.

I also removed workspace dependencies and inlined them.
We don't have much duplication, this way it just looks a bit more straightforward.