### PR TITLE
Wrap world access in a `SystemParam` for granular access

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -3,8 +3,8 @@ pub(super) mod despawn_buffer;
 pub mod event;
 pub(super) mod removal_buffer;
 pub(super) mod replicated_archetypes;
-mod replicated_world;
 pub(super) mod replication_messages;
+mod replication_read_world;
 pub mod server_tick;
 
 use std::{ops::Range, time::Duration};
@@ -16,7 +16,7 @@ use bevy::{
     time::common_conditions::on_timer,
 };
 use bytes::Buf;
-use replicated_world::ReplicatedWorld;
+use replication_read_world::ReplicationReadWorld;
 
 use crate::core::{
     channels::{ReplicationChannel, RepliconChannels},
@@ -253,7 +253,7 @@ pub(super) fn send_replication(
     mut messages: Local<ReplicationMessages>,
     mut replicated_archetypes: Local<ReplicatedArchetypes>,
     change_tick: SystemChangeTick,
-    world: ReplicatedWorld,
+    world: ReplicationReadWorld,
     mut replicated_clients: ResMut<ReplicatedClients>,
     mut removal_buffer: ResMut<RemovalBuffer>,
     mut client_buffers: ResMut<ClientBuffers>,
@@ -456,7 +456,7 @@ fn collect_changes(
     replicated_archetypes: &ReplicatedArchetypes,
     registry: &ReplicationRegistry,
     removal_buffer: &RemovalBuffer,
-    world: &ReplicatedWorld,
+    world: &ReplicationReadWorld,
     change_tick: &SystemChangeTick,
     server_tick: RepliconTick,
 ) -> postcard::Result<()> {

--- a/src/server/replicated_archetypes.rs
+++ b/src/server/replicated_archetypes.rs
@@ -2,8 +2,8 @@ use std::mem;
 
 use bevy::{
     ecs::{
-        archetype::{ArchetypeGeneration, ArchetypeId},
-        component::{ComponentId, StorageType},
+        archetype::{ArchetypeGeneration, ArchetypeId, Archetypes},
+        component::{ComponentId, Components, StorageType},
     },
     log::Level,
     prelude::*,
@@ -37,11 +37,16 @@ impl ReplicatedArchetypes {
     /// Updates the internal view of the [`World`]'s replicated archetypes.
     ///
     /// If this is not called before querying data, the results may not accurately reflect what is in the world.
-    pub(super) fn update(&mut self, world: &World, rules: &ReplicationRules) {
-        let old_generation = mem::replace(&mut self.generation, world.archetypes().generation());
+    pub(super) fn update(
+        &mut self,
+        archetypes: &Archetypes,
+        components: &Components,
+        rules: &ReplicationRules,
+    ) {
+        let old_generation = mem::replace(&mut self.generation, archetypes.generation());
 
         // Archetypes are never removed, iterate over newly added since the last update.
-        for archetype in world.archetypes()[old_generation..]
+        for archetype in archetypes[old_generation..]
             .iter()
             .filter(|archetype| archetype.contains(self.marker_id))
         {
@@ -56,17 +61,14 @@ impl ReplicatedArchetypes {
                         .any(|component| component.component_id == component_id)
                     {
                         if enabled!(Level::DEBUG) {
-                            let component_name = world
-                                .components()
+                            let component_name = components
                                 .get_name(component_id)
                                 .expect("rules should be registered with valid component");
 
                             let component_names: Vec<_> = replicated_archetype
                                 .components
                                 .iter()
-                                .flat_map(|component| {
-                                    world.components().get_name(component.component_id)
-                                })
+                                .flat_map(|component| components.get_name(component.component_id))
                                 .collect();
 
                             debug!("ignoring component `{component_name}` with priority {} for archetype with `{component_names:?}`", rule.priority);
@@ -263,7 +265,11 @@ mod tests {
 
     fn match_archetypes(world: &mut World) -> ReplicatedArchetypes {
         let mut archetypes = ReplicatedArchetypes::from_world(world);
-        archetypes.update(world, world.resource::<ReplicationRules>());
+        archetypes.update(
+            world.archetypes(),
+            world.components(),
+            world.resource::<ReplicationRules>(),
+        );
 
         archetypes
     }

--- a/src/server/replicated_world.rs
+++ b/src/server/replicated_world.rs
@@ -22,7 +22,7 @@ pub(crate) struct ReplicatedWorld<'w, 's> {
     state: &'s Access<ComponentId>,
 }
 
-impl<'w, 's> ReplicatedWorld<'w, 's> {
+impl<'w> ReplicatedWorld<'w, '_> {
     /// Extracts a component as [`Ptr`] and its ticks from a table or sparse set, depending on its storage type.
     ///
     /// # Safety

--- a/src/server/replicated_world.rs
+++ b/src/server/replicated_world.rs
@@ -1,0 +1,167 @@
+use bevy::{
+    ecs::{
+        archetype::{ArchetypeEntity, Archetypes},
+        component::{ComponentId, ComponentTicks, Components, StorageType, Tick},
+        query::{Access, FilteredAccess},
+        storage::TableId,
+        system::{ReadOnlySystemParam, SystemMeta, SystemParam},
+        world::unsafe_world_cell::UnsafeWorldCell,
+    },
+    prelude::*,
+    ptr::Ptr,
+};
+
+use crate::core::replication::replication_rules::ReplicationRules;
+
+/// A [`SystemParam`] that wraps [`World`], but provides access only for replicated components.
+///
+/// We don't use [`FilteredEntityRef`](bevy::ecs::world::FilteredEntityRef) to avoid access checks
+/// and [`StorageType`] fetch (we cache this information on replicated archetypes).
+pub(crate) struct ReplicatedWorld<'w, 's> {
+    world: UnsafeWorldCell<'w>,
+    state: &'s Access<ComponentId>,
+}
+
+impl<'w, 's> ReplicatedWorld<'w, 's> {
+    /// Extracts a component as [`Ptr`] and its ticks from a table or sparse set, depending on its storage type.
+    ///
+    /// # Safety
+    ///
+    /// The component must be present in this archetype, have the specified storage type, and be previously marked for replication.
+    pub(super) unsafe fn get_component_unchecked(
+        &self,
+        entity: &ArchetypeEntity,
+        table_id: TableId,
+        storage_type: StorageType,
+        component_id: ComponentId,
+    ) -> (Ptr<'w>, ComponentTicks) {
+        debug_assert!(self.state.has_component_read(component_id));
+
+        let storages = self.world.storages();
+        match storage_type {
+            StorageType::Table => {
+                let table = storages.tables.get(table_id).unwrap_unchecked();
+                // TODO: re-use column lookup, asked in https://github.com/bevyengine/bevy/issues/16593.
+                let component: Ptr<'w> = table
+                    .get_component(component_id, entity.table_row())
+                    .unwrap_unchecked();
+                let ticks = table
+                    .get_ticks_unchecked(component_id, entity.table_row())
+                    .unwrap_unchecked();
+
+                (component, ticks)
+            }
+            StorageType::SparseSet => {
+                let sparse_set = storages.sparse_sets.get(component_id).unwrap_unchecked();
+                let component = sparse_set.get(entity.id()).unwrap_unchecked();
+                let ticks = sparse_set.get_ticks(entity.id()).unwrap_unchecked();
+
+                (component, ticks)
+            }
+        }
+    }
+
+    pub(super) fn archetypes(&self) -> &Archetypes {
+        self.world.archetypes()
+    }
+
+    pub(super) fn components(&self) -> &Components {
+        self.world.components()
+    }
+}
+
+unsafe impl SystemParam for ReplicatedWorld<'_, '_> {
+    type State = Access<ComponentId>;
+    type Item<'world, 'state> = ReplicatedWorld<'world, 'state>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        let rules = world.resource::<ReplicationRules>();
+        let mut access = Access::new();
+        let mut filtered_access = FilteredAccess::default();
+        let combined_access = system_meta.component_access_set().combined_access();
+        for rule in rules.iter() {
+            for &(component_id, _) in &rule.components {
+                access.add_component_read(component_id);
+                filtered_access.add_component_read(component_id);
+                assert!(
+                    !combined_access.has_component_write(component_id),
+                    "replicated component `{}` in system `{}` shouldn't be in conflict with other system parameters",
+                    world.components().get_name(component_id).unwrap(),
+                    system_meta.name(),
+                );
+            }
+        }
+
+        // SAFETY: used only to extend access.
+        unsafe {
+            system_meta.component_access_set_mut().add(filtered_access);
+        }
+
+        access
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        _system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        _change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        ReplicatedWorld { world, state }
+    }
+}
+
+unsafe impl ReadOnlySystemParam for ReplicatedWorld<'_, '_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::replication::{
+        replication_registry::ReplicationRegistry, replication_rules::AppRuleExt,
+    };
+
+    #[test]
+    #[should_panic]
+    fn world_transform_mut() {
+        let mut app = App::new();
+        app.init_resource::<ReplicationRules>()
+            .init_resource::<ReplicationRegistry>()
+            .replicate::<Transform>()
+            .add_systems(Update, |_: ReplicatedWorld, _: Query<&mut Transform>| {});
+
+        app.update();
+    }
+
+    #[test]
+    #[should_panic]
+    fn transform_mut_world() {
+        let mut app = App::new();
+        app.init_resource::<ReplicationRules>()
+            .init_resource::<ReplicationRegistry>()
+            .replicate::<Transform>()
+            .add_systems(Update, |_: Query<&mut Transform>, _: ReplicatedWorld| {});
+
+        app.update();
+    }
+
+    #[test]
+    fn world_transform_ref() {
+        let mut app = App::new();
+        app.init_resource::<ReplicationRules>()
+            .init_resource::<ReplicationRegistry>()
+            .replicate::<Transform>()
+            .add_systems(Update, |_: ReplicatedWorld, _: Query<&Transform>| {});
+
+        app.update();
+    }
+
+    #[test]
+    fn replicate_after_system() {
+        let mut app = App::new();
+        app.init_resource::<ReplicationRules>()
+            .init_resource::<ReplicationRegistry>()
+            .add_systems(Update, |_: ReplicatedWorld, _: Query<&Transform>| {})
+            .replicate::<Transform>();
+
+        app.update();
+    }
+}

--- a/src/server/replicated_world.rs
+++ b/src/server/replicated_world.rs
@@ -11,7 +11,7 @@ use bevy::{
     ptr::Ptr,
 };
 
-use crate::core::replication::replication_rules::ReplicationRules;
+use crate::core::replication::{replication_rules::ReplicationRules, Replicated};
 
 /// A [`SystemParam`] that wraps [`World`], but provides access only for replicated components.
 ///
@@ -75,9 +75,14 @@ unsafe impl SystemParam for ReplicatedWorld<'_, '_> {
     type Item<'world, 'state> = ReplicatedWorld<'world, 'state>;
 
     fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
-        let rules = world.resource::<ReplicationRules>();
         let mut access = Access::new();
         let mut filtered_access = FilteredAccess::default();
+
+        let marker_id = world.register_component::<Replicated>();
+        access.add_component_read(marker_id);
+        filtered_access.add_component_read(marker_id);
+
+        let rules = world.resource::<ReplicationRules>();
         let combined_access = system_meta.component_access_set().combined_access();
         for rule in rules.iter() {
             for &(component_id, _) in &rule.components {


### PR DESCRIPTION
This allows replication to run in parallel with other systems that write to non-replicated components.
Benchmarks show the same performance, but we run them without `multi_threaded`.

Supersedes #417.