### PR TITLE
Make max message size configurable by backends

### DIFF
--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -59,7 +59,7 @@ fn receive_packets(
                 }
                 let client_id = ClientId::new(addr.port().into());
                 let client_entity = commands
-                    .spawn((ConnectedClient::new(client_id), ClientStream(stream)))
+                    .spawn((ConnectedClient::new(client_id, 1200), ClientStream(stream)))
                     .id();
                 debug!("connecting `{client_entity}` with `{client_id:?}`");
             }

--- a/src/core/connected_client.rs
+++ b/src/core/connected_client.rs
@@ -22,12 +22,23 @@ use bevy::{
 #[require(Name(|| Name::new("Connected client")), NetworkStats)]
 pub struct ConnectedClient {
     id: ClientId,
+    /// Maximum size of a message that can be transferred over unreliable channel without
+    /// splitting into multiple packets.
+    ///
+    /// Used to manually split mutations over packet-size messages to allow applying them partially.
+    ///
+    /// <div class="warning">
+    ///
+    /// Should only be modified from the messaging backend.
+    ///
+    /// </div>
+    pub max_size: usize,
 }
 
 impl ConnectedClient {
-    /// Creates a new instance with a backend-provided ID.
-    pub fn new(id: ClientId) -> Self {
-        Self { id }
+    /// Creates a new instance with a backend-provided ID and maximum message size for unreliable channel.
+    pub fn new(id: ClientId, max_size: usize) -> Self {
+        Self { id, max_size }
     }
 
     /// Returns client ID provided by backend.

--- a/src/server.rs
+++ b/src/server.rs
@@ -236,6 +236,7 @@ pub(super) fn send_replication(
         Entity,
         &mut UpdateMessage,
         &mut MutateMessage,
+        &mut ConnectedClient,
         &mut ClientEntityMap,
         &mut ClientTicks,
         &mut ClientVisibility,
@@ -301,6 +302,7 @@ fn send_messages(
         Entity,
         &mut UpdateMessage,
         &mut MutateMessage,
+        &mut ConnectedClient,
         &mut ClientEntityMap,
         &mut ClientTicks,
         &mut ClientVisibility,
@@ -314,7 +316,15 @@ fn send_messages(
     time: &Time,
 ) -> postcard::Result<()> {
     let mut server_tick_range = None;
-    for (client_entity, update_message, mut mutate_message, _, mut ticks, mut visibility) in clients
+    for (
+        client_entity,
+        update_message,
+        mut mutate_message,
+        client,
+        ..,
+        mut ticks,
+        mut visibility,
+    ) in clients
     {
         if !update_message.is_empty() {
             ticks.set_update_tick(server_tick);
@@ -339,6 +349,7 @@ fn send_messages(
                 server_tick,
                 change_tick.this_run(),
                 time.elapsed(),
+                client.max_size,
             )?;
             trace!("sending {messages_count} mutate message(s) to client `{client_entity}`");
         } else {
@@ -358,12 +369,13 @@ fn collect_mappings(
         Entity,
         &mut UpdateMessage,
         &mut MutateMessage,
+        &mut ConnectedClient,
         &mut ClientEntityMap,
         &mut ClientTicks,
         &mut ClientVisibility,
     )>,
 ) -> postcard::Result<()> {
-    for (_, mut message, _, mut entity_map, ..) in clients {
+    for (_, mut message, _, _, mut entity_map, ..) in clients {
         let len = entity_map.len();
         let mappings = serialized.write_mappings(entity_map.0.drain(..))?;
         message.set_mappings(mappings, len);
@@ -379,6 +391,7 @@ fn collect_despawns(
         Entity,
         &mut UpdateMessage,
         &mut MutateMessage,
+        &mut ConnectedClient,
         &mut ClientEntityMap,
         &mut ClientTicks,
         &mut ClientVisibility,
@@ -414,6 +427,7 @@ fn collect_removals(
         Entity,
         &mut UpdateMessage,
         &mut MutateMessage,
+        &mut ConnectedClient,
         &mut ClientEntityMap,
         &mut ClientTicks,
         &mut ClientVisibility,
@@ -441,6 +455,7 @@ fn collect_changes(
         Entity,
         &mut UpdateMessage,
         &mut MutateMessage,
+        &mut ConnectedClient,
         &mut ClientEntityMap,
         &mut ClientTicks,
         &mut ClientVisibility,

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -90,7 +90,7 @@ impl ServerTestAppExt for App {
         server.set_running(true);
         let mut client_entity = self.world_mut().spawn_empty();
         let client_id = ClientId::new(client_entity.id().to_bits()); // Use entity ID for client ID since it's just for testing.
-        client_entity.insert(ConnectedClient::new(client_id));
+        client_entity.insert(ConnectedClient::new(client_id, 1200));
 
         let mut client = client_app.world_mut().resource_mut::<RepliconClient>();
         assert!(


### PR DESCRIPTION
It's a public field since in quinnet this value is dynamic: https://docs.rs/quinn-proto/0.11.8/quinn_proto/struct.Datagrams.html#method.max_size