### PR TITLE
Buffered insertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `ServerEntityMap::get_by_*` and `ServerEntityMap::remove_by_*` with an entry-based API. Use `ServerEntityMap::server_entry` or `ServerEntityMap::client_entry` instead.
+- Print error instead of panic on mapping overwrite in `ServerEntityMap`.
+
 ## [0.33.0] - 2025-04-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Component removals and insertions for an entity are now buffered and applied as bundles to avoid triggering observers without all components being inserted or removed. This also significantly improves performance by avoiding extra archetype moves and lookups.
+- The `Replicated` component is no longer automatically inserted into non-replicated entities spawned from replicated components.
 - Replace `ServerEntityMap::get_by_*` and `ServerEntityMap::remove_by_*` with an entry-based API. Use `ServerEntityMap::server_entry` or `ServerEntityMap::client_entry` instead.
 - Print error instead of panic on mapping overwrite in `ServerEntityMap`.
+
+### Removed
+
+- `WriteCtx::commands`. You can now insert and remove components directly through `DeferredEntity`.
 
 ## [0.33.0] - 2025-04-27
 

--- a/src/shared/replication/command_markers.rs
+++ b/src/shared/replication/command_markers.rs
@@ -84,17 +84,15 @@ pub trait AppMarkerExt {
         if let Some(mut history) = entity.get_mut::<History<C>>() {
             history.insert(ctx.message_tick, component);
         } else {
-            ctx.commands
-                .entity(entity.id())
-                .insert(History([(ctx.message_tick, component)].into()));
+            entity.insert(History([(ctx.message_tick, component)].into()));
         }
 
         Ok(())
     }
 
     /// Removes component `C` and its history.
-    fn remove_history<C: Component>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
-        ctx.commands.entity(entity.id()).remove::<History<C>>().remove::<C>();
+    fn remove_history<C: Component>(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+        entity.remove::<History<C>>().remove::<C>();
     }
 
     /// If this marker is present on an entity, registered components will be stored in [`History<T>`].

--- a/src/shared/replication/deferred_entity.rs
+++ b/src/shared/replication/deferred_entity.rs
@@ -1,33 +1,202 @@
-use bevy::{ecs::world::CommandQueue, prelude::*};
+use core::{alloc::Layout, ptr::NonNull};
 
-/// An entity reference that disallows structural ECS changes.
+use bevy::{
+    ecs::component::{ComponentId, Mutable},
+    prelude::*,
+    ptr::{Aligned, PtrMut},
+};
+
+/// Like [`EntityWorldMut`], but buffers all structural changes.
 ///
-/// Similar to [`EntityMut`], but additionally provides a read-only access to the world.
-#[derive(Deref, DerefMut)]
+/// Components are deserialized one by one, and to avoid causing archetype moves
+/// or triggering observers without all components being inserted, we buffer all
+/// insertions and removals and apply them as a single removal bundle and a single
+/// insertion bundle.
+#[derive(Deref)]
 pub struct DeferredEntity<'w> {
     #[deref]
