### PR TITLE
Remove HashMap workarounds

### DIFF
--- a/bevy_replicon_example_backend/examples/tic_tac_toe.rs
+++ b/bevy_replicon_example_backend/examples/tic_tac_toe.rs
@@ -307,7 +307,7 @@ fn init_symbols(
 ///
 /// Used only for client.
 fn client_start(mut commands: Commands, cells: Query<(Entity, &Cell)>) {
-    let mut entities = HashMap::default();
+    let mut entities = HashMap::new();
     for (entity, cell) in &cells {
         entities.insert(cell.index, entity);
     }

--- a/src/shared/replication/command_markers.rs
+++ b/src/shared/replication/command_markers.rs
@@ -91,7 +91,7 @@ pub trait AppMarkerExt {
         } else {
             ctx.commands
                 .entity(entity.id())
-                .insert(History([(ctx.message_tick, component)].into_iter().collect()));
+                .insert(History([(ctx.message_tick, component)].into()));
         }
 
         Ok(())


### PR DESCRIPTION
During the migration to 0.16, I added a few workarounds related to `hashbrown` to make the code compile.
These issues have been fixed in the latest Bevy RC: https://github.com/bevyengine/bevy/pull/18694
So we can now remove those workarounds.