### PR TITLE
Don't insert `ClientVisibility` on `VisibilityPolicy::All`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't insert `ClientVisibility` at all if `ServerPlugin::visibility_policy` is set to `VisibilityPolicy::All`. Previously all calls were just no-op.
+
 ## [0.31.1] - 2025-03-15
 
 ### Fixed

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -6,59 +6,6 @@ use bevy_replicon::{
 use serde::{Deserialize, Serialize};
 
 #[test]
-fn all() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                ..Default::default()
-            }),
-        ))
-        .replicate::<DummyComponent>();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, DummyComponent))
-        .id();
-
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
-    let mut visibility = server_app
-        .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
-        .unwrap();
-    visibility.set_visibility(server_entity, false); // Shouldn't have any effect for this policy.
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut components = client_app
-        .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
-    assert_eq!(components.iter(client_app.world()).count(), 1);
-
-    // Reverse visibility back.
-    let mut visibility = server_app
-        .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
-        .unwrap();
-    visibility.set_visibility(server_entity, true);
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(components.iter(client_app.world()).count(), 1);
-}
-
-#[test]
 fn empty_blacklist() {
     let mut server_app = App::new();
     let mut client_app = App::new();


### PR DESCRIPTION
Since it's now a component, we can just skip marking it as required.

This simplifies the internal logic as well:
- No longer need a custom iterator.
- Can move some of the fields out of the enum.