-    entity: EntityMut<'w>,
-    world: &'w World,
+    entity: EntityWorldMut<'w>,
+    changes: &'w mut DeferredChanges,
 }
 
 impl<'w> DeferredEntity<'w> {
-    pub(crate) fn new(world: &'w mut World, entity: Entity) -> Self {
-        let world_cell = world.as_unsafe_world_cell();
-        // SAFETY: access split, `EntityMut` cannot make structural ECS changes,
-        // and the world cannot be accessed simultaneously with the entity.
+    pub(crate) fn new(entity: EntityWorldMut<'w>, changes: &'w mut DeferredChanges) -> Self {
+        Self { entity, changes }
+    }
+
+    /// Like [`EntityWorldMut::insert`], but accepts only a single component insertion and buffers it.
+    ///
+    /// Calling this function multiple times for different components is equivalent to inserting a bundle with them.
+    pub fn insert<C: Component>(&mut self, component: C) -> &mut Self {
+        let component_id = self.register_component::<C>();
+        // SAFETY: component ID belongs to this type.
+        unsafe { self.changes.insertions.insert(component, component_id) };
+        self
+    }
+
+    /// Like [`EntityWorldMut::remove`], but accepts only a single component removal and buffers it.
+    ///
+    /// Calling this function multiple times for different components is equivalent to removing a bundle with them.
+    pub fn remove<C: Component>(&mut self) -> &mut Self {
+        let component_id = self.register_component::<C>();
+        self.changes.removals.push(component_id);
+        self
+    }
+
+    /// Gets mutable access to the component of type `C` for the current entity.
+    ///
+    /// Returns `None` if the entity does not have a component of type `C`.
+    #[inline]
+    pub fn get_mut<C: Component<Mutability = Mutable>>(&mut self) -> Option<Mut<'_, C>> {
+        self.entity.get_mut()
+    }
+
+    fn register_component<C: Component>(&mut self) -> ComponentId {
+        // SAFETY: no location update is needed because we only register the component ID.
+        unsafe { self.entity.world_mut().register_component::<C>() }
+    }
+
+    /// Applies all buffered changes.
+    pub(crate) fn flush(&mut self) {
+        self.changes.apply(&mut self.entity);
+    }
+}
+
+/// Buffered changes for [`DeferredEntity`].
+#[derive(Default)]
+pub(crate) struct DeferredChanges {
+    insertions: DeferredInsertions,
+    removals: Vec<ComponentId>,
+}
+
+impl DeferredChanges {
+    fn apply(&mut self, entity: &mut EntityWorldMut) {
+        if !self.removals.is_empty() {
+            entity.remove_by_ids(&self.removals);
+            self.removals.clear();
+        }
+
+        if !self.insertions.is_empty() {
+            self.insertions.apply(entity);
+            self.insertions.clear();
+        }
+    }
+}
+
+/// Buffered insertions stored in type-erased way.
+#[derive(Default)]
+pub(crate) struct DeferredInsertions {
+    ids: Vec<ComponentId>,
+    offsets: Vec<usize>,
+    data: Vec<u8>,
+}
+
+impl DeferredInsertions {
+    /// Moves component data into a dynamically allocated buffer.
+    ///
+    /// # Safety
+    ///
+    /// Component ID should correspond to the passed type, otherwise [`Self::apply`] won't
+    /// write the data correctly.
+    unsafe fn insert<C: Component>(&mut self, component: C, component_id: ComponentId) {
+        let layout = Layout::new::<C>();
+
+        // If items would otherwise not be aligned, add alignment.
+        let align = layout.align();
+        let extra_offset = if self.data.len() % align != 0 {
+            align - (self.data.len() % align)
+        } else {
+            0
+        };
+
+        let grow = layout.size() + extra_offset;
+        let offset = self.data.len() + extra_offset;
+
+        self.ids.push(component_id);
+        self.offsets.push(offset);
+        self.data.resize(self.data.len() + grow, 0);
+
+        // SAFETY: pointer references a properly allocated memory.
         unsafe {
-            let entity: EntityMut = world_cell.world_mut().entity_mut(entity).into();
-            let world = world_cell.world();
-            Self { entity, world }
+            // Using `PtrMut` for debug assertions.
+            let ptr = PtrMut::<Aligned>::new(NonNull::new_unchecked(self.data.as_mut_ptr()));
+            *ptr.byte_add(offset).deref_mut() = component;
         }
     }
 
-    pub(crate) fn commands<'s>(&self, queue: &'s mut CommandQueue) -> Commands<'w, 's> {
-        Commands::new_from_entities(queue, self.world.entities())
+    fn apply(&mut self, entity: &mut EntityWorldMut) {
+        // SAFETY: iterator produces valid pointers for each component ID.
+        unsafe {
+            let iter = self.offsets.iter().map(|&offset| {
+                let ptr = PtrMut::new(NonNull::new_unchecked(self.data.as_mut_ptr()));
+                ptr.byte_add(offset).promote()
+            });
+            entity.insert_by_ids(&self.ids, iter);
+        }
     }
 
-    /// Gets read-only access to the world that the current entity belongs to.
-    pub fn world(&self) -> &World {
-        self.world
+    fn is_empty(&self) -> bool {
+        self.ids.is_empty()
     }
+
+    fn clear(&mut self) {
+        self.ids.clear();
+        self.offsets.clear();
+        self.data.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffering() {
+        let mut world = World::new();
+        let before_archetypes = world.archetypes().len();
+        let mut buffer = DeferredChanges::default();
+        let mut entity = DeferredEntity::new(world.spawn_empty(), &mut buffer);
+
+        entity
+            .insert(Unit)
+            .insert(Trivial(1))
+            .insert(Droppable(vec![2, 3]).clone());
+
+        entity.flush();
+        let after_archetypes = entity.world().archetypes().len();
+
+        assert!(entity.get::<Unit>().is_some());
+        assert_eq!(**entity.get::<Trivial>().unwrap(), 1);
+        assert_eq!(**entity.get::<Droppable>().unwrap(), [2, 3]);
+        assert_eq!(
+            after_archetypes - before_archetypes,
+            1,
+            "insertions should batch into one archetype move"
+        );
+
+        entity
+            .remove::<Unit>()
+            .remove::<Trivial>()
+            .remove::<Droppable>();
+
+        entity.flush();
+
+        assert!(!entity.contains::<Unit>());
+        assert!(!entity.contains::<Trivial>());
+        assert!(!entity.contains::<Droppable>());
+        assert_eq!(
+            entity.world().archetypes().len(),
+            after_archetypes,
+            "removals shouldn't create intermediate archetypes"
+        );
+    }
+
+    #[derive(Component)]
+    struct Unit;
+
+    #[derive(Component, Clone, Copy, Deref, Debug)]
+    struct Trivial(usize);
+
+    #[derive(Component, Clone, Deref, Debug)]
+    struct Droppable(Vec<u8>);
 }

--- a/src/shared/replication/deferred_entity.rs
+++ b/src/shared/replication/deferred_entity.rs
@@ -21,6 +21,7 @@ pub struct DeferredEntity<'w> {
 
 impl<'w> DeferredEntity<'w> {
     pub(crate) fn new(entity: EntityWorldMut<'w>, changes: &'w mut DeferredChanges) -> Self {
+        changes.clear();
         Self { entity, changes }
     }
 
@@ -65,21 +66,26 @@ impl<'w> DeferredEntity<'w> {
 /// Buffered changes for [`DeferredEntity`].
 #[derive(Default)]
 pub(crate) struct DeferredChanges {
-    insertions: DeferredInsertions,
     removals: Vec<ComponentId>,
+    insertions: DeferredInsertions,
 }
 
 impl DeferredChanges {
     fn apply(&mut self, entity: &mut EntityWorldMut) {
         if !self.removals.is_empty() {
             entity.remove_by_ids(&self.removals);
-            self.removals.clear();
         }
 
         if !self.insertions.is_empty() {
             self.insertions.apply(entity);
-            self.insertions.clear();
         }
+
+        self.clear();
+    }
+
+    fn clear(&mut self) {
+        self.removals.clear();
+        self.insertions.clear();
     }
 }
 

--- a/src/shared/replication/replication_registry/command_fns.rs
+++ b/src/shared/replication/replication_registry/command_fns.rs
@@ -112,7 +112,7 @@ pub fn default_write<C: Component<Mutability = Mutable>>(
         rule_fns.deserialize_in_place(ctx, &mut *component, message)?;
     } else {
         let component: C = rule_fns.deserialize(ctx, message)?;
-        ctx.commands.entity(entity.id()).insert(component);
+        entity.insert(component);
     }
 
     Ok(())
@@ -130,11 +130,11 @@ pub fn default_insert_write<C: Component>(
     message: &mut Bytes,
 ) -> Result<()> {
     let component: C = rule_fns.deserialize(ctx, message)?;
-    ctx.commands.entity(entity.id()).insert(component);
+    entity.insert(component);
     Ok(())
 }
 
 /// Default component removal function.
-pub fn default_remove<C: Component>(ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
-    ctx.commands.entity(entity.id()).remove::<C>();
+pub fn default_remove<C: Component>(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+    entity.remove::<C>();
 }

--- a/src/shared/replication/replication_registry/ctx.rs
+++ b/src/shared/replication/replication_registry/ctx.rs
@@ -46,7 +46,8 @@ impl EntityMapper for WriteCtx<'_, '_, '_> {
         }
 
         self.entity_map
-            .get_by_server_or_insert(source, || self.commands.spawn(Replicated).id())
+            .server_entry(source)
+            .or_insert_with(|| self.commands.spawn(Replicated).id())
     }
 
     fn set_mapped(&mut self, _source: Entity, _target: Entity) {

--- a/src/shared/replication/replication_registry/ctx.rs
+++ b/src/shared/replication/replication_registry/ctx.rs
@@ -1,8 +1,10 @@
-use bevy::{ecs::component::ComponentId, prelude::*, reflect::TypeRegistry};
-
-use crate::shared::{
-    replication::Replicated, replicon_tick::RepliconTick, server_entity_map::ServerEntityMap,
+use bevy::{
+    ecs::{component::ComponentId, entity::Entities},
+    prelude::*,
+    reflect::TypeRegistry,
 };
+
+use crate::shared::{replicon_tick::RepliconTick, server_entity_map::ServerEntityMap};
 
 /// Replication context for serialization function.
 #[non_exhaustive]
@@ -19,10 +21,7 @@ pub struct SerializeCtx<'a> {
 
 /// Replication context for writing and deserialization.
 #[non_exhaustive]
-pub struct WriteCtx<'a, 'w, 's> {
-    /// A queue to perform structural changes to the [`World`].
-    pub commands: &'a mut Commands<'w, 's>,
-
+pub struct WriteCtx<'a> {
     /// Maps server entities to client entities and vice versa.
     pub entity_map: &'a mut ServerEntityMap,
 
@@ -35,19 +34,22 @@ pub struct WriteCtx<'a, 'w, 's> {
     /// Tick for the currently processing message.
     pub message_tick: RepliconTick,
 
+    /// World's entities to reserve IDs on new entities inside components.
+    pub(crate) entities: &'a Entities,
+
     /// Disables mapping logic to avoid spawning entities for consume functions.
     pub(crate) ignore_mapping: bool,
 }
 
-impl EntityMapper for WriteCtx<'_, '_, '_> {
-    fn get_mapped(&mut self, source: Entity) -> Entity {
+impl EntityMapper for WriteCtx<'_> {
+    fn get_mapped(&mut self, server_entity: Entity) -> Entity {
         if self.ignore_mapping {
-            return source;
+            return server_entity;
         }
 
         self.entity_map
-            .server_entry(source)
-            .or_insert_with(|| self.commands.spawn(Replicated).id())
+            .server_entry(server_entity)
+            .or_insert_with(|| self.entities.reserve_entity())
     }
 
     fn set_mapped(&mut self, _source: Entity, _target: Entity) {
@@ -57,10 +59,7 @@ impl EntityMapper for WriteCtx<'_, '_, '_> {
 
 /// Replication context for removal.
 #[non_exhaustive]
-pub struct RemoveCtx<'a, 'w, 's> {
-    /// A queue to perform structural changes to the [`World`].
-    pub commands: &'a mut Commands<'w, 's>,
-
+pub struct RemoveCtx {
     /// ID of the removing component.
     pub component_id: ComponentId,
 

--- a/src/shared/server_entity_map.rs
+++ b/src/shared/server_entity_map.rs
@@ -1,12 +1,14 @@
 use bevy::{
-    ecs::entity::hash_map::EntityHashMap, platform::collections::hash_map::Entry, prelude::*,
+    ecs::entity::{EntityHash, hash_map::EntityHashMap},
+    platform::collections::hash_map::{self, Entry},
+    prelude::*,
 };
-use log::warn;
+use log::{error, warn};
 
 /// Maps server entities to client entities and vice versa.
 ///
 /// If [`ClientSet::Reset`](crate::client::ClientSet) is disabled, then this needs to be cleaned up manually
-/// via [`Self::remove_by_client`] or [`Self::clear`].
+/// by removing entries via [`EntityEntry::remove`] or [`Self::clear`].
 ///
 /// Inserted as resource by [`ClientPlugin`](crate::client::ClientPlugin).
 #[derive(Default, Resource)]
@@ -17,90 +19,148 @@ pub struct ServerEntityMap {
 
 impl ServerEntityMap {
     /// Inserts a server-client pair into the map.
-    ///
-    /// # Panics
-    ///
-    /// Panics if this mapping is already present.
     #[inline]
     pub fn insert(&mut self, server_entity: Entity, client_entity: Entity) {
-        if let Some(existing_entity) = self.server_to_client.insert(server_entity, client_entity) {
-            if client_entity != existing_entity {
-                panic!(
-                    "mapping {server_entity:?} to {client_entity:?}, but it's already mapped to {existing_entity:?}"
-                );
-            } else {
-                warn!("received duplicate mapping from {server_entity:?} to {client_entity:?}");
-            }
-        }
-        self.client_to_server.insert(client_entity, server_entity);
+        self.server_entry(server_entity)
+            .or_insert_with(|| client_entity);
     }
 
-    /// Converts server entity into client entity or inserts a new mapping with `f`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy::prelude::*;
-    /// # use bevy_replicon::{shared::server_entity_map::ServerEntityMap, prelude::*};
-    /// # let mut entity_map = ServerEntityMap::default();
-    /// # let mut world = World::default();
-    /// # let mut commands = world.commands();
-    /// # let server_entity = Entity::PLACEHOLDER;
-    /// entity_map.get_by_server_or_insert(server_entity, || commands.spawn(Replicated).id());
-    /// # world.flush();
-    /// ```
-    pub fn get_by_server_or_insert(
-        &mut self,
-        server_entity: Entity,
-        f: impl FnOnce() -> Entity,
-    ) -> Entity {
-        match self.server_to_client.entry(server_entity) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let client_entity = (f)();
-                entry.insert(client_entity);
-                self.client_to_server.insert(client_entity, server_entity);
-                client_entity
-            }
-        }
-    }
-
-    pub(crate) fn get_by_server(&mut self, server_entity: Entity) -> Option<Entity> {
-        self.server_to_client.get(&server_entity).copied()
-    }
-
-    pub(crate) fn remove_by_server(&mut self, server_entity: Entity) -> Option<Entity> {
-        let client_entity = self.server_to_client.remove(&server_entity);
-        if let Some(client_entity) = client_entity {
-            self.client_to_server.remove(&client_entity);
-        }
-        client_entity
-    }
-
-    /// Removes an entry using the client entity.
-    ///
-    /// Useful for manual cleanup, e.g. after reconnects.
-    pub fn remove_by_client(&mut self, client_entity: Entity) -> Option<Entity> {
-        let server_entity = self.client_to_server.remove(&client_entity);
-        if let Some(server_entity) = server_entity {
-            self.server_to_client.remove(&server_entity);
-        }
-        server_entity
-    }
-
+    /// Returns server to client mappings.
     #[inline]
     pub fn to_client(&self) -> &EntityHashMap<Entity> {
         &self.server_to_client
     }
 
+    /// Returns client to server mappings.
     #[inline]
     pub fn to_server(&self) -> &EntityHashMap<Entity> {
         &self.client_to_server
+    }
+
+    /// Gets a client entry using the server entity.
+    pub fn client_entry(&mut self, client_entity: Entity) -> EntityEntry {
+        EntityEntry::new(
+            self.client_to_server.entry(client_entity),
+            &mut self.server_to_client,
+        )
+    }
+
+    /// Gets a server entry using the client entity.
+    pub fn server_entry(&mut self, server_entity: Entity) -> EntityEntry {
+        EntityEntry::new(
+            self.server_to_client.entry(server_entity),
+            &mut self.client_to_server,
+        )
     }
 
     /// Clears the map.
     pub fn clear(&mut self) {
         self.client_to_server.clear();
         self.server_to_client.clear();
+    }
+}
+
+/// A view into an entry in [`ServerEntityMap`].
+#[must_use]
+pub enum EntityEntry<'a> {
+    Occupied(OccupiedEntityEntry<'a>),
+    Vacant(VacantEntityEntry<'a>),
+}
+
+impl<'a> EntityEntry<'a> {
+    fn new(
+        main_entry: Entry<'a, Entity, Entity, EntityHash>,
+        reverse_map: &'a mut EntityHashMap<Entity>,
+    ) -> Self {
+        match main_entry {
+            Entry::Occupied(main_entry) => Self::Occupied(OccupiedEntityEntry {
+                main_entry,
+                reverse_map,
+            }),
+            Entry::Vacant(main_entry) => Self::Vacant(VacantEntityEntry {
+                main_entry,
+                reverse_map,
+            }),
+        }
+    }
+
+    /// Returns the mappend entity for the entry.
+    pub fn get(&self) -> Option<Entity> {
+        match self {
+            EntityEntry::Occupied(entry) => Some(entry.get()),
+            EntityEntry::Vacant(_) => None,
+        }
+    }
+
+    /// Removes the entry and returns the mapped entity.
+    pub fn remove(self) -> Option<Entity> {
+        match self {
+            EntityEntry::Occupied(entry) => Some(entry.remove()),
+            EntityEntry::Vacant(_) => None,
+        }
+    }
+
+    /// Inserts the mapped entity from the function and returns it.
+    pub fn or_insert_with<F: FnOnce() -> Entity>(self, f: F) -> Entity {
+        match self {
+            EntityEntry::Occupied(entry) => entry.get(),
+            EntityEntry::Vacant(entry) => entry.insert(f()),
+        }
+    }
+}
+
+/// A view into an occupied entry in [`ServerEntityMap`].
+///
+/// It's part of [`EntityEntry`] enum.
+pub struct OccupiedEntityEntry<'a> {
+    main_entry: hash_map::OccupiedEntry<'a, Entity, Entity, EntityHash>,
+    reverse_map: &'a mut EntityHashMap<Entity>,
+}
+
+impl OccupiedEntityEntry<'_> {
+    /// Returns the mappend entity for the entry.
+    pub fn get(&self) -> Entity {
+        *self.main_entry.get()
+    }
+
+    /// Sets the mapped entity for the entry and returns the old mapping.
+    pub fn insert(&mut self, value: Entity) -> Entity {
+        let key = *self.main_entry.key();
+        let old_value = self.main_entry.insert(value);
+        if value != old_value {
+            error!("mapping {key:?} to {value:?}, but it's already mapped to {old_value:?}");
+        } else {
+            warn!("ignoring duplicate mapping from {key:?} to {value:?}");
+            return value;
+        }
+
+        self.reverse_map.remove(&old_value);
+        self.reverse_map.insert(value, *self.main_entry.key());
+        old_value
+    }
+
+    /// Removes the entry and returns the mapped entity.
+    pub fn remove(self) -> Entity {
+        let (_, value) = self.main_entry.remove_entry();
+        self.reverse_map.remove(&value);
+        value
+    }
+}
+
+/// A view into a vacant entry in [`ServerEntityMap`].
+///
+/// It's part of [`EntityEntry`] enum.
+pub struct VacantEntityEntry<'a> {
+    main_entry: hash_map::VacantEntry<'a, Entity, Entity, EntityHash>,
+    reverse_map: &'a mut EntityHashMap<Entity>,
+}
+
+impl VacantEntityEntry<'_> {
+    /// Sets the mapped entity for the entry and returns it.
+    pub fn insert(self, value: Entity) -> Entity {
+        let key = *self.main_entry.key();
+        self.main_entry.insert(value);
+        self.reverse_map.insert(value, key);
+        value
     }
 }

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -367,7 +367,7 @@ fn replace(
     message: &mut Bytes,
 ) -> Result<()> {
     rule_fns.deserialize(ctx, message)?;
-    ctx.commands.entity(entity.id()).insert(ReplacedComponent);
+    entity.insert(ReplacedComponent);
 
     Ok(())
 }

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -427,6 +427,8 @@ fn marker_with_history_consume() {
 
     server_app.connect_client(&mut client_app);
 
+    let entities_before = client_app.world().entities().len();
+
     let server_map_entity = server_app.world_mut().spawn_empty().id();
     let server_entity = server_app
         .world_mut()
@@ -481,9 +483,8 @@ fn marker_with_history_consume() {
         "client should consume older mutations for other components with marker that requested history"
     );
 
-    let mut replicated = client_app.world_mut().query::<&Replicated>();
     assert_eq!(
-        replicated.iter(client_app.world()).len(),
+        client_app.world().entities().len() - entities_before,
         3,
         "client should have 2 initial entities and 1 from mutate message"
     );
@@ -827,6 +828,8 @@ fn old_ignored() {
 
     server_app.connect_client(&mut client_app);
 
+    let entities_before = client_app.world().entities().len();
+
     let server_map_entity = server_app.world_mut().spawn_empty().id();
     let server_entity = server_app
         .world_mut()
@@ -867,9 +870,8 @@ fn old_ignored() {
         "client should ignore older mutation"
     );
 
-    let mut replicated = client_app.world_mut().query::<&Replicated>();
     assert_eq!(
-        replicated.iter(client_app.world()).len(),
+        client_app.world().entities().len() - entities_before,
         3,
         "client should have 2 initial entities and 1 from mutation"
     );
@@ -1100,9 +1102,8 @@ fn replace(
     message: &mut Bytes,
 ) -> Result<()> {
     let component = rule_fns.deserialize(ctx, message)?;
-    ctx.commands
-        .entity(entity.id())
-        .insert(ReplacedComponent(component.0));
+
+    entity.insert(ReplacedComponent(component.0));
 
     Ok(())
 }
@@ -1118,9 +1119,7 @@ fn write_history(
     if let Some(mut history) = entity.get_mut::<BoolHistory>() {
         history.push(component.0);
     } else {
-        ctx.commands
-            .entity(entity.id())
-            .insert(BoolHistory(vec![component.0]));
+        entity.insert(BoolHistory(vec![component.0]));
     }
 
     Ok(())


### PR DESCRIPTION
Closes #332.

Originally, we used commands to insert or remove components during replication. This wasn't optimal because Bevy doesn't batch commands. However, since Bevy was considering adding support for batching, we decided to wait.

With the introduction of triggers, this became a real issue: triggers would fire after each insertion, and inside the observer, the user might not be able to access all components (depending on the insertion order).

This change replaces commands with insertion and removal methods on `DeferredEntity` that buffer all changes and apply them later using `EntityWorldMut::insert_by_ids` and `EntityWorldMut::remove_by_ids`. They are flushed after processing each entity. This not only makes triggers behave as expected, but also significantly improves performance by avoiding extra archetype moves and lookups.

I also slightly changed the behavior of the `Replicated` component to simplify the implementation and unlock additional performance. `Replicated` is no longer automatically inserted into non-replicated entities spawned from replicated components. This change is consistent with server behavior, where such entities also do not have the `Replicated` component.

I split the PR into 2 commits to simplify the review process.

<details>
<summary>Benchmarks</summary>

```
usize_component/changes_receive
                        time:   [158.41 µs 158.53 µs 158.68 µs]
                        change: [-32.571% -32.120% -31.688%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
usize_component/mutations_receive
                        time:   [67.645 µs 67.880 µs 68.162 µs]
                        change: [-6.3463% -5.3715% -4.1207%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) high mild
  5 (5.00%) high severe

string_component/changes_receive
                        time:   [204.32 µs 204.83 µs 205.49 µs]
                        change: [-32.165% -31.667% -31.231%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe
string_component/mutations_receive
                        time:   [96.454 µs 96.725 µs 97.016 µs]
                        change: [-7.0766% -6.6830% -6.3466%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe

struct_component/changes_receive
                        time:   [207.70 µs 207.84 µs 207.99 µs]
                        change: [-35.625% -34.687% -33.795%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
struct_component/mutations_receive
                        time:   [114.11 µs 114.56 µs 114.99 µs]
                        change: [-1.8007% -0.6853% +0.3788%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) low severe
  3 (3.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
  ```
  
  </details>