### PR TITLE
Require Bevy 0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump the `bevy` dependency to 0.15.3 since we use some fields that were made public in a patch release.
+
 ## [0.31.0] - 2025-03-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ all-features = true
 members = ["bevy_replicon_example_backend"]
 
 [dependencies]
-bevy = { version = "0.15.3", default-features = false, features = ["serialize"] }
+bevy = { version = "0.15.3", default-features = false, features = [
+  "serialize",
+] }
 typeid = "1.0"
 bytes = "1.10"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 members = ["bevy_replicon_example_backend"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = ["serialize"] }
+bevy = { version = "0.15.3", default-features = false, features = ["serialize"] }
 typeid = "1.0"
 bytes = "1.10"
 serde = "1.0"
@@ -39,7 +39,7 @@ postcard = { version = "1.1", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.15.3", default-features = false, features = [
   "serialize",
   "bevy_asset",
   "bevy_scene",

--- a/bevy_replicon_example_backend/Cargo.toml
+++ b/bevy_replicon_example_backend/Cargo.toml
@@ -21,11 +21,11 @@ license = "MIT OR Apache-2.0"
 include = ["/src", "../LICENSE*"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.15.3", default-features = false }
 bevy_replicon = { path = "..", version = "0.31", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.15.3", default-features = false, features = [
   "bevy_text",
   "bevy_ui",
   "bevy_gizmos",


### PR DESCRIPTION
It looks like we used some fields that were made public in 0.15.3.