### PR TITLE
Allow sending only mappings in update messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All deserialization methods now accept `Bytes` instead of `std::io::Cursor` because deserialization from `std::io::Read` requires a temporary buffer. `Bytes` already provide cursor-like functionality. The crate now re-exported under `bevy_replicon::bytes`.
 - Use varint for `RepliconTick` because `postcard` provides more efficient encoding for it.
 - Improve panic message for non-registered functions.
+- Allow update messages with mappings-only to map non-replicated entities.
 - Log bytes count on receive.
 
 ### Fixed

--- a/src/client.rs
+++ b/src/client.rs
@@ -225,7 +225,6 @@ fn apply_update_message(
 
         match flag {
             UpdateMessageFlags::MAPPINGS => {
-                debug_assert_eq!(array_kind, ArrayKind::Sized);
                 let len = apply_array(array_kind, message, |message| {
                     apply_entity_mapping(world, params, message)
                 })?;


### PR DESCRIPTION
There is a use case for it.
For example, client and server can have non-replicated entities that should be mapped together to correctly reference them in mapped components from other replicated entities.
And in this case message could contain only mappings.