### PR TITLE
Immutable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for `no_std`.
+- Seamless support for immutable components. For these components, replication is always applied via insertion.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,22 @@ component inside it. However, it's preferred to use required components when pos
 it's better to require a [`Handle<T>`] with a default value that doesn't point to any asset
 and initialize it later in a hook or observer. This way you avoid archetype moves in ECS.
 
+#### Mutability
+
+There are two ways to change a component value on an entity: re-inserting it or mutating it.
+
+We use Bevy’s change detection to track and send changes. However, it does not distinguish between modifications
+and re-insertions. This is why we simply send the list of changes and decide how to apply them on the client.
+By default, this behavior is based on [`Component::Mutability`].
+
+When a component is [`Mutable`](bevy::ecs::component::Mutable), we check whether it already exists on the entity.
+If it doesn’t, we insert it. If it does, we mutate it. This means that if you insert a component into an entity
+that already has it on the server, the client will treat it as a mutation. As a result, triggers may behave
+differently on the client and server. If your game logic relies on this semantic, mark your component as
+[`Immutable`](bevy::ecs::component::Immutable). For such components, replication will always be applied via insertion.
+
+This behavior is also configurable via [client markers](#client-markers).
+
 #### Component relations
 
 Some components depend on each other. For example, [`ChildOf`] and [`Children`]. You can enable
@@ -532,9 +548,6 @@ All events, inserts, removals and despawns will be applied to clients in the sam
 
 However, if you insert/mutate a component and immediately remove it, the client will only receive the removal because the component value
 won't exist in the [`World`] during the replication process. But removal followed by insertion will work as expected since we buffer removals.
-Additionally, if you insert a component into an entity that already has it, the client will receive it as a mutation.
-This happens because Bevy’s change detection, which we use to track changes, does not distinguish between modifications and re-insertions.
-As a result, triggers may behave differently on the client and server. If your game logic relies on this behavior, remove components before re-inserting them.
 
 Entity component mutations are grouped by entity, and component groupings may be applied to clients in a different order than on the server.
 For example, if two entities are spawned in tick 1 on the server and their components are mutated in tick 2,

--- a/src/shared/replication/command_markers.rs
+++ b/src/shared/replication/command_markers.rs
@@ -27,13 +27,10 @@ pub trait AppMarkerExt {
     ///
     /// This function registers markers with default [`MarkerConfig`].
     /// See also [`Self::register_marker_with`].
-    fn register_marker<M: Component<Mutability = Mutable>>(&mut self) -> &mut Self;
+    fn register_marker<M: Component>(&mut self) -> &mut Self;
 
     /// Same as [`Self::register_marker`], but also accepts marker configuration.
-    fn register_marker_with<M: Component<Mutability = Mutable>>(
-        &mut self,
-        config: MarkerConfig,
-    ) -> &mut Self;
+    fn register_marker_with<M: Component>(&mut self, config: MarkerConfig) -> &mut Self;
 
     /**
     Associates command functions with a marker for a component.
@@ -118,7 +115,7 @@ pub trait AppMarkerExt {
     struct Health(u32);
     ```
     **/
-    fn set_marker_fns<M: Component<Mutability = Mutable>, C: Component<Mutability = Mutable>>(
+    fn set_marker_fns<M: Component, C: Component<Mutability = Mutable>>(
         &mut self,
         write: WriteFn<C>,
         remove: RemoveFn,
@@ -139,14 +136,11 @@ pub trait AppMarkerExt {
 }
 
 impl AppMarkerExt for App {
-    fn register_marker<M: Component<Mutability = Mutable>>(&mut self) -> &mut Self {
+    fn register_marker<M: Component>(&mut self) -> &mut Self {
         self.register_marker_with::<M>(MarkerConfig::default())
     }
 
-    fn register_marker_with<M: Component<Mutability = Mutable>>(
-        &mut self,
-        config: MarkerConfig,
-    ) -> &mut Self {
+    fn register_marker_with<M: Component>(&mut self, config: MarkerConfig) -> &mut Self {
         let component_id = self.world_mut().register_component::<M>();
         let mut command_markers = self.world_mut().resource_mut::<CommandMarkers>();
         let marker_id = command_markers.insert(CommandMarker {
@@ -160,7 +154,7 @@ impl AppMarkerExt for App {
         self
     }
 
-    fn set_marker_fns<M: Component<Mutability = Mutable>, C: Component<Mutability = Mutable>>(
+    fn set_marker_fns<M: Component, C: Component<Mutability = Mutable>>(
         &mut self,
         write: WriteFn<C>,
         remove: RemoveFn,

--- a/src/shared/replication/replication_registry.rs
+++ b/src/shared/replication/replication_registry.rs
@@ -4,14 +4,11 @@ pub mod ctx;
 pub mod rule_fns;
 pub mod test_fns;
 
-use bevy::{
-    ecs::component::{ComponentId, Mutable},
-    prelude::*,
-};
+use bevy::{ecs::component::ComponentId, prelude::*};
 use serde::{Deserialize, Serialize};
 
 use super::command_markers::CommandMarkerIndex;
-use command_fns::{RemoveFn, UntypedCommandFns, WriteFn};
+use command_fns::{MutWrite, RemoveFn, UntypedCommandFns, WriteFn};
 use component_fns::ComponentFns;
 use ctx::DespawnCtx;
 use rule_fns::{RuleFns, UntypedRuleFns};
@@ -64,7 +61,7 @@ impl ReplicationRegistry {
     /// # Panics
     ///
     /// Panics if the marker wasn't registered. Use [`Self::register_marker`] first.
-    pub(super) fn set_marker_fns<C: Component<Mutability = Mutable>>(
+    pub(super) fn set_marker_fns<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         world: &mut World,
         marker_id: CommandMarkerIndex,
@@ -84,7 +81,7 @@ impl ReplicationRegistry {
     /// Sets default functions for a component when there are no markers.
     ///
     /// See also [`Self::set_marker_fns`].
-    pub(super) fn set_command_fns<C: Component<Mutability = Mutable>>(
+    pub(super) fn set_command_fns<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         world: &mut World,
         write: WriteFn<C>,
@@ -104,7 +101,7 @@ impl ReplicationRegistry {
     ///
     /// Returned data can be assigned to a
     /// [`ReplicationRule`](super::replication_rules::ReplicationRule)
-    pub fn register_rule_fns<C: Component<Mutability = Mutable>>(
+    pub fn register_rule_fns<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         world: &mut World,
         rule_fns: RuleFns<C>,
@@ -119,7 +116,7 @@ impl ReplicationRegistry {
     ///
     /// If a [`ComponentFns`] has already been created for this component,
     /// then it returns its index instead of creating a new one.
-    fn init_component_fns<C: Component<Mutability = Mutable>>(
+    fn init_component_fns<C: Component<Mutability: MutWrite<C>>>(
         &mut self,
         world: &mut World,
     ) -> (usize, ComponentId) {

--- a/src/shared/replication/replication_registry/command_fns.rs
+++ b/src/shared/replication/replication_registry/command_fns.rs
@@ -72,7 +72,7 @@ impl UntypedCommandFns {
     }
 }
 
-/// Assotiates default writing function for a [`Component`] based on [`Component::Mutability`].
+/// Defines the default writing function for a [`Component`] based its [`Component::Mutability`].
 pub trait MutWrite<C: Component> {
     /// Returns [`default_write`] for [`Mutable`] and [`default_insert_write`] for [`Immutable`].
     fn default_write_fn() -> WriteFn<C>;

--- a/src/shared/replication/replication_registry/command_fns.rs
+++ b/src/shared/replication/replication_registry/command_fns.rs
@@ -3,7 +3,10 @@ use core::{
     mem,
 };
 
-use bevy::{ecs::component::Mutable, prelude::*};
+use bevy::{
+    ecs::component::{Immutable, Mutable},
+    prelude::*,
+};
 use bytes::Bytes;
 
 use super::{
@@ -24,8 +27,8 @@ pub(super) struct UntypedCommandFns {
 
 impl UntypedCommandFns {
     /// Creates a new instance with default command functions for `C`.
-    pub(super) fn default_fns<C: Component<Mutability = Mutable>>() -> Self {
-        Self::new(default_write::<C>, default_remove::<C>)
+    pub(super) fn default_fns<C: Component<Mutability: MutWrite<C>>>() -> Self {
+        Self::new(C::Mutability::default_write_fn(), default_remove::<C>)
     }
 
     /// Creates a new instance by erasing the function pointer for `write`.
@@ -69,16 +72,36 @@ impl UntypedCommandFns {
     }
 }
 
+/// Assotiates default writing function for a [`Component`] based on [`Component::Mutability`].
+pub trait MutWrite<C: Component> {
+    /// Returns [`default_write`] for [`Mutable`] and [`default_insert_write`] for [`Immutable`].
+    fn default_write_fn() -> WriteFn<C>;
+}
+
+impl<C: Component<Mutability = Self>> MutWrite<C> for Mutable {
+    fn default_write_fn() -> WriteFn<C> {
+        default_write::<C>
+    }
+}
+
+impl<C: Component<Mutability = Self>> MutWrite<C> for Immutable {
+    fn default_write_fn() -> WriteFn<C> {
+        default_insert_write::<C>
+    }
+}
+
 /// Signature of component writing function.
 pub type WriteFn<C> = fn(&mut WriteCtx, &RuleFns<C>, &mut DeferredEntity, &mut Bytes) -> Result<()>;
 
 /// Signature of component removal functions.
 pub type RemoveFn = fn(&mut RemoveCtx, &mut DeferredEntity);
 
-/// Default component writing function.
+/// Default component writing function for [`Mutable`] components.
 ///
 /// If the component does not exist on the entity, it will be deserialized with [`RuleFns::deserialize`] and inserted via [`Commands`].
 /// If the component exists on the entity, [`RuleFns::deserialize_in_place`] will be used directly on the entity's component.
+///
+/// See also [`default_insert_write`].
 pub fn default_write<C: Component<Mutability = Mutable>>(
     ctx: &mut WriteCtx,
     rule_fns: &RuleFns<C>,
@@ -92,6 +115,22 @@ pub fn default_write<C: Component<Mutability = Mutable>>(
         ctx.commands.entity(entity.id()).insert(component);
     }
 
+    Ok(())
+}
+
+/// Default component writing function for [`Immutable`] components.
+///
+/// The component will be deserialized with [`RuleFns::deserialize`] and inserted via [`Commands`].
+///
+/// Similar to [`default_write`], but always performs an insertion regardless of whether the component exists.
+pub fn default_insert_write<C: Component>(
+    ctx: &mut WriteCtx,
+    rule_fns: &RuleFns<C>,
+    entity: &mut DeferredEntity,
+    message: &mut Bytes,
+) -> Result<()> {
+    let component: C = rule_fns.deserialize(ctx, message)?;
+    ctx.commands.entity(entity.id()).insert(component);
     Ok(())
 }
 

--- a/src/shared/replication/replication_registry/component_fns.rs
+++ b/src/shared/replication/replication_registry/component_fns.rs
@@ -1,8 +1,8 @@
-use bevy::{ecs::component::Mutable, prelude::*, ptr::Ptr};
+use bevy::{prelude::*, ptr::Ptr};
 use bytes::Bytes;
 
 use super::{
-    command_fns::UntypedCommandFns,
+    command_fns::{MutWrite, UntypedCommandFns},
     ctx::{RemoveCtx, SerializeCtx, WriteCtx},
     rule_fns::UntypedRuleFns,
 };
@@ -24,7 +24,7 @@ pub(crate) struct ComponentFns {
 
 impl ComponentFns {
     /// Creates a new instance for `C` with the specified number of empty marker function slots.
-    pub(super) fn new<C: Component<Mutability = Mutable>>(marker_slots: usize) -> Self {
+    pub(super) fn new<C: Component<Mutability: MutWrite<C>>>(marker_slots: usize) -> Self {
         Self {
             serialize: untyped_serialize::<C>,
             write: untyped_write::<C>,

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -124,7 +124,7 @@ fn immutable() {
 
     let mut components = client_app.world_mut().query::<&ImmutableComponent>();
     let component = components.single(client_app.world()).unwrap();
-    assert_eq!(component.0, false);
+    assert!(!component.0);
 
     server_app
         .world_mut()
@@ -136,7 +136,7 @@ fn immutable() {
     client_app.update();
 
     let component = components.single(client_app.world()).unwrap();
-    assert_eq!(component.0, true);
+    assert!(component.0);
 }
 
 #[test]

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -116,14 +116,27 @@ fn immutable() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(ImmutableComponent);
+        .insert(ImmutableComponent(false));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let mut components = client_app.world_mut().query::<&ImmutableComponent>();
-    assert_eq!(components.iter(client_app.world()).count(), 1);
+    let component = components.single(client_app.world()).unwrap();
+    assert_eq!(component.0, false);
+
+    server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(ImmutableComponent(true));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let component = components.single(client_app.world()).unwrap();
+    assert_eq!(component.0, true);
 }
 
 #[test]
@@ -592,7 +605,7 @@ struct DummyComponent;
 
 #[derive(Component, Deserialize, Serialize)]
 #[component(immutable)]
-struct ImmutableComponent;
+struct ImmutableComponent(bool);
 
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "SparseSet")]


### PR DESCRIPTION
Immutable components were introduced in Bevy via: https://github.com/bevyengine/bevy/pull/16372
These components can only be changed via re-insertion. This allows users to enforce invariants through triggers and hooks.

When porting to 0.16, I initially added a `Mutability = Mutable` constraint. In this PR, to support immutable components, I replaced this constraint with the `MutWrite` trait. It is implemented for both `Mutable` and `Immutable` markers to select the appropriate write function. For `Immutable` components, this function always performs insertion.