### PR TITLE
Improve docs for `replicate_with`

### DIFF
--- a/src/core/replication/replication_rules.rs
+++ b/src/core/replication/replication_rules.rs
@@ -124,7 +124,7 @@ pub trait AppRuleExt {
     /// Applies the assigned deserialization function and assigns only translation.
     ///
     /// Called by Replicon on component mutations.
-    pub fn deserialize_transform_in_place(
+    fn deserialize_transform_in_place(
         deserialize: DeserializeFn<Transform>,
         ctx: &mut WriteCtx,
         component: &mut Transform,
@@ -162,8 +162,7 @@ pub trait AppRuleExt {
         deserialize_big_component,
     ));
 
-    /// Serializes [`BigComponent`] with compression.
-    pub fn serialize_big_component(
+    fn serialize_big_component(
         _ctx: &SerializeCtx,
         component: &BigComponent,
         message: &mut Vec<u8>,
@@ -185,8 +184,7 @@ pub trait AppRuleExt {
         Ok(())
     }
 
-    /// Deserializes [`BigComponent`] with decompression.
-    pub fn deserialize_big_component(
+    fn deserialize_big_component(
         _ctx: &mut WriteCtx,
         message: &mut Bytes,
     ) -> postcard::Result<BigComponent> {
@@ -228,12 +226,12 @@ pub trait AppRuleExt {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins);
     app.replicate_with(RuleFns::new(
-        serialize_big_component,
-        deserialize_big_component,
+        serialize_mapped_component,
+        deserialize_mapped_component,
     ));
 
     /// Serializes [`MappedComponent`], but skips [`MappedComponent::unused_field`].
-    pub fn serialize_big_component(
+    fn serialize_mapped_component(
         _ctx: &SerializeCtx,
         component: &MappedComponent,
         message: &mut Vec<u8>,
@@ -242,7 +240,7 @@ pub trait AppRuleExt {
     }
 
     /// Deserializes an entity and creates [`MappedComponent`] from it.
-    pub fn deserialize_big_component(
+    fn deserialize_mapped_component(
         ctx: &mut WriteCtx,
         message: &mut Bytes,
     ) -> postcard::Result<MappedComponent> {


### PR DESCRIPTION
- Remove unneeded `pub` from examples.
- Remove pointless comments from examples.
- Fix copy-pasted method name.