### PR TITLE
Use system builder for `send_replication` system

### DIFF
--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -215,7 +215,8 @@ fn create_app<C: Component + Serialize + DeserializeOwned>() -> App {
             ..Default::default()
         }),
     ))
-    .replicate::<C>();
+    .replicate::<C>()
+    .finish();
 
     app
 }

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -17,7 +17,8 @@ fn connect_disconnect() {
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
-        ));
+        ))
+        .finish();
     }
 
     setup(&mut server_app, &mut client_app).unwrap();
@@ -69,7 +70,8 @@ fn replication() {
                 ..Default::default()
             }),
             RepliconExampleBackendPlugins,
-        ));
+        ))
+        .finish();
     }
 
     setup(&mut server_app, &mut client_app).unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -190,7 +190,7 @@ impl Plugin for ServerPlugin {
             ParamBuilder,
             ParamBuilder,
         )
-            .build_state(&mut app.world_mut())
+            .build_state(app.world_mut())
             .build_system(send_replication);
 
         app.insert_resource(rules).add_systems(

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -29,7 +29,8 @@ for app in [&mut server_app, &mut client_app] {
             tick_policy: TickPolicy::EveryFrame, // To tick each app update.
             ..Default::default()
         }),
-    ));
+    ))
+    .finish();
 }
 
 // Simulate connection between two apps:

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -9,7 +9,7 @@ fn client_to_server() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((MinimalPlugins, RepliconPlugins));
+        app.add_plugins((MinimalPlugins, RepliconPlugins)).finish();
         app.update();
     }
 
@@ -43,7 +43,7 @@ fn server_to_client() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((MinimalPlugins, RepliconPlugins));
+        app.add_plugins((MinimalPlugins, RepliconPlugins)).finish();
         app.update();
     }
 
@@ -80,7 +80,8 @@ fn connect_disconnect() {
                 tick_policy: TickPolicy::EveryFrame,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -103,7 +104,8 @@ fn client_cleanup_on_disconnect() {
             tick_policy: TickPolicy::EveryFrame,
             ..Default::default()
         }),
-    ));
+    ))
+    .finish();
 
     app.update();
 
@@ -130,7 +132,8 @@ fn server_cleanup_on_stop() {
             tick_policy: TickPolicy::EveryFrame,
             ..Default::default()
         }),
-    ));
+    ))
+    .finish();
 
     app.update();
 
@@ -160,7 +163,8 @@ fn client_disconnected() {
             tick_policy: TickPolicy::EveryFrame,
             ..Default::default()
         }),
-    ));
+    ))
+    .finish();
 
     app.update();
 
@@ -184,7 +188,8 @@ fn server_inactive() {
             tick_policy: TickPolicy::EveryFrame,
             ..Default::default()
         }),
-    ));
+    ))
+    .finish();
 
     app.update();
 
@@ -215,7 +220,8 @@ fn deferred_replication() {
                 replicate_after_connect: false,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -15,7 +15,8 @@ fn single() {
                 tick_policy: TickPolicy::EveryFrame,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -52,7 +53,8 @@ fn with_hierarchy() {
                 tick_policy: TickPolicy::EveryFrame,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -98,7 +100,8 @@ fn after_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -129,7 +132,8 @@ fn hidden() {
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 #[should_panic]
 fn serialize_missing_component() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, RepliconPlugins));
+    app.add_plugins((MinimalPlugins, RepliconPlugins)).finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -39,7 +39,7 @@ fn serialize_missing_component() {
 #[test]
 fn write() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, RepliconPlugins));
+    app.add_plugins((MinimalPlugins, RepliconPlugins)).finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -58,7 +58,7 @@ fn write() {
 #[test]
 fn remove() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, RepliconPlugins));
