### PR TITLE
Rename ranges struct

### DIFF
--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -1,4 +1,4 @@
-mod component_changes;
+mod change_ranges;
 pub(super) mod mutate_message;
 pub(super) mod serialized_data;
 pub(super) mod update_message;

--- a/src/server/replication_messages/change_ranges.rs
+++ b/src/server/replication_messages/change_ranges.rs
@@ -9,13 +9,13 @@ use postcard::experimental::serialized_size;
 ///
 /// Used inside [`UpdateMessage`](super::update_message::UpdateMessage) and
 /// [`MutateMessage`](super::mutate_message::MutateMessage).
-pub(super) struct ComponentChanges {
+pub(super) struct ChangeRanges {
     pub(super) entity: Range<usize>,
     pub(super) components_len: usize,
     pub(super) components: Vec<Range<usize>>,
 }
 
-impl ComponentChanges {
+impl ChangeRanges {
     /// Returns serialized size.
     pub(super) fn size(&self) -> Result<usize> {
         let len_size = serialized_size(&self.components_len)?;

--- a/src/server/replication_messages/mutate_message.rs
+++ b/src/server/replication_messages/mutate_message.rs
@@ -3,7 +3,7 @@ use core::{ops::Range, time::Duration};
 use bevy::{ecs::component::Tick, prelude::*};
 use postcard::experimental::{max_size::MaxSize, serialized_size};
 
-use super::{component_changes::ComponentChanges, serialized_data::SerializedData};
+use super::{change_ranges::ChangeRanges, serialized_data::SerializedData};
 use crate::shared::{
     backend::{replicon_channels::ReplicationChannel, replicon_server::RepliconServer},
     postcard_utils,
@@ -50,7 +50,7 @@ pub(crate) struct MutateMessage {
     /// of chunk bytes instead of the number of components. This is because, during deserialization,
     /// some entities may be skipped if they have already been updated (as mutations are sent until
     /// the client acknowledges them).
-    mutations: Vec<ComponentChanges>,
+    mutations: Vec<ChangeRanges>,
 
     /// Indicates that an entity has been written since the
     /// last call of [`Self::start_entity_mutations`].
@@ -83,7 +83,7 @@ impl MutateMessage {
     /// Adds an entity chunk.
     pub(crate) fn add_mutated_entity(&mut self, entity: Entity, entity_range: Range<usize>) {
         let components = self.buffer.pop().unwrap_or_default();
-        self.mutations.push(ComponentChanges {
+        self.mutations.push(ChangeRanges {
             entity: entity_range,
             components_len: 0,
             components,
@@ -103,7 +103,7 @@ impl MutateMessage {
     }
 
     /// Returns written mutations for the last entity from [`Self::add_mutated_entity`].
-    pub(super) fn last_mutations(&mut self) -> Option<&ComponentChanges> {
+    pub(super) fn last_mutations(&mut self) -> Option<&ChangeRanges> {
         self.mutations.last()
     }
 

--- a/src/server/replication_messages/mutate_message.rs
+++ b/src/server/replication_messages/mutate_message.rs
@@ -30,8 +30,6 @@ use crate::shared::{
 ///
 /// Sent over the [`ReplicationChannel::Mutations`] channel. If the message gets lost, we try to resend it manually,
 /// using the last up-to-date mutations to avoid re-sending old values.
-///
-/// Stored inside [`ReplicationMessages`](super::ReplicationMessages).
 #[derive(Default, Component)]
 pub(crate) struct MutateMessage {
     /// List of entity values for [`Self::mutations`].

--- a/src/server/replication_messages/update_message.rs
+++ b/src/server/replication_messages/update_message.rs
@@ -33,8 +33,6 @@ use crate::shared::{
 ///
 /// Additionally, we don't serialize the size for the last array and
 /// on deserialization just consume all remaining bytes.
-///
-/// Stored inside [`ReplicationMessages`](super::ReplicationMessages).
 #[derive(Default, Component)]
 pub(crate) struct UpdateMessage {
     /// Mappings for client's pre-spawned entities.


### PR DESCRIPTION
Just an internal rename. I think it makes the intent clearer.
This will better fit the upcoming relationships support.