### PR TITLE
Rename `registry` in all event contexts into `type_registry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive `Debug` for `FnsId`.
 - Derive `Deref` and `DerefMut` to underlying event in `ToClients` and `FromClient`.
 - Derive `PartialEq` for `RepliconClientStatus`.
+- `SerializeCtx::type_registry` and `WriteCtx::type_registry` to replicate components with reflection.
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `ClientId` to `connected_client` module and remove from `prelude`.
 - Use `TestClientEntity` instead of `ClientId` resource on clients in `ServerTestAppExt` to identify client entity.
 - Rename `FromClient::client_id` into `FromClient::client_entity`.
+- Rename `registry` in all event contexts into `type_registry`.
 - Replace `bincode` with `postcard`. It has more suitable variable integer encoding and potentially unlocks `no_std` support. If you use custom ser/de functions, replace `DefaultOptions::new().serialize_into(message, event)` with `postcard_utils::to_extend_mut(event, message)` and `DefaultOptions::new().deserialize_from(cursor)` with `postcard_utils::from_buf(message)`.
 - All serde methods now use `postcard::Result` instead of `bincode::Result`.
 - All deserialization methods now accept `Bytes` instead of `std::io::Cursor` because deserialization from `std::io::Read` requires a temporary buffer. `Bytes` already provide cursor-like functionality. The crate now re-exported under `bevy_replicon::bytes`.

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -144,13 +144,13 @@ fn send(
     events: FilteredResources,
     mut readers: FilteredResourcesMut,
     mut client: ResMut<RepliconClient>,
-    registry: Res<AppTypeRegistry>,
+    type_registry: Res<AppTypeRegistry>,
     entity_map: Res<ServerEntityMap>,
     event_registry: Res<EventRegistry>,
 ) {
     let mut ctx = ClientSendCtx {
         entity_map: &entity_map,
-        registry: &registry.read(),
+        type_registry: &type_registry.read(),
         invalid_entities: Vec::new(),
     };
 
@@ -173,13 +173,13 @@ fn receive(
     mut events: FilteredResourcesMut,
     mut queues: FilteredResourcesMut,
     mut client: ResMut<RepliconClient>,
-    registry: Res<AppTypeRegistry>,
+    type_registry: Res<AppTypeRegistry>,
     entity_map: Res<ServerEntityMap>,
     event_registry: Res<EventRegistry>,
     update_tick: Res<ServerUpdateTick>,
 ) {
     let mut ctx = ClientReceiveCtx {
-        registry: &registry.read(),
+        type_registry: &type_registry.read(),
         entity_map: &entity_map,
         invalid_entities: Vec::new(),
     };

--- a/src/core/event/client_event.rs
+++ b/src/core/event/client_event.rs
@@ -96,7 +96,7 @@ pub trait ClientEventAppExt {
         message: &mut Vec<u8>,
     ) -> postcard::Result<()> {
         let mut serializer = Serializer { output: ExtendMutFlavor::new(message) };
-        ReflectSerializer::new(&*event.0, ctx.registry).serialize(&mut serializer)
+        ReflectSerializer::new(&*event.0, ctx.type_registry).serialize(&mut serializer)
     }
 
     fn deserialize_reflect(
@@ -104,7 +104,7 @@ pub trait ClientEventAppExt {
         message: &mut Bytes,
     ) -> postcard::Result<ReflectEvent> {
         let mut deserializer = Deserializer::from_flavor(BufFlavor::new(message));
-        let reflect = ReflectDeserializer::new(ctx.registry).deserialize(&mut deserializer)?;
+        let reflect = ReflectDeserializer::new(ctx.type_registry).deserialize(&mut deserializer)?;
         Ok(ReflectEvent(reflect))
     }
 

--- a/src/core/event/ctx.rs
+++ b/src/core/event/ctx.rs
@@ -6,7 +6,7 @@ use crate::core::server_entity_map::ServerEntityMap;
 #[non_exhaustive]
 pub struct ClientSendCtx<'a> {
     /// Registry of reflected types.
-    pub registry: &'a TypeRegistry,
+    pub type_registry: &'a TypeRegistry,
 
     /// Maps server entities to client entities and vice versa.
     pub entity_map: &'a ServerEntityMap,
@@ -32,21 +32,21 @@ impl EntityMapper for ClientSendCtx<'_> {
 #[non_exhaustive]
 pub struct ServerReceiveCtx<'a> {
     /// Registry of reflected types.
-    pub registry: &'a TypeRegistry,
+    pub type_registry: &'a TypeRegistry,
 }
 
 /// Event sending context for server.
 #[non_exhaustive]
 pub struct ServerSendCtx<'a> {
     /// Registry of reflected types.
-    pub registry: &'a TypeRegistry,
+    pub type_registry: &'a TypeRegistry,
 }
 
 /// Event receiving context for client.
 #[non_exhaustive]
 pub struct ClientReceiveCtx<'a> {
     /// Registry of reflected types.
-    pub registry: &'a TypeRegistry,
+    pub type_registry: &'a TypeRegistry,
 
     /// Maps server entities to client entities and vice versa.
     pub entity_map: &'a ServerEntityMap,

--- a/src/core/event/server_event.rs
+++ b/src/core/event/server_event.rs
@@ -102,7 +102,7 @@ pub trait ServerEventAppExt {
         message: &mut Vec<u8>,
     ) -> postcard::Result<()> {
         let mut serializer = Serializer { output: ExtendMutFlavor::new(message) };
-        ReflectSerializer::new(&*event.0, ctx.registry).serialize(&mut serializer)
+        ReflectSerializer::new(&*event.0, ctx.type_registry).serialize(&mut serializer)
     }
 
     fn deserialize_reflect(
@@ -110,7 +110,7 @@ pub trait ServerEventAppExt {
         message: &mut Bytes,
     ) -> postcard::Result<ReflectEvent> {
         let mut deserializer = Deserializer::from_flavor(BufFlavor::new(message));
-        let reflect = ReflectDeserializer::new(ctx.registry).deserialize(&mut deserializer)?;
+        let reflect = ReflectDeserializer::new(ctx.type_registry).deserialize(&mut deserializer)?;
         Ok(ReflectEvent(reflect))
     }
 

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -119,13 +119,13 @@ fn send_or_buffer(
     server_events: FilteredResources,
     mut server: ResMut<RepliconServer>,
     mut buffered_events: ResMut<BufferedServerEvents>,
-    registry: Res<AppTypeRegistry>,
+    type_registry: Res<AppTypeRegistry>,
     event_registry: Res<EventRegistry>,
     clients: Query<Entity, With<ConnectedClient>>,
 ) {
     buffered_events.start_tick();
     let mut ctx = ServerSendCtx {
-        registry: &registry.read(),
+        type_registry: &type_registry.read(),
     };
 
     for event in event_registry.iter_server_events() {
@@ -159,11 +159,11 @@ fn send_buffered(
 fn receive(
     mut client_events: FilteredResourcesMut,
     mut server: ResMut<RepliconServer>,
-    registry: Res<AppTypeRegistry>,
+    type_registry: Res<AppTypeRegistry>,
     event_registry: Res<EventRegistry>,
 ) {
     let mut ctx = ServerReceiveCtx {
-        registry: &registry.read(),
+        type_registry: &type_registry.read(),
     };
 
     for event in event_registry.iter_client_events() {


### PR DESCRIPTION
For consistency with replication contexts. We use longer name to disambiguate from replication registry.