### PR TITLE
Provide access to `TypeRegistry` for component contexts

### DIFF
--- a/src/core/replication/replication_registry/ctx.rs
+++ b/src/core/replication/replication_registry/ctx.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::component::ComponentId, prelude::*};
+use bevy::{ecs::component::ComponentId, prelude::*, reflect::TypeRegistry};
 
 use crate::core::{
     replication::Replicated, replicon_tick::RepliconTick, server_entity_map::ServerEntityMap,
@@ -6,12 +6,15 @@ use crate::core::{
 
 /// Replication context for serialization function.
 #[non_exhaustive]
-pub struct SerializeCtx {
+pub struct SerializeCtx<'a> {
     /// ID of the serializing component.
     pub component_id: ComponentId,
 
     /// Current tick.
     pub server_tick: RepliconTick,
+
+    /// Registry of reflected types.
+    pub type_registry: &'a TypeRegistry,
 }
 
 /// Replication context for writing and deserialization.
@@ -23,6 +26,9 @@ pub struct WriteCtx<'a, 'w, 's> {
     /// Maps server entities to client entities and vice versa.
     pub entity_map: &'a mut ServerEntityMap,
 
+    /// Registry of reflected types.
+    pub type_registry: &'a TypeRegistry,
+
     /// ID of the writing component.
     pub component_id: ComponentId,
 
@@ -30,24 +36,7 @@ pub struct WriteCtx<'a, 'w, 's> {
     pub message_tick: RepliconTick,
 
     /// Disables mapping logic to avoid spawning entities for consume functions.
-    pub(super) ignore_mapping: bool,
-}
-
-impl<'a, 'w, 's> WriteCtx<'a, 'w, 's> {
-    pub(crate) fn new(
-        commands: &'a mut Commands<'w, 's>,
-        entity_map: &'a mut ServerEntityMap,
-        component_id: ComponentId,
-        message_tick: RepliconTick,
-    ) -> Self {
-        Self {
-            commands,
-            entity_map,
-            component_id,
-            message_tick,
-            ignore_mapping: false,
-        }
-    }
+    pub(crate) ignore_mapping: bool,
 }
 
 impl EntityMapper for WriteCtx<'_, '_, '_> {

--- a/src/core/replication/replication_registry/test_fns.rs
+++ b/src/core/replication/replication_registry/test_fns.rs
@@ -95,12 +95,14 @@ pub trait TestFnsEntityExt {
 
 impl TestFnsEntityExt for EntityWorldMut<'_> {
     fn serialize(&mut self, fns_id: FnsId, server_tick: RepliconTick) -> Vec<u8> {
+        let type_registry = self.world().resource::<AppTypeRegistry>();
         let registry = self.world().resource::<ReplicationRegistry>();
         let (component_id, component_fns, rule_fns) = registry.get(fns_id);
         let mut message = Vec::new();
         let ctx = SerializeCtx {
             server_tick,
             component_id,
+            type_registry: &type_registry.read(),
         };
         let ptr = self.get_by_id(component_id).unwrap_or_else(|_| {
             let components = self.world().components();
@@ -133,27 +135,35 @@ impl TestFnsEntityExt for EntityWorldMut<'_> {
         self.world_scope(|world| {
             world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
                 world.resource_scope(|world, registry: Mut<ReplicationRegistry>| {
-                    let mut queue = CommandQueue::default();
-                    let mut entity = DeferredEntity::new(world, entity);
-                    let mut commands = entity.commands(&mut queue);
+                    world.resource_scope(|world, type_registry: Mut<AppTypeRegistry>| {
+                        let mut queue = CommandQueue::default();
+                        let mut entity = DeferredEntity::new(world, entity);
+                        let mut commands = entity.commands(&mut queue);
 
-                    let (component_id, component_fns, rule_fns) = registry.get(fns_id);
-                    let mut ctx =
-                        WriteCtx::new(&mut commands, &mut entity_map, component_id, message_tick);
+                        let (component_id, component_fns, rule_fns) = registry.get(fns_id);
+                        let mut ctx = WriteCtx {
+                            commands: &mut commands,
+                            entity_map: &mut entity_map,
+                            type_registry: &type_registry.read(),
+                            component_id,
+                            message_tick,
+                            ignore_mapping: false,
+                        };
 
-                    unsafe {
-                        component_fns
-                            .write(
-                                &mut ctx,
-                                rule_fns,
-                                &entity_markers,
-                                &mut entity,
-                                &mut data.into(),
-                            )
-                            .expect("writing data into an entity shouldn't fail");
-                    }
+                        unsafe {
+                            component_fns
+                                .write(
+                                    &mut ctx,
+                                    rule_fns,
+                                    &entity_markers,
+                                    &mut entity,
+                                    &mut data.into(),
+                                )
+                                .expect("writing data into an entity shouldn't fail");
+                        }
 
-                    queue.apply(world);
+                        queue.apply(world);
+                    })
                 })
             })
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,10 +468,10 @@ impl MapEntities for MappedEvent {
 As shown above, mapped client events must also implement [`Clone`].
 
 There is also [`ClientEventAppExt::add_client_event_with()`] to register an event with special serialization and
-deserialization functions. This could be used for sending events that contain [`Box<dyn Reflect>`], which
+deserialization functions. This could be used for sending events that contain [`Box<dyn PartialReflect>`], which
 require access to the [`AppTypeRegistry`] resource.
 
-Don't forget to validate the contents of every [`Box<dyn Reflect>`] from a client, it could be anything!
+Don't forget to validate the contents of every [`Box<dyn PartialReflect>`] from a client, it could be anything!
 
 Alternatively you can use triggers with similar API. First, you need to register the event
 with [`ClientTriggerAppExt::add_client_trigger()`] and then use [`ClientTriggerExt::client_trigger`]:

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,7 @@ use bevy::{
     ecs::{component::StorageType, system::SystemChangeTick},
     prelude::*,
     ptr::Ptr,
+    reflect::TypeRegistry,
     time::common_conditions::on_timer,
 };
 use bytes::Buf;
@@ -246,6 +247,7 @@ pub(super) fn send_replication(
     mut server: ResMut<RepliconServer>,
     track_mutate_messages: Res<TrackMutateMessages>,
     registry: Res<ReplicationRegistry>,
+    type_registry: Res<AppTypeRegistry>,
     server_tick: Res<ServerTick>,
     time: Res<Time>,
 ) -> postcard::Result<()> {
@@ -261,6 +263,7 @@ pub(super) fn send_replication(
         &mut serialized,
         &mut clients,
         &registry,
+        &type_registry.read(),
         &removal_buffer,
         &world,
         &change_tick,
@@ -446,6 +449,7 @@ fn collect_changes(
         &mut ClientVisibility,
     )>,
     registry: &ReplicationRegistry,
+    type_registry: &TypeRegistry,
     removal_buffer: &RemovalBuffer,
     world: &ServerWorld,
     change_tick: &SystemChangeTick,
@@ -492,6 +496,7 @@ fn collect_changes(
                 let ctx = SerializeCtx {
                     server_tick,
                     component_id,
+                    type_registry,
                 };
                 let mut component_range = None;
                 for (_, mut update_message, mut mutate_message, .., client_ticks, _) in


### PR DESCRIPTION
Useful to replicate components with dynamic types inside.
I removed `WriteCtx::new` since we starting to have quite a lot of args. It's internal method anyway.
A also added usage example.