### PR TITLE
Rename `despawn_recursive` into `despawn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `replication_registry::despawn_recursive` into `replication_registry::despawn`.
+
 ## [0.33.0] - 2025-04-27
 
 ### Changed

--- a/src/shared/replication/replication_registry.rs
+++ b/src/shared/replication/replication_registry.rs
@@ -18,7 +18,7 @@ use rule_fns::{RuleFns, UntypedRuleFns};
 pub struct ReplicationRegistry {
     /// Custom function to handle entity despawning.
     ///
-    /// By default uses [`despawn_recursive`].
+    /// By default uses [`despawn`].
     /// Useful if you need to intercept despawns and handle them in a special way.
     pub despawn: DespawnFn,
 
@@ -153,7 +153,7 @@ impl ReplicationRegistry {
 impl Default for ReplicationRegistry {
     fn default() -> Self {
         Self {
-            despawn: despawn_recursive,
+            despawn,
             components: Default::default(),
             rules: Default::default(),
             marker_slots: 0,
@@ -171,7 +171,7 @@ pub struct FnsId(usize);
 pub type DespawnFn = fn(&DespawnCtx, EntityWorldMut);
 
 /// Default entity despawn function.
-pub fn despawn_recursive(_ctx: &DespawnCtx, entity: EntityWorldMut) {
+pub fn despawn(_ctx: &DespawnCtx, entity: EntityWorldMut) {
     entity.despawn();
 }
 


### PR DESCRIPTION
Bevy deprecated `despawn_recursive` and this function calls `despawn`, but has the old name.