### PR TITLE
Configurable send rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Deprecated methods.
+
 ## [0.33.0] - 2025-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rules created with the same priority now evaluated in their creation order.
+
 ### Removed
 
 - Deprecated methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configurable `SendRate` for deterministic replication. Use `SendRate::Once` to send only the initial value, or `SendRate::Periodic` to only sync the state periodically.
+- `AppRuleExt::replicate_with_priority` to configure replication rule priority.
+
 ### Changed
 
+- `AppRuleExt::replicate_with` now accepts `IntoReplicationRule` trait that allows to define rules with multiple components.
+- Rename `GroupReplication` into `BundleReplication`.
+- Rename `AppRuleExt::replicate_group` into `AppRuleExt::replicate_bundle`.
+- `ReplicationRule` now stores `Vec<ComponentRule>` instead of `Vec<(ComponentId, FnsId)>`
+- `RuleFns` now available from prelude.
 - Rules created with the same priority now evaluated in their creation order.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Check out the [quick start guide](https://docs.rs/bevy_replicon).
 For examples navigate to the [`bevy_replicon_example_backend`](bevy_replicon_example_backend) (because you need I/O in order to run them).
 
 You can also:
-- Watch [my talk at Bevy Meetup #9](https://www.youtube.com/watch?v=aDsVFmXD2cc)  
-- Read [this great article](https://www.hankruiger.com/posts/adding-networked-multiplayer-to-my-game-with-bevy-replicon) *(not mine)*  
+- Watch [my talk at Bevy Meetup #9](https://www.youtube.com/watch?v=aDsVFmXD2cc)
+- Read [this great article](https://www.hankruiger.com/posts/adding-networked-multiplayer-to-my-game-with-bevy-replicon) *(not mine)*
 
 Have any questions? Feel free to ask in the dedicated [`bevy_replicon` channel](https://discord.com/channels/691052431525675048/1090432346907492443) in Bevy's Discord server.
 
@@ -62,7 +62,7 @@ Depending on your game, you may need additional features. We provide an API that
 #### Miscellaneous
 
 - [`bevy_replicon_repair`](https://github.com/UkoeHB/bevy_replicon_repair) - preserves replicated client state across reconnects.
-- [`bevy_bundlication`](https://github.com/NiseVoid/bevy_bundlication) - adds registration of replication groups using a bundle-like api.
+- [`bevy_bundlication`](https://github.com/NiseVoid/bevy_bundlication) - automates the creation of replication rules for bundles.
 
 #### Unmaintained
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ If your component doesn't implement serde traits or you want to customize the se
 You can also create a rule for multiple components. Use [`AppRuleExt::replicate_bundle`],
 or pass a tuple of [`RuleFns`] to [`AppRuleExt::replicate_with`]. The components will only
 be replicated if all of them are present on the entity. This also allows you to specialize
-serialization and deserialization based on specific specific entity components.
+serialization and deserialization based on specific entity components.
 
 #### Required components
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,9 @@ resource.
 ### Components
 
 Components will be replicated only on entities marked for replication.
-By default no components are replicated.
+By default no components are replicated, you need to define rules for it.
 
-Use [`AppRuleExt::replicate`] to enable replication for a component:
+Use [`AppRuleExt::replicate`] to create a replication rule for a single component:
 
 ```
 # use bevy::prelude::*;
@@ -132,8 +132,10 @@ If your component doesn't implement serde traits or you want to customize the se
 (for example, quantize, skip some fields or apply compression), you can use
 [`AppRuleExt::replicate_with`].
 
-If you want a group of components to be replicated only if all of them are present on an entity,
-you can use [`AppRuleExt::replicate_group`].
+You can also create a rule for multiple components. Use [`AppRuleExt::replicate_bundle`],
+or pass a tuple of [`RuleFns`] to [`AppRuleExt::replicate_with`]. The components will only
+be replicated if all of them are present on the entity. This also allows you to specialize
+serialization and deserialization based on specific specific entity components.
 
 #### Required components
 
@@ -210,6 +212,21 @@ Some components depend on each other. For example, [`ChildOf`] and [`Children`].
 replication only for [`ChildOf`] and [`Children`] will be updated automatically on insertion.
 
 You can also ensure that their mutations arrive in sync by using [`SyncRelatedAppExt::sync_related_entities`].
+
+#### Deterministic replication
+
+Up until now, we've covered only authoritative replication (AR), where the server is the source of truth
+and continuously sends changes. However, sometimes you may want to send data only once and simulate independently,
+relying on determinism. This approach is called deterministic replication (DR).
+
+For example, you might use AR for things like player health, and DR for moving platform positions to reduce
+network traffic.
+
+Use [`AppRuleExt::replicate_once`] to replicate only the initial value of a component. If you want a mix of
+both - relying on determinism but periodically syncing with a defined interval - use [`AppRuleExt::replicate_periodic`].
+You can configure this per-component within a replication rule using [`AppRuleExt::replicate_with`].
+
+See also [server events](#from-server-to-client), which are also useful for DR.
 
 ## Network events and triggers
 
@@ -614,7 +631,10 @@ pub mod prelude {
                 server_trigger::{ServerTriggerAppExt, ServerTriggerExt},
             },
             replication::{
-                Replicated, command_markers::AppMarkerExt, replication_rules::AppRuleExt,
+                Replicated,
+                command_markers::AppMarkerExt,
+                replication_registry::rule_fns::RuleFns,
+                replication_rules::{AppRuleExt, SendRate},
             },
         },
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,7 @@ A tick for an entity is confirmed if one of the following is true:
 - [`ConfirmHistory`](client::confirm_history::ConfirmHistory) is greater than the tick.
 - [`ServerMutateTicks`](client::server_mutate_ticks::ServerMutateTicks) reports that for at least one of the next ticks, all update
   messages have been received.
+- [`SendRate::send_mutations`] returns `false` for all replicated components on the entity for every tick prior to the current one.
 
 # Eventual consistency
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -71,14 +71,10 @@ pub fn replicate_into(scene: &mut DynamicScene, world: &World) {
         }
 
         for rule in rules.iter().filter(|rule| rule.matches(archetype)) {
-            for component_id in rule
-                .components
-                .iter()
-                .map(|&(component_id, _)| component_id)
-            {
+            for component in &rule.components {
                 // SAFETY: replication rules can be registered only with valid component IDs.
                 let replicated_component =
-                    unsafe { world.components().get_info_unchecked(component_id) };
+                    unsafe { world.components().get_info_unchecked(component.id) };
                 let type_name = replicated_component.name();
                 let type_id = replicated_component
                     .type_id()

--- a/src/shared/replication/replication_registry/rule_fns.rs
+++ b/src/shared/replication/replication_registry/rule_fns.rs
@@ -3,7 +3,7 @@ use core::{
     mem,
 };
 
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::prelude::*;
 use bytes::Bytes;
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -155,14 +155,6 @@ impl<C: Component> RuleFns<C> {
     }
 }
 
-impl<C: Component + Serialize + DeserializeOwned + MapEntities> RuleFns<C> {
-    #[deprecated(note = "no longer needed, use `default` instead")]
-    #[allow(deprecated)]
-    pub fn default_mapped() -> Self {
-        Self::new(default_serialize::<C>, default_deserialize_mapped::<C>)
-    }
-}
-
 impl<C: Component + Serialize + DeserializeOwned> Default for RuleFns<C> {
     /// Creates a new instance with default functions for a component.
     ///
@@ -202,16 +194,6 @@ pub fn default_deserialize<C: Component + DeserializeOwned>(
 ) -> Result<C> {
     let mut component: C = postcard_utils::from_buf(message)?;
     C::map_entities(&mut component, ctx);
-    Ok(component)
-}
-
-#[deprecated(note = "no longer needed, use `default_serialize` instead")]
-pub fn default_deserialize_mapped<C: Component + DeserializeOwned + MapEntities>(
-    ctx: &mut WriteCtx,
-    message: &mut Bytes,
-) -> Result<C> {
-    let mut component: C = postcard_utils::from_buf(message)?;
-    component.map_entities(ctx);
     Ok(component)
 }
 

--- a/src/shared/replication/replication_registry/test_fns.rs
+++ b/src/shared/replication/replication_registry/test_fns.rs
@@ -28,7 +28,7 @@ use bevy::prelude::*;
 use bevy_replicon::{
     shared::{
         replication::replication_registry::{
-            rule_fns::RuleFns, test_fns::TestFnsEntityExt, ReplicationRegistry,
+            test_fns::TestFnsEntityExt, ReplicationRegistry,
         },
         replicon_tick::RepliconTick,
     },

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -10,34 +10,131 @@ use serde::{Serialize, de::DeserializeOwned};
 use super::replication_registry::{
     FnsId, ReplicationRegistry, command_fns::MutWrite, rule_fns::RuleFns,
 };
+use crate::shared::replicon_tick::RepliconTick;
 
 /// Replication functions for [`App`].
 pub trait AppRuleExt {
-    /// Creates a replication rule for a single component.
+    /// Defines a [`ReplicationRule`] for a single component.
     ///
-    /// The component will be replicated if its entity contains the [`Replicated`](super::Replicated)
-    /// marker component.
+    /// If present on an entity with [`Replicated`](super::Replicated) component,
+    /// it will be serialized and deserialized as-is using [`postcard`]
+    /// and sent at [`SendRate::EveryTick`]. To customize this, use [`Self::replicate_with`].
     ///
-    /// Component will be serialized and deserialized as-is using postcard.
-    /// To customize it, use [`Self::replicate_group`].
-    ///
-    /// See also [`Self::replicate_with`] and the section on [`components`](../../index.html#components)
-    /// from the quick start guide.
+    /// See also the section on [`components`](../../index.html#components) from the quick start guide.
     fn replicate<C>(&mut self) -> &mut Self
     where
         C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
     {
-        self.replicate_with::<C>(RuleFns::default())
+        self.replicate_with(RuleFns::<C>::default())
+    }
+
+    /// Sames as [`Self::replicate`], but uses [`SendRate::Once`].
+    fn replicate_once<C>(&mut self) -> &mut Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.replicate_with((RuleFns::<C>::default(), SendRate::Once))
+    }
+
+    /// Sames as [`Self::replicate`], but uses [`SendRate::Periodic`] with the given period.
+    fn replicate_periodic<C>(&mut self, period: u32) -> &mut Self
+    where
+        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
+    {
+        self.replicate_with((RuleFns::<C>::default(), SendRate::Periodic(period)))
     }
 
     /**
-    Same as [`Self::replicate`], but uses the specified functions for serialization and deserialization.
+    Defines a [`ReplicationRule`] for a bundle.
 
-    Can be used to customize how the component will be passed over the network or
+    Implemented for tuples of components. Use it to conveniently create a rule with
+    default ser/de functions and [`SendRate::EveryTick`] for all components.
+    To customize this, use [`Self::replicate_with`].
+
+    Can also be implemented manually for user-defined bundles.
+
+    # Examples
+
+    ```
+    use bevy::prelude::*;
+    use bevy_replicon::{
+        bytes::Bytes,
+        shared::replication::{
+            replication_registry::{
+                ctx::{SerializeCtx, WriteCtx},
+                ReplicationRegistry,
+            },
+            replication_rules::{ReplicationBundle, ReplicationRule, ComponentRule},
+        },
+        prelude::*,
+    };
+    use serde::{Deserialize, Serialize};
+
+    # let mut app = App::new();
+    # app.add_plugins(RepliconPlugins);
+    app.replicate_bundle::<(Name, City)>() // Tuple of components is also a bundle!
+        .replicate_bundle::<PlayerBundle>();
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct City;
+
+    #[derive(Bundle)]
+    struct PlayerBundle {
+        transform: Transform,
+        player: Player,
+        replicated: Replicated,
+    }
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct Player;
+
+    impl ReplicationBundle for PlayerBundle {
+        fn register(world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule {
+            // Customize serlialization to serialize only `translation`.
+            let (transform_id, transform_fns_id) = registry.register_rule_fns(
+                world,
+                RuleFns::new(serialize_translation, deserialize_translation),
+            );
+            let transform_rule = ComponentRule::new(transform_id, transform_fns_id);
+
+            // Serialize `player` as usual.
+            let (player_id, player_fns_id) = registry.register_rule_fns(world, RuleFns::<Player>::default());
+            let player_rule = ComponentRule::new(player_id, player_fns_id);
+
+            // We skip `replication` registration since it's a special component.
+            // It's automatically inserted on clients after replication and
+            // deserialization from scenes.
+
+            ReplicationRule::new(vec![transform_rule, player_rule])
+        }
+    }
+
+    # fn serialize_translation(_: &SerializeCtx, _: &Transform, _: &mut Vec<u8>) -> Result<()> { unimplemented!() }
+    # fn deserialize_translation(_: &mut WriteCtx, _: &mut Bytes) -> Result<Transform> { unimplemented!() }
+    ```
+    **/
+    fn replicate_bundle<B: ReplicationBundle>(&mut self) -> &mut Self;
+
+    /**
+    Defines a customizable [`ReplicationRule`].
+
+    Can be used to customize how a component is passed over the network, or
     for components that don't implement [`Serialize`] or [`DeserializeOwned`].
 
-    You can also override how the component will be written,
-    see [`AppMarkerExt`](super::command_markers::AppMarkerExt).
+    You can also pass a tuple of [`RuleFns`] to define a rule for multiple components.
+    These components will only be replicated if all of them are present on the entity.
+    To assign a [`SendRate`] to a component, wrap its [`RuleFns`] in a tuple with the
+    desired rate.
+
+    If an entity matches multiple rules, the functions from the rule with higher priority
+    will take precedence for overlapping components. For example, a rule for `Health`
+    and a `Player` marker will take precedence over a rule for `Health` alone. This can
+    be used to specialize serialization for a specific set of components.
+
+    If you remove a single component from such a rule from an entity, only one
+    removal will be sent to clients. The other components in the rule will remain
+    present on both the server and the clients. Replication for them will be stopped,
+    unless they match another rule.
 
     <div class="warning">
 
@@ -46,11 +143,14 @@ pub trait AppRuleExt {
 
     </div>
 
-    See also [`postcard_utils`](crate::shared::postcard_utils).
+    You can also override how the component will be written,
+    see [`AppMarkerExt`](super::command_markers::AppMarkerExt).
+
+    See also [`postcard_utils`](crate::shared::postcard_utils) for serialization helpers.
 
     # Examples
 
-    Ser/de only specific field:
+    Pass [`RuleFns`] to ser/de only specific field:
 
     ```
     use bevy::prelude::*;
@@ -60,7 +160,7 @@ pub trait AppRuleExt {
             postcard_utils,
             replication::replication_registry::{
                 ctx::{SerializeCtx, WriteCtx},
-                rule_fns::{RuleFns, DeserializeFn},
+                rule_fns::DeserializeFn,
             },
         },
         prelude::*,
@@ -108,6 +208,37 @@ pub trait AppRuleExt {
         component.translation = transform.translation;
         Ok(())
     }
+    ```
+
+    A rule with multiple components:
+
+    ```
+    use bevy::prelude::*;
+    use bevy_replicon::prelude::*;
+    use serde::{Deserialize, Serialize};
+
+    # let mut app = App::new();
+    # app.add_plugins(RepliconPlugins);
+    app.replicate_with((
+        // You can also use `replicate_bundle` if you don't want
+        // to tweak functions or send rate.
+        RuleFns::<Player>::default(),
+        RuleFns::<Position>::default(),
+    ))
+    .replicate_with((
+        RuleFns::<MovingPlatform>::default(),
+        // Send position only once.
+        (RuleFns::<Position>::default(), SendRate::Once),
+    ));
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct Player;
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct MovingPlatform;
+
+    #[derive(Component, Deserialize, Serialize)]
+    struct Position(Vec2);
     ```
 
     Ser/de with compression:
@@ -285,66 +416,29 @@ pub trait AppRuleExt {
     #[derive(Component)]
     struct ReflectedComponent(Box<dyn PartialReflect>);
     ```
-    */
-    fn replicate_with<C>(&mut self, rule_fns: RuleFns<C>) -> &mut Self
-    where
-        C: Component<Mutability: MutWrite<C>>;
-
-    /**
-    Creates a replication rule for a group of components.
-
-    A group will only be replicated if all its components are present on the entity.
-
-    If a group contains a single component, it will work the same as [`Self::replicate`].
-
-    If an entity matches multiple groups, functions from a group with higher priority
-    will take precedence for overlapping components. For example, a rule with `Health`
-    and a `Player` marker will take precedence over a single `Health` rule.
-
-    If you remove a single component from a group, only a single removal will be sent to clients.
-    Other group components will continue to be present on both server and clients.
-    Replication for them will be stopped, unless they match other rules.
-
-    We provide blanket impls for tuples to replicate them as-is, but a user could manually implement the trait
-    to customize how components will be serialized and deserialized. For details see [`GroupReplication`].
-
-    # Panics
-
-    Panics if `debug_assertions` are enabled and any rule is a subset of another.
-
-    # Examples
-
-    Replicate `Health` and `Player` components only if both of them are present on an entity:
-
-    ```
-    use bevy::prelude::*;
-    use bevy_replicon::prelude::*;
-    use serde::{Deserialize, Serialize};
-
-    # let mut app = App::new();
-    # app.add_plugins(RepliconPlugins);
-    app.replicate_group::<(Player, Health)>();
-
-    #[derive(Component, Deserialize, Serialize)]
-    struct Player;
-
-    #[derive(Component, Deserialize, Serialize)]
-    struct Health(u32);
-    ```
     **/
-    fn replicate_group<C: GroupReplication>(&mut self) -> &mut Self;
+    fn replicate_with<R: IntoReplicationRule>(&mut self, rule: R) -> &mut Self {
+        self.replicate_with_priority(R::DEFAULT_PRIORITY, rule)
+    }
+
+    /// Same as [`Self::replicate_with`], but uses the specified priority instead of the default one.
+    fn replicate_with_priority<R: IntoReplicationRule>(
+        &mut self,
+        priority: usize,
+        rule: R,
+    ) -> &mut Self;
 }
 
 impl AppRuleExt for App {
-    fn replicate_with<C>(&mut self, rule_fns: RuleFns<C>) -> &mut Self
-    where
-        C: Component<Mutability: MutWrite<C>>,
-    {
+    fn replicate_with_priority<R: IntoReplicationRule>(
+        &mut self,
+        priority: usize,
+        rule: R,
+    ) -> &mut Self {
         let rule =
             self.world_mut()
                 .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                    let fns_info = registry.register_rule_fns(world, rule_fns);
-                    ReplicationRule::new(vec![fns_info])
+                    rule.register(priority, world, &mut registry)
                 });
 
         self.world_mut()
@@ -354,11 +448,11 @@ impl AppRuleExt for App {
         self
     }
 
-    fn replicate_group<C: GroupReplication>(&mut self) -> &mut Self {
+    fn replicate_bundle<B: ReplicationBundle>(&mut self) -> &mut Self {
         let rule =
             self.world_mut()
                 .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                    C::register(world, &mut registry)
+                    B::register(world, &mut registry)
                 });
 
         self.world_mut()
@@ -368,6 +462,144 @@ impl AppRuleExt for App {
         self
     }
 }
+
+/// Parameters that can be turned into a replication rule.
+///
+/// Implemented for tuples of [`IntoComponentRule`].
+///
+/// See [`AppRuleExt::replicate_with`] for more details.
+pub trait IntoReplicationRule {
+    /// Priority when registered with [`AppRuleExt::replicate_with`].
+    ///
+    /// Equals to the number of component in a rule.
+    const DEFAULT_PRIORITY: usize;
+
+    /// Turns into a replication rule and registers its functions in [`ReplicationRegistry`].
+    fn register(
+        self,
+        priority: usize,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> ReplicationRule;
+}
+
+impl<C: IntoComponentRule> IntoReplicationRule for C {
+    const DEFAULT_PRIORITY: usize = 1;
+
+    fn register(
+        self,
+        priority: usize,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> ReplicationRule {
+        ReplicationRule {
+            priority,
+            components: vec![self.register_component(world, registry)],
+        }
+    }
+}
+
+macro_rules! impl_into_replication_rule {
+    ($(($n:tt, $C:ident)),*) => {
+        impl<$($C: IntoComponentRule),*> IntoReplicationRule for ($($C,)*) {
+            const DEFAULT_PRIORITY: usize = 0 $(+ { let _ = $n; 1 })*;
+
+            fn register(self, priority: usize, world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule {
+                let components = vec![
+                    $(
+                        self.$n.register_component(world, registry),
+                    )*
+                ];
+
+                ReplicationRule {
+                    priority,
+                    components,
+                }
+            }
+        }
+    }
+}
+
+variadics_please::all_tuples_enumerated!(impl_into_replication_rule, 1, 15, R);
+
+/// Parameters for that can be turned into a component replication rule.
+///
+/// Used for [`IntoReplicationRule`] to accept either [`RuleFns`] or a tuple combining
+/// [`RuleFns`] with an associated [`SendRate`].
+///
+/// See [`AppRuleExt::replicate_with`] for more details.
+pub trait IntoComponentRule {
+    /// Turns into a component replication rule and registers its functions in [`ReplicationRegistry`].
+    fn register_component(
+        self,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> ComponentRule;
+}
+
+impl<C: Component<Mutability: MutWrite<C>>> IntoComponentRule for RuleFns<C> {
+    fn register_component(
+        self,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> ComponentRule {
+        let (id, fns_id) = registry.register_rule_fns(world, self);
+        ComponentRule {
+            id,
+            fns_id,
+            send_rate: Default::default(),
+        }
+    }
+}
+
+impl<C: Component<Mutability: MutWrite<C>>> IntoComponentRule for (RuleFns<C>, SendRate) {
+    fn register_component(
+        self,
+        world: &mut World,
+        registry: &mut ReplicationRegistry,
+    ) -> ComponentRule {
+        let (rule_fns, send_rate) = self;
+        let (id, fns_id) = registry.register_rule_fns(world, rule_fns);
+        ComponentRule {
+            id,
+            fns_id,
+            send_rate,
+        }
+    }
+}
+
+/// Replication rule associated with a bundle.
+///
+/// See [`AppRuleExt::replicate_bundle`] for more details.
+pub trait ReplicationBundle {
+    /// Creates the associated replication rules and registers its functions in [`ReplicationRegistry`].
+    fn register(world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule;
+}
+
+macro_rules! impl_replication_bundle {
+    ($($C:ident),*) => {
+        impl<$($C: Component<Mutability: MutWrite<$C>> + Serialize + DeserializeOwned),*> ReplicationBundle for ($($C,)*) {
+            fn register(world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule {
+                let components = vec![
+                    $(
+                        {
+                            let (id, fns_id) = registry.register_rule_fns(world, RuleFns::<$C>::default());
+                            ComponentRule {
+                                id,
+                                fns_id,
+                                send_rate: Default::default(),
+                            }
+                        },
+                    )*
+                ];
+
+                ReplicationRule::new(components)
+            }
+        }
+    }
+}
+
+variadics_please::all_tuples!(impl_replication_bundle, 1, 15, C);
 
 /// All registered rules for components replication.
 #[derive(Default, Deref, Resource, Clone)]
@@ -391,8 +623,8 @@ impl ReplicationRules {
     }
 }
 
-/// Describes a replicated component or a group of components.
-#[derive(Clone)]
+/// Describes how component(s) will be replicated.
+#[derive(Clone, Debug)]
 pub struct ReplicationRule {
     /// Priority for this rule.
     ///
@@ -400,13 +632,13 @@ pub struct ReplicationRule {
     /// but can be adjusted by the user.
     pub priority: usize,
 
-    /// Rule components and their serialization/deserialization/removal functions.
-    pub components: Vec<(ComponentId, FnsId)>,
+    /// Components for the rule.
+    pub components: Vec<ComponentRule>,
 }
 
 impl ReplicationRule {
     /// Creates a new rule with priority equal to the number of serializable components.
-    pub fn new(components: Vec<(ComponentId, FnsId)>) -> Self {
+    pub fn new(components: Vec<ComponentRule>) -> Self {
         Self {
             priority: components.len(),
             components,
@@ -417,7 +649,7 @@ impl ReplicationRule {
     pub(crate) fn matches(&self, archetype: &Archetype) -> bool {
         self.components
             .iter()
-            .all(|&(component_id, _)| archetype.contains(component_id))
+            .all(|component| archetype.contains(component.id))
     }
 
     /// Determines whether the rule is applicable to an archetype with removals included and contains at least one removal.
@@ -432,10 +664,10 @@ impl ReplicationRule {
         removed_components: &HashSet<ComponentId>,
     ) -> bool {
         let mut matches = false;
-        for &(component_id, _) in &self.components {
-            if removed_components.contains(&component_id) {
+        for component in &self.components {
+            if removed_components.contains(&component.id) {
                 matches = true;
-            } else if !post_removal_archetype.contains(component_id) {
+            } else if !post_removal_archetype.contains(component.id) {
                 return false;
             }
         }
@@ -444,88 +676,67 @@ impl ReplicationRule {
     }
 }
 
-/**
-Describes how a component group should be serialized, deserialized, written, and removed.
-
-Can be implemented on any struct to create a custom replication group.
-
-# Examples
-
-```
-# use bevy::prelude::*;
-# use bevy_replicon::{
-#     bytes::Bytes,
-#     shared::replication::{
-#         replication_registry::{
-#             ctx::{SerializeCtx, WriteCtx},
-#             rule_fns::RuleFns,
-#             ReplicationRegistry,
-#         },
-#         replication_rules::{GroupReplication, ReplicationRule},
-#     },
-#     prelude::*,
-# };
-# use serde::{Deserialize, Serialize};
-# let mut app = App::new();
-# app.add_plugins(RepliconPlugins);
-app.replicate_group::<PlayerBundle>();
-
-#[derive(Bundle)]
-struct PlayerBundle {
-    transform: Transform,
-    player: Player,
-    replicated: Replicated,
+/// Component for [`ReplicationRule`].
+#[derive(Clone, Copy, Debug)]
+pub struct ComponentRule {
+    /// ID of the replicated component.
+    pub id: ComponentId,
+    /// Associated serialization and deserialization functions.
+    pub fns_id: FnsId,
+    /// Sendi rate configuration.
+    pub send_rate: SendRate,
 }
 
-#[derive(Component, Deserialize, Serialize)]
-struct Player;
-
-impl GroupReplication for PlayerBundle {
-    fn register(world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule {
-        // Customize serlialization to serialize only `translation`.
-        let transform_info = registry.register_rule_fns(
-            world,
-            RuleFns::new(serialize_translation, deserialize_translation),
-        );
-
-        // Serialize `player` as usual.
-        let player_info = registry.register_rule_fns(world, RuleFns::<Player>::default());
-
-        // We skip `replication` registration since it's a special component.
-        // It's automatically inserted on clients after replication and
-        // deserialization from scenes.
-
-        ReplicationRule::new(vec![transform_info, player_info])
-    }
-}
-
-# fn serialize_translation(_: &SerializeCtx, _: &Transform, _: &mut Vec<u8>) -> Result<()> { unimplemented!() }
-# fn deserialize_translation(_: &mut WriteCtx, _: &mut Bytes) -> Result<Transform> { unimplemented!() }
-```
-**/
-pub trait GroupReplication {
-    /// Creates the associated replication rules and registers its functions in [`ReplicationRegistry`].
-    fn register(world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule;
-}
-
-macro_rules! impl_registrations {
-    ($($type:ident),*) => {
-        impl<$($type: Component<Mutability: MutWrite<$type>> + Serialize + DeserializeOwned),*> GroupReplication for ($($type,)*) {
-            fn register(world: &mut World, registry: &mut ReplicationRegistry) -> ReplicationRule {
-                // TODO: initialize with capacity after stabilization: https://github.com/rust-lang/rust/pull/122808
-                let mut components = Vec::new();
-                $(
-                    let fns_info = registry.register_rule_fns(world, RuleFns::<$type>::default());
-                    components.push(fns_info);
-                )*
-
-                ReplicationRule::new(components)
-            }
+impl ComponentRule {
+    /// Creates a new instance with the default send rate.
+    pub fn new(id: ComponentId, fns_id: FnsId) -> Self {
+        Self {
+            id,
+            fns_id,
+            send_rate: Default::default(),
         }
     }
 }
 
-variadics_please::all_tuples!(impl_registrations, 1, 15, B);
+/// Describes how often component changes should be replicated.
+///
+/// Used inside [`ComponentRule`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SendRate {
+    /// Replicate any change every tick.
+    ///
+    /// If multiple changes occur in the same tick,
+    /// only the latest value will be replicated.
+    #[default]
+    EveryTick,
+
+    /// Replicates only the initial value and removal.
+    ///
+    /// Component mutations won't be sent.
+    Once,
+
+    /// Replicate mutations at a specified interval.
+    ///
+    /// If multiple mutations occur within the interval,
+    /// only the latest value at the time of sending will
+    /// be replicated.
+    ///
+    /// Does not affect initial values or removals.
+    ///
+    /// For example, with a period of 2, any mutation
+    /// will be replicated every second tick.
+    Periodic(u32),
+}
+
+impl SendRate {
+    pub fn send_mutations(self, tick: RepliconTick) -> bool {
+        match self {
+            SendRate::EveryTick => true,
+            SendRate::Once => false,
+            SendRate::Periodic(period) => tick.get() % period == 0,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -535,20 +746,77 @@ mod tests {
     use crate::AppRuleExt;
 
     #[test]
-    fn sorting() {
+    fn registration() {
         let mut app = App::new();
         app.init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<ComponentA>()
-            .replicate::<ComponentB>()
-            .replicate_group::<(ComponentA, ComponentB)>()
-            .replicate_group::<(ComponentB, ComponentC)>()
-            .replicate::<ComponentC>()
-            .replicate::<ComponentD>();
+            .replicate_with((
+                RuleFns::<ComponentA>::default(),
+                RuleFns::<ComponentB>::default(),
+            ))
+            .replicate_once::<ComponentB>()
+            .replicate_with((
+                (RuleFns::<ComponentB>::default(), SendRate::Once),
+                (RuleFns::<ComponentC>::default(), SendRate::Periodic(2)),
+            ))
+            .replicate_periodic::<ComponentC>(1)
+            .replicate_with_priority(
+                4,
+                (
+                    RuleFns::<ComponentC>::default(),
+                    RuleFns::<ComponentD>::default(),
+                ),
+            )
+            .replicate_with((RuleFns::<ComponentD>::default(), SendRate::Once))
+            .replicate_bundle::<(ComponentA, ComponentB)>();
 
-        let replication_rules = app.world().resource::<ReplicationRules>();
-        let priorities: Vec<_> = replication_rules.iter().map(|rule| rule.priority).collect();
-        assert_eq!(priorities, [2, 2, 1, 1, 1, 1]);
+        let a = app.world().component_id::<ComponentA>().unwrap();
+        let b = app.world().component_id::<ComponentB>().unwrap();
+        let c = app.world().component_id::<ComponentC>().unwrap();
+        let d = app.world().component_id::<ComponentD>().unwrap();
+
+        let rules = &**app.world().resource::<ReplicationRules>();
+
+        assert_eq!(rules[0].priority, 4);
+        assert_eq!(rules[0].components[0].id, c);
+        assert_eq!(rules[0].components[0].send_rate, SendRate::EveryTick);
+        assert_eq!(rules[0].components[1].id, d);
+        assert_eq!(rules[0].components[1].send_rate, SendRate::EveryTick);
+
+        assert_eq!(rules[1].priority, 2);
+        assert_eq!(rules[1].components[0].id, a);
+        assert_eq!(rules[1].components[0].send_rate, SendRate::EveryTick);
+        assert_eq!(rules[1].components[1].id, b);
+        assert_eq!(rules[1].components[1].send_rate, SendRate::EveryTick);
+
+        assert_eq!(rules[2].priority, 2);
+        assert_eq!(rules[2].components[0].id, b);
+        assert_eq!(rules[2].components[0].send_rate, SendRate::Once);
+        assert_eq!(rules[2].components[1].id, c);
+        assert_eq!(rules[2].components[1].send_rate, SendRate::Periodic(2));
+
+        assert_eq!(rules[3].priority, 2);
+        assert_eq!(rules[3].components[0].id, a);
+        assert_eq!(rules[3].components[0].send_rate, SendRate::EveryTick);
+        assert_eq!(rules[3].components[1].id, b);
+        assert_eq!(rules[3].components[1].send_rate, SendRate::EveryTick);
+
+        assert_eq!(rules[4].priority, 1);
+        assert_eq!(rules[4].components[0].id, a);
+        assert_eq!(rules[4].components[0].send_rate, SendRate::EveryTick);
+
+        assert_eq!(rules[5].priority, 1);
+        assert_eq!(rules[5].components[0].id, b);
+        assert_eq!(rules[5].components[0].send_rate, SendRate::Once);
+
+        assert_eq!(rules[6].priority, 1);
+        assert_eq!(rules[6].components[0].id, c);
+        assert_eq!(rules[6].components[0].send_rate, SendRate::Periodic(1));
+
+        assert_eq!(rules[7].priority, 1);
+        assert_eq!(rules[7].components[0].id, d);
+        assert_eq!(rules[7].components[0].send_rate, SendRate::Once);
     }
 
     #[derive(Serialize, Deserialize, Component)]

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -83,7 +83,6 @@ pub trait AppRuleExt {
     struct PlayerBundle {
         transform: Transform,
         player: Player,
-        replicated: Replicated,
     }
 
     #[derive(Component, Deserialize, Serialize)]

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -376,11 +376,18 @@ pub struct ReplicationRules(Vec<ReplicationRule>);
 impl ReplicationRules {
     /// Inserts a new rule, maintaining sorting by their priority in descending order.
     fn insert(&mut self, rule: ReplicationRule) {
-        let index = self
-            .binary_search_by_key(&Reverse(rule.priority), |rule| Reverse(rule.priority))
-            .unwrap_or_else(|index| index);
-
-        self.0.insert(index, rule);
+        match self.binary_search_by_key(&Reverse(rule.priority), |rule| Reverse(rule.priority)) {
+            Ok(index) => {
+                // Insert last to preserve entry creation order.
+                let last_priority_index = self
+                    .iter()
+                    .skip(index + 1)
+                    .position(|other| other.priority != rule.priority)
+                    .unwrap_or_default();
+                self.0.insert(index + last_priority_index + 1, rule);
+            }
+            Err(index) => self.0.insert(index, rule),
+        }
     }
 }
 

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -1,10 +1,11 @@
-use core::cmp::Reverse;
+use core::{any, cmp::Reverse};
 
 use bevy::{
     ecs::{archetype::Archetype, component::ComponentId},
     platform::collections::HashSet,
     prelude::*,
 };
+use log::debug;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::replication_registry::{
@@ -435,6 +436,7 @@ impl AppRuleExt for App {
         priority: usize,
         rule: R,
     ) -> &mut Self {
+        debug!("registering rule for '{}'", any::type_name::<R>());
         let rule =
             self.world_mut()
                 .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
@@ -449,6 +451,7 @@ impl AppRuleExt for App {
     }
 
     fn replicate_bundle<B: ReplicationBundle>(&mut self) -> &mut Self {
+        debug!("registering rule for bundle '{}'", any::type_name::<B>());
         let rule =
             self.world_mut()
                 .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -1,7 +1,7 @@
 use core::cmp::Reverse;
 
 use bevy::{
-    ecs::{archetype::Archetype, component::ComponentId, entity::MapEntities},
+    ecs::{archetype::Archetype, component::ComponentId},
     platform::collections::HashSet,
     prelude::*,
 };
@@ -28,14 +28,6 @@ pub trait AppRuleExt {
         C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
     {
         self.replicate_with::<C>(RuleFns::default())
-    }
-
-    #[deprecated(note = "no longer needed, just use `replicate` instead")]
-    fn replicate_mapped<C>(&mut self) -> &mut Self
-    where
-        C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned + MapEntities,
-    {
-        self.replicate::<C>()
     }
 
     /**

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -29,7 +29,7 @@ pub trait AppRuleExt {
         self.replicate_with(RuleFns::<C>::default())
     }
 
-    /// Sames as [`Self::replicate`], but uses [`SendRate::Once`].
+    /// Same as [`Self::replicate`], but uses [`SendRate::Once`].
     fn replicate_once<C>(&mut self) -> &mut Self
     where
         C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
@@ -37,7 +37,7 @@ pub trait AppRuleExt {
         self.replicate_with((RuleFns::<C>::default(), SendRate::Once))
     }
 
-    /// Sames as [`Self::replicate`], but uses [`SendRate::Periodic`] with the given period.
+    /// Sames as [`Self::replicate`], but uses [`SendRate::Periodic`] with the given tick period.
     fn replicate_periodic<C>(&mut self, period: u32) -> &mut Self
     where
         C: Component<Mutability: MutWrite<C>> + Serialize + DeserializeOwned,
@@ -474,7 +474,7 @@ impl AppRuleExt for App {
 pub trait IntoReplicationRule {
     /// Priority when registered with [`AppRuleExt::replicate_with`].
     ///
-    /// Equals to the number of component in a rule.
+    /// Equals the number of components in a rule.
     const DEFAULT_PRIORITY: usize;
 
     /// Turns into a replication rule and registers its functions in [`ReplicationRegistry`].
@@ -686,7 +686,7 @@ pub struct ComponentRule {
     pub id: ComponentId,
     /// Associated serialization and deserialization functions.
     pub fns_id: FnsId,
-    /// Sendi rate configuration.
+    /// Send rate configuration.
     pub send_rate: SendRate,
 }
 

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -729,6 +729,7 @@ pub enum SendRate {
 }
 
 impl SendRate {
+    /// Returns `true` if a mutation for should be replicated on this tick.
     pub fn send_mutations(self, tick: RepliconTick) -> bool {
         match self {
             SendRate::EveryTick => true,

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -8,7 +8,6 @@ use bevy_replicon::{
             replication_registry::{
                 ReplicationRegistry, command_fns,
                 ctx::{DespawnCtx, WriteCtx},
-                rule_fns::RuleFns,
                 test_fns::TestFnsEntityExt,
             },
         },

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -6,7 +6,7 @@ use bevy_replicon::{
     shared::{
         replication::{
             deferred_entity::DeferredEntity,
-            replication_registry::{command_fns, ctx::WriteCtx, rule_fns::RuleFns},
+            replication_registry::{command_fns, ctx::WriteCtx},
         },
         server_entity_map::ServerEntityMap,
     },
@@ -337,7 +337,7 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_group::<(GroupComponentA, GroupComponentB)>();
+        .replicate_bundle::<(GroupComponentA, GroupComponentB)>();
     }
 
     server_app.connect_client(&mut client_app);

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -5,7 +5,7 @@ use bevy_replicon::{
     server::server_tick::ServerTick,
     shared::replication::{
         deferred_entity::DeferredEntity,
-        replication_registry::{command_fns, ctx::WriteCtx, rule_fns::RuleFns},
+        replication_registry::{command_fns, ctx::WriteCtx},
     },
     test_app::{ServerTestAppExt, TestClientEntity},
 };
@@ -163,7 +163,7 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_group::<(GroupComponentA, GroupComponentB)>();
+        .replicate_bundle::<(GroupComponentA, GroupComponentB)>();
     }
 
     server_app.connect_client(&mut client_app);


### PR DESCRIPTION
Implements #331. Replication rules could be split it into 2 types:

1. Static rules. These rules are very cheap and related to components. For example, you might want to replicate only the initial position for your moving platforms. It would be very annoying to configure it on each spawn.

2. Dynamic rules. Reduce or pause updates for distant entities. Not cheap. In Unreal Engine, this is configured by the prioritization feature. Won't be included in this PR. We have a different issue for it: #184

To provide static rules, I introduced `SendRate`. It's a per-component property inside `ReplicationRule`. It can be set to `SendRate::EveryTick` (the current and default behavior), `SendRate::Once`, or `SendRate::Periodic(u32)`. When we collect mutations, we simply check this field to determine whether mutations should be sent in the current tick. It affects only mutations.

While it's a simple change, our rule creation API was not flexible enough to conveniently set the rate, so I had to rework it.

For single components, I just added `replicate_once` and `replicate_periodic`. But `replicate_with` now accepts the newly added `IntoReplicationRule`. It's implemented for tuples of another trait – `IntoComponentRule` – which is implemented for `RuleFns` and `(RuleFns, SendRate)`. This allows the following:
```rust
app.replicate_with(RuleFns::<Health>::default()) // Just like before, functions can be customized.
    .replicate_with((
        // Group of components:
        RuleFns::<Player>::default(),
        RuleFns::<Position>::default(),
    ))
    .replicate_with((
        RuleFns::<MovingPlatform>::default(),
        // Send rate can be optionally set like this:
        (RuleFns::<Position>::default(), SendRate::Once),
    ))
```

This not only allows us to conveniently set `SendRate` per-component, but also define customizable rules for groups of components without defining a trait.

I also renamed `GroupReplication` and `AppRuleExt::replicate_group` into `BundleReplication` and `AppRuleExt::replicate_bundle` respectively. It's still useful for conveniently defining a rule for tuple of components with default parameters. Users can also define the trait for its own bundles, although it's a rare pattern since required components introduction.

I tried to split changes across multiple commits to simplify the review a bit. But most changes are in the last one.