+    app.add_plugins((MinimalPlugins, RepliconPlugins)).finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -76,7 +76,8 @@ fn remove() {
 fn write_with_command() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -95,7 +96,8 @@ fn write_with_command() {
 fn remove_with_command() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -117,7 +119,8 @@ fn write_without_marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -141,7 +144,8 @@ fn remove_without_marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -163,7 +167,8 @@ fn write_with_marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -186,7 +191,8 @@ fn remove_with_marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -213,7 +219,8 @@ fn write_with_multiple_markers() {
         .set_marker_fns::<DummyMarker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -246,7 +253,8 @@ fn remove_with_mutltiple_markers() {
         .set_marker_fns::<DummyMarker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -281,7 +289,8 @@ fn write_with_priority_marker() {
         .set_marker_fns::<DummyMarker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -314,7 +323,8 @@ fn remove_with_priority_marker() {
         .set_marker_fns::<DummyMarker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
-        );
+        )
+        .finish();
 
     let tick = RepliconTick::default();
     let (_, fns_id) =
@@ -333,7 +343,7 @@ fn remove_with_priority_marker() {
 #[test]
 fn despawn() {
     let mut app = App::new();
-    app.add_plugins((MinimalPlugins, RepliconPlugins));
+    app.add_plugins((MinimalPlugins, RepliconPlugins)).finish();
 
     let mut registry = app.world_mut().resource_mut::<ReplicationRegistry>();
     registry.despawn = mark_despawned;

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -27,7 +27,8 @@ fn table_storage() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -66,7 +67,8 @@ fn sparse_set_storage() {
                 ..Default::default()
             }),
         ))
-        .replicate::<SparseSetComponent>();
+        .replicate::<SparseSetComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -105,7 +107,8 @@ fn mapped_existing_entity() {
                 ..Default::default()
             }),
         ))
-        .replicate_mapped::<MappedComponent>();
+        .replicate_mapped::<MappedComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -155,7 +158,8 @@ fn mapped_new_entity() {
                 ..Default::default()
             }),
         ))
-        .replicate_mapped::<MappedComponent>();
+        .replicate_mapped::<MappedComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -203,7 +207,8 @@ fn command_fns() {
             }),
         ))
         .replicate::<OriginalComponent>()
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -247,7 +252,8 @@ fn marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -298,7 +304,8 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_group::<(GroupComponentA, GroupComponentB)>();
+        .replicate_group::<(GroupComponentA, GroupComponentB)>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -336,7 +343,8 @@ fn not_replicated() {
                 tick_policy: TickPolicy::EveryFrame,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -377,7 +385,8 @@ fn after_removal() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -422,7 +431,8 @@ fn before_started_replication() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -473,7 +483,8 @@ fn after_started_replication() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -512,7 +523,8 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -21,9 +21,9 @@ fn without_changes() {
             }),
         ))
         .track_mutate_messages()
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
-    client_app.finish();
 
     server_app.connect_client(&mut client_app);
 
@@ -56,9 +56,9 @@ fn one_message() {
             }),
         ))
         .track_mutate_messages()
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
-    client_app.finish();
 
     server_app.connect_client(&mut client_app);
 
@@ -123,9 +123,9 @@ fn multiple_messages() {
             }),
         ))
         .track_mutate_messages()
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
-    client_app.finish();
 
     server_app.connect_client(&mut client_app);
 

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -31,7 +31,8 @@ fn small_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -76,7 +77,8 @@ fn package_size_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<VecComponent>();
+        .replicate::<VecComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -128,7 +130,8 @@ fn many_components() {
             }),
         ))
         .replicate::<BoolComponent>()
-        .replicate::<VecComponent>();
+        .replicate::<VecComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -182,7 +185,8 @@ fn command_fns() {
             }),
         ))
         .replicate::<OriginalComponent>()
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -237,7 +241,8 @@ fn marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -304,7 +309,8 @@ fn marker_with_history() {
             write_history,
             command_fns::default_remove::<BoolComponent>,
         )
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -385,7 +391,8 @@ fn marker_with_history_consume() {
             command_fns::default_remove::<BoolComponent>,
         )
         .replicate::<BoolComponent>()
