### PR TITLE
Move `ConnectedClient::id` into a separate component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.31.1] - 2025-03-15
 
+### Changed
+
+- Rename `ClientId` into `ConnectionId`.
+- Move `ConnectedClient::id` into a separate optional component for backends that doesn't provide persistent identifiers.
+
 ### Fixed
 
 - Bump the `bevy` dependency to 0.15.3 since we use some fields that were made public in a patch release.
+
+### Removed
+
+- `ConnectedClient::new`, you can now construct the struct directly.
 
 ## [0.31.0] - 2025-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rename `ClientId` into `ConnectionId`.
+- Rename `ClientId` into `NetworkId`.
 - Move `ConnectedClient::id` into a separate optional component for backends that doesn't provide persistent identifiers.
 
 ### Fixed

--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bevy::prelude::*;
-use bevy_replicon::{core::connected_client::ClientId, prelude::*};
+use bevy_replicon::{core::connected_client::ConnectionId, prelude::*};
 
 use super::tcp;
 
@@ -57,11 +57,15 @@ fn receive_packets(
                     error!("unable to enable non-blocking for `{addr}`: {e}");
                     continue;
                 }
-                let client_id = ClientId::new(addr.port().into());
+                let connection_id = ConnectionId::new(addr.port().into());
                 let client_entity = commands
-                    .spawn((ConnectedClient::new(client_id, 1200), ClientStream(stream)))
+                    .spawn((
+                        ConnectedClient { max_size: 1200 },
+                        connection_id,
+                        ClientStream(stream),
+                    ))
                     .id();
