### PR TITLE
Do immediate cleanup after sending

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -259,11 +259,6 @@ pub(super) fn send_replication(
     server_tick: Res<ServerTick>,
     time: Res<Time>,
 ) -> Result<()> {
-    for (_, mut mutations, mut updates, ..) in &mut clients {
-        updates.clear();
-        mutations.clear();
-    }
-
     collect_mappings(&mut serialized, &mut clients)?;
     collect_despawns(&mut serialized, &mut clients, &mut despawn_buffer)?;
     collect_removals(&mut serialized, &mut clients, &removal_buffer)?;
@@ -326,7 +321,7 @@ fn send_messages(
     time: &Time,
 ) -> Result<()> {
     let mut server_tick_range = None;
-    for (client_entity, updates, mut mutations, client, .., mut ticks, visibility) in clients {
+    for (client_entity, mut updates, mut mutations, client, .., mut ticks, visibility) in clients {
         if !updates.is_empty() {
             ticks.set_update_tick(server_tick);
             let server_tick = write_tick_cached(&mut server_tick_range, serialized, server_tick)?;

--- a/src/server/replication_messages/mutations.rs
+++ b/src/server/replication_messages/mutations.rs
@@ -129,7 +129,7 @@ impl Mutations {
         &mut self,
         server: &mut RepliconServer,
         client_entity: Entity,
-        client: &mut ClientTicks,
+        ticks: &mut ClientTicks,
         entity_buffer: &mut EntityBuffer,
         serialized: &SerializedData,
         track_mutate_messages: bool,
@@ -142,14 +142,14 @@ impl Mutations {
 
         const MAX_COUNT_SIZE: usize = usize::POSTCARD_MAX_SIZE;
         let mut tick_buffer = [0; RepliconTick::POSTCARD_MAX_SIZE];
-        let update_tick = postcard::to_slice(&client.update_tick(), &mut tick_buffer)?;
+        let update_tick = postcard::to_slice(&ticks.update_tick(), &mut tick_buffer)?;
         let mut metadata_size = update_tick.len() + server_tick.len();
         if track_mutate_messages {
             metadata_size += MAX_COUNT_SIZE;
         }
 
         let (mut mutate_index, mut entities) =
-            client.register_mutate_message(entity_buffer, tick, timestamp);
+            ticks.register_mutate_message(entity_buffer, tick, timestamp);
         let mut header_size = metadata_size + serialized_size(&mutate_index)?;
         let mut body_size = 0;
         let mut mutations_range = Range::<usize>::default();
@@ -169,7 +169,7 @@ impl Mutations {
 
                 mutations_range.start = mutations_range.end;
                 (mutate_index, entities) =
-                    client.register_mutate_message(entity_buffer, tick, timestamp);
+                    ticks.register_mutate_message(entity_buffer, tick, timestamp);
                 header_size = metadata_size + serialized_size(&mutate_index)?; // Recalculate since the mutate index changed.
                 body_size = 0;
             }

--- a/src/server/replication_messages/mutations.rs
+++ b/src/server/replication_messages/mutations.rs
@@ -124,7 +124,7 @@ impl Mutations {
     /// independently on the client.
     /// Message splits only happen per-entity to avoid weird behavior from partial entity mutations.
     ///
-    /// After sendining all data in the component will be cleared.
+    /// After sending all data in the component will be cleared.
     pub(crate) fn send(
         &mut self,
         server: &mut RepliconServer,

--- a/src/server/replication_messages/updates.rs
+++ b/src/server/replication_messages/updates.rs
@@ -177,12 +177,11 @@ impl Updates {
 
     /// Packs updates into a message.
     ///
-    /// Contains tick, mappings, insertions, removals, and despawns that
-    /// happened in this tick.
-    ///
     /// Sent over [`ReplicationChannel::Updates`] channel.
     ///
-    /// Some data is optional, and their presence is encoded in the [`UpdateMessageFlags`] bitset.
+    /// Contains tick, mappings, insertions, removals, and despawns that
+    /// happened in this tick. Some data is optional, and their presence is
+    /// encoded in the [`UpdateMessageFlags`] bitset.
     ///
     /// To know how much data array takes, we serialize it's length. We use `usize`,
     /// but we use variable integer encoding, so they are correctly deserialized even
@@ -192,8 +191,10 @@ impl Updates {
     ///
     /// Additionally, we don't serialize the size for the last array and
     /// on deserialization just consume all remaining bytes.
+    ///
+    /// After sendining all data in the component will be cleared.
     pub(crate) fn send(
-        &self,
+        &mut self,
         server: &mut RepliconServer,
         client_entity: Entity,
         serialized: &SerializedData,
@@ -287,6 +288,8 @@ impl Updates {
 
         server.send(client_entity, ReplicationChannel::Updates, message);
 
+        self.clear();
+
         Ok(())
     }
 
@@ -312,7 +315,7 @@ impl Updates {
     /// Clears all chunks.
     ///
     /// Keeps allocated memory for reuse.
-    pub(crate) fn clear(&mut self) {
+    fn clear(&mut self) {
         self.mappings = Default::default();
         self.mappings_len = 0;
         self.despawns.clear();

--- a/src/server/replication_messages/updates.rs
+++ b/src/server/replication_messages/updates.rs
@@ -192,7 +192,7 @@ impl Updates {
     /// Additionally, we don't serialize the size for the last array and
     /// on deserialization just consume all remaining bytes.
     ///
-    /// After sendining all data in the component will be cleared.
+    /// After sending all data in the component will be cleared.
     pub(crate) fn send(
         &mut self,
         server: &mut RepliconServer,


### PR DESCRIPTION
To avoid looping through each client in the beginning.