-        .replicate_mapped::<MappedComponent>();
+        .replicate_mapped::<MappedComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -477,7 +484,8 @@ fn marker_with_history_old_update() {
             write_history,
             command_fns::default_remove::<BoolComponent>,
         )
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -550,7 +558,8 @@ fn many_entities() {
                 ..Default::default()
             }),
         ))
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -603,7 +612,8 @@ fn with_insertion() {
             }),
         ))
         .replicate::<BoolComponent>()
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -646,7 +656,8 @@ fn with_removal() {
             }),
         ))
         .replicate::<BoolComponent>()
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -688,7 +699,8 @@ fn with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -736,7 +748,8 @@ fn buffering() {
                 ..Default::default()
             }),
         ))
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -798,7 +811,8 @@ fn old_ignored() {
                 ..Default::default()
             }),
         ))
-        .replicate_mapped::<MappedComponent>();
+        .replicate_mapped::<MappedComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -864,7 +878,8 @@ fn acknowledgment() {
                 ..Default::default()
             }),
         ))
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -944,9 +959,9 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<BoolComponent>();
+        .replicate::<BoolComponent>()
+        .finish();
     }
-    client_app.finish();
 
     server_app.connect_client(&mut client_app);
 

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -24,7 +24,8 @@ fn single() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -70,7 +71,8 @@ fn command_fns() {
             }),
         ))
         .replicate::<OriginalComponent>()
-        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>);
+        .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -120,7 +122,8 @@ fn marker() {
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
-        );
+        )
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -174,7 +177,8 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_group::<(GroupComponentA, GroupComponentB)>();
+        .replicate_group::<(GroupComponentA, GroupComponentB)>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -219,7 +223,8 @@ fn not_replicated() {
                 tick_policy: TickPolicy::EveryFrame,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -269,7 +274,8 @@ fn after_insertion() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -316,7 +322,8 @@ fn with_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -348,7 +355,8 @@ fn with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -395,7 +403,8 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -463,7 +472,8 @@ fn hidden() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -10,7 +10,8 @@ fn replicated_entity() {
         .register_type::<NonReflectedComponent>()
         .replicate::<DummyComponent>()
         .replicate::<OtherReflectedComponent>() // Reflected, but the type is not registered.
-        .replicate::<NonReflectedComponent>();
+        .replicate::<NonReflectedComponent>()
+        .finish();
 
     let entity = app
         .world_mut()
@@ -40,7 +41,7 @@ fn replicated_entity() {
 #[test]
 fn empty_entity() {
     let mut app = App::new();
-    app.add_plugins(RepliconPlugins);
+    app.add_plugins(RepliconPlugins).finish();
 
     let entity = app.world_mut().spawn(Replicated).id();
 
@@ -61,7 +62,8 @@ fn not_replicated_entity() {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins)
         .register_type::<DummyComponent>()
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
 
     app.world_mut().spawn(DummyComponent);
 
@@ -78,7 +80,8 @@ fn entity_update() {
     app.add_plugins(RepliconPlugins)
         .register_type::<DummyComponent>()
         .replicate::<DummyComponent>()
-        .register_type::<OtherReflectedComponent>();
+        .register_type::<OtherReflectedComponent>()
+        .finish();
 
     let entity = app
         .world_mut()

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -16,7 +16,8 @@ fn empty() {
                 tick_policy: TickPolicy::EveryFrame,
                 ..Default::default()
             }),
-        ));
+        ))
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -57,7 +58,8 @@ fn with_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -86,7 +88,8 @@ fn with_old_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -130,7 +133,8 @@ fn before_connection() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     // Spawn an entity before client connected.
@@ -159,7 +163,8 @@ fn pre_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -235,7 +240,8 @@ fn after_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -14,7 +14,8 @@ fn client_stats() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -14,7 +14,8 @@ fn all() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -68,7 +69,8 @@ fn empty_blacklist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -98,7 +100,8 @@ fn blacklist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -150,7 +153,8 @@ fn blacklist_with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -189,7 +193,8 @@ fn empty_whitelist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -220,7 +225,8 @@ fn whitelist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);
@@ -274,7 +280,8 @@ fn whitelist_with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<DummyComponent>()
+        .finish();
     }
 
     server_app.connect_client(&mut client_app);


### PR DESCRIPTION
We read components through `FilteredEntityRef`.
This allows replication to run in parallel with other systems that write to non-replicated components.
However, it is 2x slower for a single client due to the overhead of access checks.
We need to find a better approach.