### PR TITLE
Refactor queries in tests

### DIFF
--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -72,10 +72,8 @@ fn replication() {
     server_app.update();
     client_app.update();
 
-    client_app
-        .world_mut()
-        .query::<&Replicated>()
-        .single(client_app.world());
+    let mut replicated = client_app.world_mut().query::<&Replicated>();
+    assert_eq!(replicated.iter(client_app.world()).len(), 1);
 }
 
 #[test]

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -214,8 +214,8 @@ fn deferred_replication() {
 
     server_app.connect_client(&mut client_app);
 
-    server_app
+    let mut clients = server_app
         .world_mut()
-        .query_filtered::<&ConnectedClient, Without<ReplicatedClient>>()
-        .single(server_app.world());
+        .query_filtered::<&ConnectedClient, Without<ReplicatedClient>>();
+    assert_eq!(clients.iter(server_app.world()).count(), 1);
 }

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -48,10 +48,8 @@ fn table_storage() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
-        .world_mut()
-        .query::<&DummyComponent>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -87,10 +85,8 @@ fn sparse_set_storage() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
-        .world_mut()
-        .query::<&SparseSetComponent>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&SparseSetComponent>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -219,10 +215,10 @@ fn command_fns() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query_filtered::<&ReplacedComponent, Without<OriginalComponent>>()
-        .single(client_app.world());
+        .query_filtered::<&ReplacedComponent, Without<OriginalComponent>>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -310,10 +306,10 @@ fn group() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut groups = client_app
         .world_mut()
-        .query::<(&GroupComponentA, &GroupComponentB)>()
-        .single(client_app.world());
+        .query::<(&GroupComponentA, &GroupComponentB)>();
+    assert_eq!(groups.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -348,12 +344,8 @@ fn not_replicated() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let components = client_app
-        .world_mut()
-        .query::<&DummyComponent>()
-        .iter(client_app.world())
-        .count();
-    assert_eq!(components, 0);
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    assert_eq!(components.iter(client_app.world()).count(), 0);
 }
 
 #[test]
@@ -394,10 +386,8 @@ fn after_removal() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
-        .world_mut()
-        .query::<&DummyComponent>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -425,14 +415,10 @@ fn before_started_replication() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let replicated_components = client_app
-        .world_mut()
-        .query::<&DummyComponent>()
-        .iter(client_app.world())
-        .count();
-
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
     assert_eq!(
-        replicated_components, 0,
+        components.iter(client_app.world()).count(),
+        0,
         "no entities should have been sent to the client"
     );
 
@@ -447,10 +433,7 @@ fn before_started_replication() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    client_app
-        .world_mut()
-        .query::<&DummyComponent>()
-        .single(client_app.world());
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -489,10 +472,8 @@ fn after_started_replication() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    client_app
-        .world_mut()
-        .query::<&DummyComponent>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -39,10 +39,8 @@ fn single() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let client_entity = client_app
-        .world_mut()
-        .query_filtered::<Entity, With<DummyComponent>>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    assert_eq!(components.iter(client_app.world()).len(), 1);
 
     server_app
         .world_mut()
@@ -53,8 +51,7 @@ fn single() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<DummyComponent>());
+    assert_eq!(components.iter(client_app.world()).len(), 0);
 }
 
 #[test]
@@ -85,10 +82,8 @@ fn command_fns() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let client_entity = client_app
-        .world_mut()
-        .query_filtered::<Entity, With<ReplacedComponent>>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&ReplacedComponent>();
+    assert_eq!(components.iter(client_app.world()).len(), 1);
 
     server_app
         .world_mut()
@@ -99,8 +94,7 @@ fn command_fns() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<ReplacedComponent>());
+    assert_eq!(components.iter(client_app.world()).len(), 0);
 }
 
 #[test]
@@ -279,10 +273,8 @@ fn after_insertion() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let client_entity = client_app
-        .world_mut()
-        .query_filtered::<Entity, With<DummyComponent>>()
-        .single(client_app.world());
+    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    assert_eq!(components.iter(client_app.world()).len(), 1);
 
     // Insert and remove at the same time.
     server_app
@@ -295,8 +287,7 @@ fn after_insertion() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<DummyComponent>());
+    assert_eq!(components.iter(client_app.world()).len(), 0);
 }
 
 #[test]
@@ -325,10 +316,10 @@ fn with_spawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query_filtered::<Entity, (With<Replicated>, Without<DummyComponent>)>()
-        .single(client_app.world());
+        .query_filtered::<&Replicated, Without<DummyComponent>>();
+    assert_eq!(components.iter(client_app.world()).len(), 1);
 }
 
 #[test]
@@ -358,10 +349,8 @@ fn with_despawn() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    client_app
-        .world_mut()
-        .query::<&Replicated>()
-        .single(client_app.world());
+    let mut replicated = client_app.world_mut().query::<&Replicated>();
+    assert_eq!(replicated.iter(client_app.world()).len(), 1);
 
     // Un-replicate and remove at the same time.
     server_app
@@ -374,7 +363,6 @@ fn with_despawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut replicated = client_app.world_mut().query::<&Replicated>();
     assert_eq!(replicated.iter(client_app.world()).len(), 0);
 }
 

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -70,10 +70,10 @@ fn with_component() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -114,10 +114,10 @@ fn with_old_component() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -143,10 +143,10 @@ fn before_connection() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -245,10 +245,10 @@ fn after_despawn() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -39,10 +39,10 @@ fn all() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 
     // Reverse visibility back.
     let mut visibility = server_app
@@ -55,10 +55,7 @@ fn all() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
-        .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -85,10 +82,10 @@ fn empty_blacklist() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -140,10 +137,10 @@ fn blacklist() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    client_app
+    let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[test]
@@ -255,10 +252,10 @@ fn whitelist() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let client_entity = client_app
+    let mut components = client_app
         .world_mut()
-        .query_filtered::<Entity, (With<Replicated>, With<DummyComponent>)>()
-        .single(client_app.world());
+        .query::<(&Replicated, &DummyComponent)>();
+    assert_eq!(components.iter(client_app.world()).len(), 1);
 
     // Reverse visibility.
     let mut visibility = server_app
@@ -271,8 +268,9 @@ fn whitelist() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert!(
-        client_app.world().get_entity(client_entity).is_err(),
+    assert_eq!(
+        components.iter(client_app.world()).len(),
+        0,
         "entity should be despawned after removing from whitelist"
     );
 }


### PR DESCRIPTION
- Reuse queries where possible.
- Don't use `single` when we don't care about the value.
  In the latest Bevy, it will require unwrapping, so just check the size for better ergonomics.
  Additionally, in some places, this allows us to reuse the query.