-                debug!("connecting `{client_entity}` with `{client_id:?}`");
+                debug!("connecting `{client_entity}` with `{connection_id:?}`");
             }
             Err(e) => {
                 if e.kind() != io::ErrorKind::WouldBlock {

--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bevy::prelude::*;
-use bevy_replicon::{core::connected_client::ConnectionId, prelude::*};
+use bevy_replicon::{core::connected_client::NetworkId, prelude::*};
 
 use super::tcp;
 
@@ -57,15 +57,15 @@ fn receive_packets(
                     error!("unable to enable non-blocking for `{addr}`: {e}");
                     continue;
                 }
-                let connection_id = ConnectionId::new(addr.port().into());
+                let network_id = NetworkId::new(addr.port().into());
                 let client_entity = commands
                     .spawn((
                         ConnectedClient { max_size: 1200 },
-                        connection_id,
+                        network_id,
                         ClientStream(stream),
                     ))
                     .id();
-                debug!("connecting `{client_entity}` with `{connection_id:?}`");
+                debug!("connecting `{client_entity}` with `{network_id:?}`");
             }
             Err(e) => {
                 if e.kind() != io::ErrorKind::WouldBlock {

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,7 +13,7 @@ pub mod server_entity_map;
 use bevy::prelude::*;
 
 use channels::RepliconChannels;
-use connected_client::{ConnectedClient, ConnectionIdMap, NetworkStats};
+use connected_client::{ConnectedClient, NetworkIdMap, NetworkStats};
 use event::event_registry::EventRegistry;
 use replication::{
     command_markers::CommandMarkers, replication_registry::ReplicationRegistry,
@@ -27,9 +27,9 @@ impl Plugin for RepliconCorePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Replicated>()
             .register_type::<ConnectedClient>()
-            .register_type::<ConnectionIdMap>()
+            .register_type::<NetworkIdMap>()
             .register_type::<NetworkStats>()
-            .init_resource::<ConnectionIdMap>()
+            .init_resource::<NetworkIdMap>()
             .init_resource::<TrackMutateMessages>()
             .init_resource::<RepliconChannels>()
             .init_resource::<ReplicationRegistry>()

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,7 +13,7 @@ pub mod server_entity_map;
 use bevy::prelude::*;
 
 use channels::RepliconChannels;
-use connected_client::{ClientIdMap, ConnectedClient, NetworkStats};
+use connected_client::{ConnectedClient, ConnectionIdMap, NetworkStats};
 use event::event_registry::EventRegistry;
 use replication::{
     command_markers::CommandMarkers, replication_registry::ReplicationRegistry,
@@ -27,8 +27,9 @@ impl Plugin for RepliconCorePlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Replicated>()
             .register_type::<ConnectedClient>()
+            .register_type::<ConnectionIdMap>()
             .register_type::<NetworkStats>()
-            .init_resource::<ClientIdMap>()
+            .init_resource::<ConnectionIdMap>()
             .init_resource::<TrackMutateMessages>()
             .init_resource::<RepliconChannels>()
             .init_resource::<ReplicationRegistry>()

--- a/src/core/connected_client.rs
+++ b/src/core/connected_client.rs
@@ -14,7 +14,7 @@ use bevy::{
 ///
 /// `Entity` is used an identifier to refer to a client.
 ///
-/// Needs to be inserted with [`ConnectionId`] if the backend provides support for it.
+/// Needs to be inserted with [`NetworkId`] if the backend provides support for it.
 ///
 /// <div class="warning">
 ///
@@ -40,11 +40,11 @@ pub struct ConnectedClient {
     pub max_size: usize,
 }
 
-/// Maps [`ConnectionId`] to its associated entity.
+/// Maps [`NetworkId`] to its associated entity.
 ///
 /// Automatically updated on client entity spawns and despawns.
 #[derive(Resource, Reflect, Default, Deref)]
-pub struct ConnectionIdMap(HashMap<ConnectionId, Entity>);
+pub struct NetworkIdMap(HashMap<NetworkId, Entity>);
 
 /// A unique and persistent client ID provided by a messaging backend.
 ///
@@ -53,7 +53,7 @@ pub struct ConnectionIdMap(HashMap<ConnectionId, Entity>);
 ///
 /// This component needs to be optionally inserted alongside [`ConnectedClient`].
 ///
-/// See also [`ConnectionIdMap`].
+/// See also [`NetworkIdMap`].
 ///
 /// <div class="warning">
 ///
@@ -63,9 +63,9 @@ pub struct ConnectionIdMap(HashMap<ConnectionId, Entity>);
 /// </div>
 #[derive(Component, Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd, Reflect)]
 #[component(on_add = on_id_add, on_remove = on_id_remove)]
-pub struct ConnectionId(u64);
+pub struct NetworkId(u64);
 
-impl ConnectionId {
+impl NetworkId {
     /// Creates a new ID wrapping the given value.
     pub const fn new(value: u64) -> Self {
         Self(value)
@@ -78,19 +78,19 @@ impl ConnectionId {
 }
 
 fn on_id_add(mut world: DeferredWorld, entity: Entity, _id: ComponentId) {
-    let connection_id = *world.get::<ConnectionId>(entity).unwrap();
-    let mut network_map = world.resource_mut::<ConnectionIdMap>();
-    if let Some(old_entity) = network_map.0.insert(connection_id, entity) {
+    let network_id = *world.get::<NetworkId>(entity).unwrap();
+    let mut network_map = world.resource_mut::<NetworkIdMap>();
+    if let Some(old_entity) = network_map.0.insert(network_id, entity) {
         error!(
-            "backend-provided `{connection_id:?}` that was already mapped to client `{old_entity}`"
+            "backend-provided `{network_id:?}` that was already mapped to client `{old_entity}`"
         );
     }
 }
 
 fn on_id_remove(mut world: DeferredWorld, entity: Entity, _id: ComponentId) {
-    let connection_id = *world.get::<ConnectionId>(entity).unwrap();
-    let mut client_map = world.resource_mut::<ConnectionIdMap>();
-    client_map.0.remove(&connection_id);
+    let network_id = *world.get::<NetworkId>(entity).unwrap();
+    let mut network_map = world.resource_mut::<NetworkIdMap>();
+    network_map.0.remove(&network_id);
 }
 
 /// Statistic associated with [`RepliconClient`](super::replicon_client::RepliconClient) or

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::core::{
-    connected_client::{ClientId, ConnectedClient},
+    connected_client::ConnectedClient,
     replicon_client::{RepliconClient, RepliconClientStatus},
     replicon_server::RepliconServer,
 };
@@ -88,9 +88,10 @@ impl ServerTestAppExt for App {
     fn connect_client(&mut self, client_app: &mut App) {
         let mut server = self.world_mut().resource_mut::<RepliconServer>();
         server.set_running(true);
-        let mut client_entity = self.world_mut().spawn_empty();
-        let client_id = ClientId::new(client_entity.id().to_bits()); // Use entity ID for client ID since it's just for testing.
-        client_entity.insert(ConnectedClient::new(client_id, 1200));
+        let client_entity = self
+            .world_mut()
+            .spawn(ConnectedClient { max_size: 1200 })
+            .id();
 
         let mut client = client_app.world_mut().resource_mut::<RepliconClient>();
         assert!(
@@ -100,7 +101,7 @@ impl ServerTestAppExt for App {
         client.set_status(RepliconClientStatus::Connected);
         client_app
             .world_mut()
-            .insert_resource(TestClientEntity(client_entity.id()));
+            .insert_resource(TestClientEntity(client_entity));
 
         self.update();
         client_app.update();

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_replicon::{
     core::{
         channels::ReplicationChannel,
-        connected_client::{ConnectedClient, ConnectionId, ConnectionIdMap},
+        connected_client::{ConnectedClient, NetworkId, NetworkIdMap},
     },
     prelude::*,
     server::server_tick::ServerTick,
@@ -87,16 +87,16 @@ fn connect_disconnect() {
         .query_filtered::<Entity, With<ConnectedClient>>();
     let client_entity = clients.single(server_app.world_mut());
 
-    // Assign a dummy connection ID to test connection map.
+    // Assign a dummy network ID to test network map.
     server_app
         .world_mut()
         .entity_mut(client_entity)
-        .insert(ConnectionId::new(0));
-    assert_eq!(server_app.world().resource::<ConnectionIdMap>().len(), 1);
+        .insert(NetworkId::new(0));
+    assert_eq!(server_app.world().resource::<NetworkIdMap>().len(), 1);
 
     server_app.disconnect_client(&mut client_app);
     assert_eq!(clients.iter(server_app.world()).len(), 0);
-    assert_eq!(server_app.world().resource::<ConnectionIdMap>().len(), 0);
+    assert_eq!(server_app.world().resource::<NetworkIdMap>().len(), 0);
 }
 
 #[test]

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_replicon::{
     core::{
         channels::ReplicationChannel,
-        connected_client::{ClientIdMap, ConnectedClient},
+        connected_client::{ConnectedClient, ConnectionIdMap},
     },
     prelude::*,
     server::server_tick::ServerTick,
@@ -84,11 +84,11 @@ fn connect_disconnect() {
 
     let mut clients = server_app.world_mut().query::<&ConnectedClient>();
     assert_eq!(clients.iter(server_app.world()).len(), 1);
-    assert_eq!(server_app.world().resource::<ClientIdMap>().len(), 1);
+    assert_eq!(server_app.world().resource::<ConnectionIdMap>().len(), 1);
 
     server_app.disconnect_client(&mut client_app);
     assert_eq!(clients.iter(server_app.world()).len(), 0);
-    assert_eq!(server_app.world().resource::<ClientIdMap>().len(), 0);
+    assert_eq!(server_app.world().resource::<ConnectionIdMap>().len(), 0);
 }
 
 #[test]

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_replicon::{
     core::{
         channels::ReplicationChannel,
-        connected_client::{ConnectedClient, ConnectionIdMap},
+        connected_client::{ConnectedClient, ConnectionId, ConnectionIdMap},
     },
     prelude::*,
     server::server_tick::ServerTick,
@@ -82,8 +82,16 @@ fn connect_disconnect() {
 
     server_app.connect_client(&mut client_app);
 
-    let mut clients = server_app.world_mut().query::<&ConnectedClient>();
-    assert_eq!(clients.iter(server_app.world()).len(), 1);
+    let mut clients = server_app
+        .world_mut()
+        .query_filtered::<Entity, With<ConnectedClient>>();
+    let client_entity = clients.single(server_app.world_mut());
+
+    // Assign a dummy connection ID to test connection map.
+    server_app
+        .world_mut()
+        .entity_mut(client_entity)
+        .insert(ConnectionId::new(0));
     assert_eq!(server_app.world().resource::<ConnectionIdMap>().len(), 1);
 
     server_app.disconnect_client(&mut client_app);


### PR DESCRIPTION
Some backends don't support persistent identifiers. To avoid forcing them to use bytes from `Entity` for this, `ConnectedClient::id` is now a separate component.

This makes it less explicit, but I included information about this in the documentation, so it shouldn't be easy to miss. It's only for backend authors, not for regular users.
I think this way `ConnectedClient` looks cleaner (no `new` method needed) and should integrate better with possible component indexing in the future.

I also renamed it from `ClientId` to `NetworkId` to avoid confusion with client entities (which are also technically client IDs).