### PR TITLE
Add link conditioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ConditionerConfig` for `bevy_replicon_example_backend` to simulate various network conditions.
+
 ## [0.31.1] - 2025-03-15
 
 ### Fixed

--- a/bevy_replicon_example_backend/Cargo.toml
+++ b/bevy_replicon_example_backend/Cargo.toml
@@ -23,6 +23,7 @@ include = ["/src", "../LICENSE*"]
 [dependencies]
 bevy = { version = "0.15.3", default-features = false }
 bevy_replicon = { path = "..", version = "0.31", default-features = false }
+fastrand = "2.3"
 
 [dev-dependencies]
 bevy = { version = "0.15.3", default-features = false, features = [

--- a/bevy_replicon_example_backend/src/lib.rs
+++ b/bevy_replicon_example_backend/src/lib.rs
@@ -5,12 +5,14 @@
 
 #[cfg(feature = "client")]
 mod client;
+mod link_conditioner;
 #[cfg(feature = "server")]
 mod server;
 mod tcp;
 
 #[cfg(feature = "client")]
 pub use client::*;
+pub use link_conditioner::*;
 #[cfg(feature = "server")]
 pub use server::*;
 
@@ -25,7 +27,7 @@ pub struct RepliconExampleBackendPlugins;
 
 impl PluginGroup for RepliconExampleBackendPlugins {
     fn build(self) -> PluginGroupBuilder {
-        let mut group = PluginGroupBuilder::start::<Self>();
+        let mut group = PluginGroupBuilder::start::<Self>().add(LinkConditionerPlugin);
 
         #[cfg(feature = "server")]
         {

--- a/bevy_replicon_example_backend/src/link_conditioner.rs
+++ b/bevy_replicon_example_backend/src/link_conditioner.rs
@@ -1,0 +1,203 @@
+use std::{
+    cmp::Ordering,
+    collections::BinaryHeap,
+    time::{Duration, Instant},
+};
+
+use bevy::prelude::*;
+use bevy_replicon::bytes::Bytes;
+use fastrand::Rng;
+
+/// Adds [`ConditionerConfig`] to [`AppTypeRegistry`].
+pub struct LinkConditionerPlugin;
+
+impl Plugin for LinkConditionerPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<ConditionerConfig>();
+    }
+}
+
+#[derive(Default)]
+pub(super) struct LinkConditioner {
+    rng: Rng,
+    heap: BinaryHeap<TimedMessage>,
+}
+
+impl LinkConditioner {
+    pub(super) fn insert(
+        &mut self,
+        config: Option<&ConditionerConfig>,
+        mut timestamp: Instant,
+        channel_id: u8,
+        message: Bytes,
+    ) {
+        if let Some(config) = config {
+            if self.rng.f32() <= config.loss {
+                trace!("simulating a message drop for channel {channel_id}");
+                return;
+            }
+
+            let mut latency = config.latency;
+            if config.jitter > 0 {
+                let jitter = self.rng.u16(0..config.jitter);
+                if self.rng.bool() {
+                    latency += jitter;
+                } else {
+                    latency = latency.saturating_sub(jitter);
+                }
+            }
+
+            trace!("simulating {latency} ms latency for channel {channel_id}");
+            timestamp += Duration::from_millis(latency.into());
+        }
+
+        self.heap.push(TimedMessage {
+            timestamp,
+            channel_id,
+            message,
+        });
+    }
+
+    pub(super) fn pop(&mut self, now: Instant) -> Option<(u8, Bytes)> {
+        if self.heap.peek().is_some_and(|m| now >= m.timestamp) {
+            // Item's instant has passed, so it's ready to be returned.
+            self.heap.pop().map(|m| (m.channel_id, m.message))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct TimedMessage {
+    timestamp: Instant,
+    channel_id: u8,
+    message: Bytes,
+}
+
+impl Ord for TimedMessage {
+    fn cmp(&self, other: &TimedMessage) -> Ordering {
+        other.timestamp.cmp(&self.timestamp)
+    }
+}
+
+impl PartialOrd for TimedMessage {
+    fn partial_cmp(&self, other: &TimedMessage) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Configuration for simulating various network conditions.
+///
+/// When inserted as a resource, these settings apply to all received messages:
+/// - For a client, it affects messages received from the server.
+/// - For a server, it affects messages received from all connected clients.
+///
+/// You can also insert this as a component on a connected entity.
+/// This will affect only that specific entity and take priority over
+/// the resource configuration.
+#[derive(Resource, Component, Debug, Clone, Copy, Reflect)]
+pub struct ConditionerConfig {
+    /// Base delay for incoming messages in milliseconds.
+    pub latency: u16,
+
+    /// Maximum additional random latency for incoming messages in milliseconds.
+    ///
+    /// This value is either added to **or** subtracted from [`Self::latency`].
+    pub jitter: u16,
+
+    /// The probability of an incoming packet being dropped.
+    ///
+    /// Represented as a value between 0 and 1.
+    pub loss: f32,
+}
+
+impl ConditionerConfig {
+    pub const VERY_GOOD: Self = Self {
+        latency: 12,
+        jitter: 3,
+        loss: 0.001,
+    };
+
+    pub const GOOD: Self = Self {
+        latency: 40,
+        jitter: 10,
+        loss: 0.002,
+    };
+
+    pub const AVERAGE: Self = Self {
+        latency: 100,
+        jitter: 25,
+        loss: 0.02,
+    };
+
+    pub const POOR: Self = Self {
+        latency: 200,
+        jitter: 50,
+        loss: 0.04,
+    };
+
+    pub const VERY_POOR: Self = Self {
+        latency: 300,
+        jitter: 75,
+        loss: 0.06,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latency() {
+        let config = ConditionerConfig {
+            latency: 300,
+            jitter: 0,
+            loss: 0.0,
+        };
+
+        let now = Instant::now();
+        let mut conditioner = LinkConditioner::default();
+        conditioner.rng.seed(0);
+        conditioner.insert(Some(&config), now, 0, Bytes::new());
+
+        assert!(conditioner.pop(now).is_none());
+
+        let passed = now + Duration::from_millis(config.latency.into());
+        assert!(conditioner.pop(passed).is_some());
+    }
+
+    #[test]
+    fn jitter() {
+        let config = ConditionerConfig {
+            latency: 0,
+            jitter: 300,
+            loss: 0.0,
+        };
+
+        let now = Instant::now();
+        let mut conditioner = LinkConditioner::default();
+        conditioner.rng.seed(0);
+        conditioner.insert(Some(&config), now, 0, Bytes::new());
+
+        assert!(conditioner.pop(now).is_none());
+
+        let passed = now + Duration::from_millis(config.jitter.into());
+        assert!(conditioner.pop(passed).is_some());
+    }
+
+    #[test]
+    fn loss() {
+        let config = ConditionerConfig {
+            latency: 0,
+            jitter: 0,
+            loss: 1.0,
+        };
+
+        let mut conditioner = LinkConditioner::default();
+        conditioner.rng.seed(0);
+        conditioner.insert(Some(&config), Instant::now(), 0, Bytes::new());
+
+        assert!(conditioner.heap.is_empty());
+    }
+}

--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -1,12 +1,16 @@
 use std::{
     io,
     net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
+    time::Instant,
 };
 
 use bevy::prelude::*;
 use bevy_replicon::{core::connected_client::ClientId, prelude::*};
 
-use super::tcp;
+use super::{
+    link_conditioner::{ConditionerConfig, LinkConditioner},
+    tcp,
+};
 
 /// Adds a server messaging backend made for examples to `bevy_replicon`.
 pub struct RepliconExampleServerPlugin;
@@ -44,7 +48,8 @@ fn receive_packets(
     mut commands: Commands,
     server: Res<ExampleServer>,
     mut replicon_server: ResMut<RepliconServer>,
-    mut clients: Query<(Entity, &mut ClientStream)>,
+    mut clients: Query<(Entity, &mut ExampleConnection, Option<&ConditionerConfig>)>,
+    global_config: Option<Res<ConditionerConfig>>,
 ) {
     loop {
         match server.0.accept() {
@@ -59,7 +64,13 @@ fn receive_packets(
                 }
                 let client_id = ClientId::new(addr.port().into());
                 let client_entity = commands
-                    .spawn((ConnectedClient::new(client_id, 1200), ClientStream(stream)))
+                    .spawn((
+                        ConnectedClient::new(client_id, 1200),
+                        ExampleConnection {
+                            stream,
+                            conditioner: Default::default(),
+                        },
+                    ))
                     .id();
                 debug!("connecting `{client_entity}` with `{client_id:?}`");
             }
@@ -73,12 +84,14 @@ fn receive_packets(
         }
     }
 
-    for (client_entity, mut stream) in &mut clients {
+    let now = Instant::now();
+    for (client_entity, mut connection, config) in &mut clients {
+        let config = config.or(global_config.as_deref());
         loop {
-            match tcp::read_message(&mut stream) {
-                Ok((channel_id, message)) => {
-                    replicon_server.insert_received(client_entity, channel_id, message)
-                }
+            match tcp::read_message(&mut connection.stream) {
+                Ok((channel_id, message)) => connection
+                    .conditioner
+                    .insert(config, now, channel_id, message),
                 Err(e) => {
                     match e.kind() {
                         io::ErrorKind::WouldBlock => (),
@@ -95,19 +108,23 @@ fn receive_packets(
                 }
             }
         }
+
+        while let Some((channel_id, message)) = connection.conditioner.pop(now) {
+            replicon_server.insert_received(client_entity, channel_id, message)
+        }
     }
 }
 
 fn send_packets(
     mut commands: Commands,
     mut replicon_server: ResMut<RepliconServer>,
-    mut clients: Query<&mut ClientStream>,
+    mut clients: Query<&mut ExampleConnection>,
 ) {
     for (client_entity, channel_id, message) in replicon_server.drain_sent() {
-        let mut stream = clients
+        let mut connection = clients
             .get_mut(client_entity)
             .expect("all connected clients should have streams");
-        if let Err(e) = tcp::send_message(&mut stream, channel_id, &message) {
+        if let Err(e) = tcp::send_message(&mut connection.stream, channel_id, &message) {
             commands.entity(client_entity).despawn();
             error!("disconnecting client `{client_entity}` due to error: {e}");
         }
@@ -132,6 +149,9 @@ impl ExampleServer {
     }
 }
 
-/// A stream for a connected client.
-#[derive(Component, Deref, DerefMut)]
-struct ClientStream(TcpStream);
+/// A connected for a client.
+#[derive(Component)]
+struct ExampleConnection {
+    stream: TcpStream,
+    conditioner: LinkConditioner,
+}


### PR DESCRIPTION
Add `ConditionerConfig` component and resource to simulate various network conditions. We can't use OS-level tools for our example backend, but some third-party plugins require this.