### PR TITLE
Remove uses of the word "Dummy"

### DIFF
--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -89,7 +89,7 @@ fn server_event() {
             }),
             RepliconExampleBackendPlugins,
         ))
-        .add_server_event::<DummyEvent>(Channel::Ordered)
+        .add_server_event::<TestEvent>(Channel::Ordered)
         .finish();
     }
 
@@ -97,14 +97,14 @@ fn server_event() {
 
     server_app.world_mut().send_event(ToClients {
         mode: SendMode::Broadcast,
-        event: DummyEvent,
+        event: TestEvent,
     });
 
     server_app.update();
     client_app.update();
 
-    let dummy_events = client_app.world().resource::<Events<DummyEvent>>();
-    assert_eq!(dummy_events.len(), 1);
+    let events = client_app.world().resource::<Events<TestEvent>>();
+    assert_eq!(events.len(), 1);
 }
 
 #[test]
@@ -120,20 +120,20 @@ fn client_event() {
             }),
             RepliconExampleBackendPlugins,
         ))
-        .add_client_event::<DummyEvent>(Channel::Ordered)
+        .add_client_event::<TestEvent>(Channel::Ordered)
         .finish();
     }
 
     setup(&mut server_app, &mut client_app).unwrap();
 
-    client_app.world_mut().send_event(DummyEvent);
+    client_app.world_mut().send_event(TestEvent);
 
     client_app.update();
     server_app.update();
 
     let client_events = server_app
         .world()
-        .resource::<Events<FromClient<DummyEvent>>>();
+        .resource::<Events<FromClient<TestEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
 
@@ -152,4 +152,4 @@ fn setup(server_app: &mut App, client_app: &mut App) -> io::Result<()> {
 }
 
 #[derive(Deserialize, Event, Serialize)]
-struct DummyEvent;
+struct TestEvent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,10 +114,10 @@ Use [`AppRuleExt::replicate`] to create a replication rule for a single componen
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(RepliconPlugins);
-app.replicate::<DummyComponent>();
+app.replicate::<ExampleComponent>();
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct ExampleComponent;
 ```
 
 If your component contains an entity, it cannot be deserialized as is
@@ -251,7 +251,7 @@ contains sender ID and the sent event.
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(RepliconPlugins);
-app.add_client_event::<DummyEvent>(Channel::Ordered)
+app.add_client_event::<ExampleEvent>(Channel::Ordered)
     .add_systems(
         PreUpdate,
         receive_events
@@ -263,18 +263,18 @@ app.add_client_event::<DummyEvent>(Channel::Ordered)
         send_events.before(ClientSet::Send).run_if(client_connected),
     );
 
-fn send_events(mut dummy_events: EventWriter<DummyEvent>) {
-    dummy_events.send_default();
+fn send_events(mut events: EventWriter<ExampleEvent>) {
+    events.send_default();
 }
 
-fn receive_events(mut dummy_events: EventReader<FromClient<DummyEvent>>) {
-    for FromClient { client_entity, event } in dummy_events.read() {
+fn receive_events(mut events: EventReader<FromClient<ExampleEvent>>) {
+    for FromClient { client_entity, event } in events.read() {
         info!("received event `{event:?}` from client `{client_entity}`");
     }
 }
 
 #[derive(Debug, Default, Deserialize, Event, Serialize)]
-struct DummyEvent;
+struct ExampleEvent;
 ```
 
 If an event contains an entity, implement
@@ -295,19 +295,19 @@ using [`ClientTriggerAppExt::add_client_trigger`], and then use [`ClientTriggerE
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(RepliconPlugins);
-app.add_client_trigger::<DummyEvent>(Channel::Ordered)
+app.add_client_trigger::<ExampleEvent>(Channel::Ordered)
     .add_observer(receive_events)
     .add_systems(Update, send_events.run_if(client_connected));
 
 fn send_events(mut commands: Commands) {
-    commands.client_trigger(DummyEvent);
+    commands.client_trigger(ExampleEvent);
 }
 
-fn receive_events(trigger: Trigger<FromClient<DummyEvent>>) {
+fn receive_events(trigger: Trigger<FromClient<ExampleEvent>>) {
     info!("received event `{:?}` from client `{}`", **trigger, trigger.client_entity);
 }
 # #[derive(Event, Debug, Deserialize, Serialize)]
-# struct DummyEvent;
+# struct ExampleEvent;
 ```
 
 Trigger targets are also supported via [`ClientTriggerExt::client_trigger_targets`], no change
@@ -329,7 +329,7 @@ and the event itself.
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(RepliconPlugins);
-app.add_server_event::<DummyEvent>(Channel::Ordered)
+app.add_server_event::<ExampleEvent>(Channel::Ordered)
     .add_systems(
         PreUpdate,
         receive_events
@@ -341,21 +341,21 @@ app.add_server_event::<DummyEvent>(Channel::Ordered)
         send_events.before(ServerSet::Send).run_if(server_running),
     );
 
-fn send_events(mut dummy_events: EventWriter<ToClients<DummyEvent>>) {
-    dummy_events.write(ToClients {
+fn send_events(mut events: EventWriter<ToClients<ExampleEvent>>) {
+    events.write(ToClients {
         mode: SendMode::Broadcast,
-        event: DummyEvent,
+        event: ExampleEvent,
     });
 }
 
-fn receive_events(mut dummy_events: EventReader<DummyEvent>) {
-    for event in dummy_events.read() {
+fn receive_events(mut events: EventReader<ExampleEvent>) {
+    for event in events.read() {
         info!("received event {event:?} from server");
     }
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Event, Serialize)]
-struct DummyEvent;
+struct ExampleEvent;
 ```
 
 Just like for client events, we provide [`ServerEventAppExt::add_mapped_server_event`]
@@ -370,22 +370,22 @@ with [`ServerTriggerAppExt::add_server_trigger`] and then use [`ServerTriggerExt
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(RepliconPlugins);
-app.add_server_trigger::<DummyEvent>(Channel::Ordered)
+app.add_server_trigger::<ExampleEvent>(Channel::Ordered)
     .add_observer(receive_events)
     .add_systems(Update, send_events.run_if(server_running));
 
 fn send_events(mut commands: Commands) {
     commands.server_trigger(ToClients {
         mode: SendMode::Broadcast,
-        event: DummyEvent,
+        event: ExampleEvent,
     });
 }
 
-fn receive_events(trigger: Trigger<DummyEvent>) {
+fn receive_events(trigger: Trigger<ExampleEvent>) {
     info!("received event {:?} from server", *trigger);
 }
 # #[derive(Event, Debug, Deserialize, Serialize)]
-# struct DummyEvent;
+# struct ExampleEvent;
 ```
 
 And just like for client trigger, we provide [`ServerTriggerAppExt::add_mapped_server_trigger`]

--- a/src/shared/event/server_event/client_event_queue.rs
+++ b/src/shared/event/server_event/client_event_queue.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn lower_tick() {
-        let mut queue = ClientEventQueue::<DummyEvent>::default();
+        let mut queue = ClientEventQueue::<TestEvent>::default();
         queue.insert(RepliconTick::new(1), Default::default());
 
         assert_eq!(queue.len(), 1);
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn bigger_tick() {
-        let mut queue = ClientEventQueue::<DummyEvent>::default();
+        let mut queue = ClientEventQueue::<TestEvent>::default();
         queue.insert(RepliconTick::new(1), Default::default());
 
         assert!(queue.pop_if_le(RepliconTick::new(2)).is_some());
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn ticks_ordering() {
-        let mut queue = ClientEventQueue::<DummyEvent>::default();
+        let mut queue = ClientEventQueue::<TestEvent>::default();
         queue.insert(RepliconTick::new(0), Default::default());
         queue.insert(RepliconTick::new(1), Default::default());
         queue.insert(RepliconTick::new(2), Default::default());
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn messages_ordering() {
-        let mut queue = ClientEventQueue::<DummyEvent>::default();
+        let mut queue = ClientEventQueue::<TestEvent>::default();
         queue.insert(RepliconTick::new(0), Bytes::from_static(&[0]));
         queue.insert(RepliconTick::new(0), Bytes::from_static(&[1]));
 
@@ -121,5 +121,5 @@ mod tests {
         assert!(queue.is_empty());
     }
 
-    struct DummyEvent;
+    struct TestEvent;
 }

--- a/src/shared/replication/command_markers.rs
+++ b/src/shared/replication/command_markers.rs
@@ -319,9 +319,9 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<CommandMarkers>()
             .init_resource::<ReplicationRegistry>()
-            .set_marker_fns::<DummyMarkerA, DummyComponent>(
+            .set_marker_fns::<Marker, TestComponent>(
                 command_fns::default_write,
-                command_fns::default_remove::<DummyComponent>,
+                command_fns::default_remove::<TestComponent>,
             );
     }
 
@@ -330,16 +330,16 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<CommandMarkers>()
             .init_resource::<ReplicationRegistry>()
-            .register_marker::<DummyMarkerA>()
-            .register_marker_with::<DummyMarkerB>(MarkerConfig {
+            .register_marker::<MarkerA>()
+            .register_marker_with::<MarkerB>(MarkerConfig {
                 priority: 2,
                 ..Default::default()
             })
-            .register_marker_with::<DummyMarkerC>(MarkerConfig {
+            .register_marker_with::<MarkerC>(MarkerConfig {
                 priority: 1,
                 ..Default::default()
             })
-            .register_marker::<DummyMarkerD>();
+            .register_marker::<MarkerD>();
 
         let markers = app.world().resource::<CommandMarkers>();
         let priorities: Vec<_> = markers
@@ -351,17 +351,20 @@ mod tests {
     }
 
     #[derive(Component)]
-    struct DummyMarkerA;
+    struct Marker;
 
     #[derive(Component)]
-    struct DummyMarkerB;
+    struct MarkerA;
 
     #[derive(Component)]
-    struct DummyMarkerC;
+    struct MarkerB;
 
     #[derive(Component)]
-    struct DummyMarkerD;
+    struct MarkerC;
+
+    #[derive(Component)]
+    struct MarkerD;
 
     #[derive(Component, Serialize, Deserialize)]
-    struct DummyComponent;
+    struct TestComponent;
 }

--- a/src/shared/replication/replication_registry/test_fns.rs
+++ b/src/shared/replication/replication_registry/test_fns.rs
@@ -45,25 +45,25 @@ let tick = RepliconTick::default();
 let (_, fns_id) = app
     .world_mut()
     .resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-        registry.register_rule_fns(world, RuleFns::<DummyComponent>::default())
+        registry.register_rule_fns(world, RuleFns::<ExampleComponent>::default())
     });
 
-let mut entity = app.world_mut().spawn(DummyComponent);
+let mut entity = app.world_mut().spawn(ExampleComponent);
 let data = entity.serialize(fns_id, tick);
-entity.remove::<DummyComponent>();
+entity.remove::<ExampleComponent>();
 
 entity.apply_write(data, fns_id, tick);
-assert!(entity.contains::<DummyComponent>());
+assert!(entity.contains::<ExampleComponent>());
 
 entity.apply_remove(fns_id, tick);
-assert!(!entity.contains::<DummyComponent>());
+assert!(!entity.contains::<ExampleComponent>());
 
 entity.apply_despawn(tick);
-let mut replicated = app.world_mut().query::<&DummyComponent>();
+let mut replicated = app.world_mut().query::<&ExampleComponent>();
 assert_eq!(replicated.iter(app.world()).len(), 0);
 
 #[derive(Component, Serialize, Deserialize)]
-struct DummyComponent;
+struct ExampleComponent;
 ```
 **/
 pub trait TestFnsEntityExt {

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -23,12 +23,12 @@ fn channels() {
         }),
     ))
     .add_event::<NonRemoteEvent>()
-    .add_client_event::<DummyEvent>(Channel::Ordered)
+    .add_client_event::<TestEvent>(Channel::Ordered)
     .finish();
 
     let event_registry = app.world().resource::<RemoteEventRegistry>();
     assert_eq!(event_registry.client_channel::<NonRemoteEvent>(), None);
-    assert_eq!(event_registry.client_channel::<DummyEvent>(), Some(2));
+    assert_eq!(event_registry.client_channel::<TestEvent>(), Some(2));
 }
 
 #[test]
@@ -37,13 +37,13 @@ fn sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, RepliconPlugins))
-            .add_client_event::<DummyEvent>(Channel::Ordered)
+            .add_client_event::<TestEvent>(Channel::Ordered)
             .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    client_app.world_mut().send_event(DummyEvent);
+    client_app.world_mut().send_event(TestEvent);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -51,7 +51,7 @@ fn sending_receiving() {
 
     let client_events = server_app
         .world()
-        .resource::<Events<FromClient<DummyEvent>>>();
+        .resource::<Events<FromClient<TestEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
 
@@ -103,7 +103,7 @@ fn sending_receiving_without_plugins() {
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
-        .add_client_event::<DummyEvent>(Channel::Ordered)
+        .add_client_event::<TestEvent>(Channel::Ordered)
         .finish();
     client_app
         .add_plugins((
@@ -113,12 +113,12 @@ fn sending_receiving_without_plugins() {
                 .disable::<ServerPlugin>()
                 .disable::<ServerEventPlugin>(),
         ))
-        .add_client_event::<DummyEvent>(Channel::Ordered)
+        .add_client_event::<TestEvent>(Channel::Ordered)
         .finish();
 
     server_app.connect_client(&mut client_app);
 
-    client_app.world_mut().send_event(DummyEvent);
+    client_app.world_mut().send_event(TestEvent);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -126,7 +126,7 @@ fn sending_receiving_without_plugins() {
 
     let client_events = server_app
         .world()
-        .resource::<Events<FromClient<DummyEvent>>>();
+        .resource::<Events<FromClient<TestEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
 
@@ -134,17 +134,17 @@ fn sending_receiving_without_plugins() {
 fn local_resending() {
     let mut app = App::new();
     app.add_plugins((TimePlugin, RepliconPlugins))
-        .add_client_event::<DummyEvent>(Channel::Ordered)
+        .add_client_event::<TestEvent>(Channel::Ordered)
         .finish();
 
-    app.world_mut().send_event(DummyEvent);
+    app.world_mut().send_event(TestEvent);
 
     app.update();
 
-    let dummy_events = app.world().resource::<Events<DummyEvent>>();
-    assert!(dummy_events.is_empty());
+    let events = app.world().resource::<Events<TestEvent>>();
+    assert!(events.is_empty());
 
-    let client_events = app.world().resource::<Events<FromClient<DummyEvent>>>();
+    let client_events = app.world().resource::<Events<FromClient<TestEvent>>>();
     assert_eq!(client_events.len(), 1);
 }
 
@@ -152,7 +152,7 @@ fn local_resending() {
 struct NonRemoteEvent;
 
 #[derive(Deserialize, Event, Serialize)]
-struct DummyEvent;
+struct TestEvent;
 
 #[derive(Deserialize, Event, Serialize, Clone, MapEntities)]
 struct EntityEvent(#[entities] Entity);

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -10,20 +10,20 @@ fn sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, RepliconPlugins))
-            .add_client_trigger::<DummyEvent>(Channel::Ordered)
+            .add_client_trigger::<TestEvent>(Channel::Ordered)
             .finish();
     }
-    server_app.init_resource::<TriggerReader<DummyEvent>>();
+    server_app.init_resource::<TriggerReader<TestEvent>>();
 
     server_app.connect_client(&mut client_app);
 
-    client_app.world_mut().client_trigger(DummyEvent);
+    client_app.world_mut().client_trigger(TestEvent);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let reader = server_app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = server_app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities, [Entity::PLACEHOLDER]);
 }
 
@@ -33,10 +33,10 @@ fn sending_receiving_with_target() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, RepliconPlugins))
-            .add_client_trigger::<DummyEvent>(Channel::Ordered)
+            .add_client_trigger::<TestEvent>(Channel::Ordered)
             .finish();
     }
-    server_app.init_resource::<TriggerReader<DummyEvent>>();
+    server_app.init_resource::<TriggerReader<TestEvent>>();
 
     server_app.connect_client(&mut client_app);
 
@@ -49,13 +49,13 @@ fn sending_receiving_with_target() {
 
     client_app
         .world_mut()
-        .client_trigger_targets(DummyEvent, client_entity);
+        .client_trigger_targets(TestEvent, client_entity);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let reader = server_app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = server_app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities, [server_entity]);
 }
 
@@ -104,7 +104,7 @@ fn sending_receiving_without_plugins() {
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
-        .add_client_trigger::<DummyEvent>(Channel::Ordered)
+        .add_client_trigger::<TestEvent>(Channel::Ordered)
         .finish();
     client_app
         .add_plugins((
@@ -114,19 +114,19 @@ fn sending_receiving_without_plugins() {
                 .disable::<ServerPlugin>()
                 .disable::<ServerEventPlugin>(),
         ))
-        .add_client_trigger::<DummyEvent>(Channel::Ordered)
+        .add_client_trigger::<TestEvent>(Channel::Ordered)
         .finish();
-    server_app.init_resource::<TriggerReader<DummyEvent>>();
+    server_app.init_resource::<TriggerReader<TestEvent>>();
 
     server_app.connect_client(&mut client_app);
 
-    client_app.world_mut().client_trigger(DummyEvent);
+    client_app.world_mut().client_trigger(TestEvent);
 
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let reader = server_app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = server_app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities.len(), 1);
 }
 
@@ -134,23 +134,23 @@ fn sending_receiving_without_plugins() {
 fn local_resending() {
     let mut app = App::new();
     app.add_plugins((TimePlugin, RepliconPlugins))
-        .add_client_trigger::<DummyEvent>(Channel::Ordered)
+        .add_client_trigger::<TestEvent>(Channel::Ordered)
         .finish();
-    app.init_resource::<TriggerReader<DummyEvent>>();
+    app.init_resource::<TriggerReader<TestEvent>>();
 
-    app.world_mut().client_trigger(DummyEvent);
+    app.world_mut().client_trigger(TestEvent);
 
     // Requires 2 updates because local resending runs
     // in `PostUpdate` and triggering runs in `PreUpdate`.
     app.update();
     app.update();
 
-    let reader = app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities.len(), 1);
 }
 
 #[derive(Deserialize, Event, Serialize, Clone)]
-struct DummyEvent;
+struct TestEvent;
 
 #[derive(Deserialize, Event, Serialize, Clone, MapEntities)]
 struct EntityEvent(#[entities] Entity);

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -87,7 +87,7 @@ fn connect_disconnect() {
         .query_filtered::<Entity, With<ConnectedClient>>();
     let client_entity = clients.single(server_app.world_mut()).unwrap();
 
-    // Assign a dummy network ID to test network map.
+    // Assign a placeholder network ID to test network map.
     server_app
         .world_mut()
         .entity_mut(client_entity)

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -98,7 +98,7 @@ fn after_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -106,7 +106,7 @@ fn after_spawn() {
     // Insert and remove `Replicated` to trigger spawn and despawn for client at the same time.
     server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .remove::<Replicated>();
 
     server_app.update();
@@ -156,4 +156,4 @@ fn hidden() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct TestComponent;

--- a/tests/fns.rs
+++ b/tests/fns.rs
@@ -202,13 +202,13 @@ fn remove_with_marker() {
 fn write_with_multiple_markers() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .register_marker::<DummyMarker>()
+        .register_marker::<Marker>()
         .register_marker::<ReplaceMarker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
         )
-        .set_marker_fns::<DummyMarker, _>(
+        .set_marker_fns::<Marker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
         );
@@ -222,7 +222,7 @@ fn write_with_multiple_markers() {
 
     let mut entity = app
         .world_mut()
-        .spawn((OriginalComponent, ReplaceMarker, DummyMarker));
+        .spawn((OriginalComponent, ReplaceMarker, Marker));
     let data = entity.serialize(fns_id, tick);
     entity.apply_write(data, fns_id, tick);
     assert!(
@@ -235,13 +235,13 @@ fn write_with_multiple_markers() {
 fn remove_with_mutltiple_markers() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, RepliconPlugins))
-        .register_marker::<DummyMarker>()
+        .register_marker::<Marker>()
         .register_marker::<ReplaceMarker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
         )
-        .set_marker_fns::<DummyMarker, _>(
+        .set_marker_fns::<Marker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
         );
@@ -255,7 +255,7 @@ fn remove_with_mutltiple_markers() {
 
     let mut entity = app
         .world_mut()
-        .spawn((ReplacedComponent, ReplaceMarker, DummyMarker));
+        .spawn((ReplacedComponent, ReplaceMarker, Marker));
     entity.apply_remove(fns_id, tick);
     assert!(
         !entity.contains::<ReplacedComponent>(),
@@ -271,12 +271,12 @@ fn write_with_priority_marker() {
             priority: 1,
             ..Default::default()
         })
-        .register_marker::<DummyMarker>()
+        .register_marker::<Marker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
         )
-        .set_marker_fns::<DummyMarker, _>(
+        .set_marker_fns::<Marker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
         );
@@ -290,7 +290,7 @@ fn write_with_priority_marker() {
 
     let mut entity = app
         .world_mut()
-        .spawn((OriginalComponent, ReplaceMarker, DummyMarker));
+        .spawn((OriginalComponent, ReplaceMarker, Marker));
     let data = entity.serialize(fns_id, tick);
     entity.apply_write(data, fns_id, tick);
     assert!(entity.contains::<ReplacedComponent>());
@@ -304,12 +304,12 @@ fn remove_with_priority_marker() {
             priority: 1,
             ..Default::default()
         })
-        .register_marker::<DummyMarker>()
+        .register_marker::<Marker>()
         .set_marker_fns::<ReplaceMarker, _>(
             replace,
             command_fns::default_remove::<ReplacedComponent>,
         )
-        .set_marker_fns::<DummyMarker, _>(
+        .set_marker_fns::<Marker, _>(
             command_fns::default_write::<OriginalComponent>,
             command_fns::default_remove::<OriginalComponent>,
         );
@@ -323,7 +323,7 @@ fn remove_with_priority_marker() {
 
     let mut entity = app
         .world_mut()
-        .spawn((ReplacedComponent, ReplaceMarker, DummyMarker));
+        .spawn((ReplacedComponent, ReplaceMarker, Marker));
     entity.apply_remove(fns_id, tick);
     assert!(!entity.contains::<ReplacedComponent>());
 }
@@ -356,7 +356,7 @@ struct Despawned;
 struct ReplaceMarker;
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyMarker;
+struct Marker;
 
 /// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
 fn replace(

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -27,7 +27,7 @@ fn table_storage() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TableComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -42,13 +42,13 @@ fn table_storage() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(DummyComponent);
+        .insert(TableComponent);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TableComponent>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -245,8 +245,8 @@ fn multiple_components() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>()
-        .replicate::<SparseSetComponent>();
+        .replicate::<ComponentA>()
+        .replicate::<ComponentB>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -263,15 +263,13 @@ fn multiple_components() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert((DummyComponent, SparseSetComponent));
+        .insert((ComponentA, ComponentB));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&DummyComponent, &SparseSetComponent)>();
+    let mut components = client_app.world_mut().query::<(&ComponentA, &ComponentB)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
     assert_eq!(
         client_app.world().archetypes().len() - before_archetypes,
@@ -384,7 +382,7 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_bundle::<(GroupComponentA, GroupComponentB)>();
+        .replicate_bundle::<(ComponentA, ComponentB)>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -399,15 +397,13 @@ fn group() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert((GroupComponentA, GroupComponentB));
+        .insert((ComponentA, ComponentB));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut groups = client_app
-        .world_mut()
-        .query::<(&GroupComponentA, &GroupComponentB)>();
+    let mut groups = client_app.world_mut().query::<(&ComponentA, &ComponentB)>();
     assert_eq!(groups.iter(client_app.world()).count(), 1);
 }
 
@@ -437,13 +433,13 @@ fn not_replicated() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(DummyComponent);
+        .insert(TestComponent);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TestComponent>();
     assert_eq!(components.iter(client_app.world()).count(), 0);
 }
 
@@ -459,14 +455,14 @@ fn after_removal() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     server_app.update();
@@ -478,17 +474,17 @@ fn after_removal() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<DummyComponent>()
-        .insert(DummyComponent);
+        .remove::<TestComponent>()
+        .insert(TestComponent);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TestComponent>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 
-    let mut system_state: SystemState<RemovedComponents<DummyComponent>> =
+    let mut system_state: SystemState<RemovedComponents<TestComponent>> =
         SystemState::new(client_app.world_mut());
     let removals = system_state.get(client_app.world());
     assert_eq!(
@@ -511,19 +507,19 @@ fn before_started_replication() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, TestComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TestComponent>();
     assert_eq!(
         components.iter(client_app.world()).count(),
         0,
@@ -557,7 +553,7 @@ fn after_started_replication() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -573,14 +569,14 @@ fn after_started_replication() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, TestComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TestComponent>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -596,7 +592,7 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -611,7 +607,7 @@ fn confirm_history() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(DummyComponent);
+        .insert(TestComponent);
 
     // Clear previous events.
     client_app
@@ -645,24 +641,28 @@ fn confirm_history() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct MappedComponent(#[entities] Entity);
-
-#[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
-
-#[derive(Component, Deserialize, Serialize)]
-#[component(immutable)]
-struct ImmutableComponent(bool);
+#[component(storage = "Table")]
+struct TableComponent;
 
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "SparseSet")]
 struct SparseSetComponent;
 
 #[derive(Component, Deserialize, Serialize)]
-struct GroupComponentA;
+struct TestComponent;
 
 #[derive(Component, Deserialize, Serialize)]
-struct GroupComponentB;
+struct MappedComponent(#[entities] Entity);
+
+#[derive(Component, Deserialize, Serialize)]
+#[component(immutable)]
+struct ImmutableComponent(bool);
+
+#[derive(Component, Deserialize, Serialize)]
+struct ComponentA;
+
+#[derive(Component, Deserialize, Serialize)]
+struct ComponentB;
 
 #[derive(Component)]
 struct ReplaceMarker;

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -620,32 +620,32 @@ fn marker_with_history_consume() {
     server_app.exchange_with_client(&mut client_app);
 
     // Change value, but don't process it on client.
-    let dummy_entity1 = server_app.world_mut().spawn_empty().id();
+    let new_entity1 = server_app.world_mut().spawn_empty().id();
     let mut component = server_app
         .world_mut()
         .get_mut::<MappedComponent>(server_entity)
         .unwrap();
-    component.0 = dummy_entity1;
+    component.0 = new_entity1;
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
 
     // Change value again to trigger another message.
-    let dummy_entity2 = server_app.world_mut().spawn_empty().id();
+    let new_entity2 = server_app.world_mut().spawn_empty().id();
     let mut component = server_app
         .world_mut()
         .get_mut::<MappedComponent>(server_entity)
         .unwrap();
-    component.0 = dummy_entity2;
+    component.0 = new_entity2;
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let entity_map = client_app.world().resource::<ServerEntityMap>();
-    assert!(entity_map.to_client().contains_key(&dummy_entity2));
+    assert!(entity_map.to_client().contains_key(&new_entity2));
     assert!(
-        !entity_map.to_client().contains_key(&dummy_entity1),
+        !entity_map.to_client().contains_key(&new_entity1),
         "client should consume older mutations for other components with marker that requested history"
     );
 
@@ -797,7 +797,7 @@ fn with_insertion() {
             }),
         ))
         .replicate::<BoolComponent>()
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -814,7 +814,7 @@ fn with_insertion() {
 
     let mut server_entity = server_app.world_mut().entity_mut(server_entity);
     server_entity.get_mut::<BoolComponent>().unwrap().0 = true;
-    server_entity.insert(DummyComponent);
+    server_entity.insert(TestComponent);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -822,7 +822,7 @@ fn with_insertion() {
 
     let component = client_app
         .world_mut()
-        .query_filtered::<&BoolComponent, With<DummyComponent>>()
+        .query_filtered::<&BoolComponent, With<TestComponent>>()
         .single(client_app.world())
         .unwrap();
     assert!(component.0);
@@ -841,14 +841,14 @@ fn with_removal() {
             }),
         ))
         .replicate::<BoolComponent>()
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, BoolComponent(false), DummyComponent))
+        .spawn((Replicated, BoolComponent(false), TestComponent))
         .id();
 
     server_app.update();
@@ -858,7 +858,7 @@ fn with_removal() {
 
     let mut server_entity = server_app.world_mut().entity_mut(server_entity);
     server_entity.get_mut::<BoolComponent>().unwrap().0 = true;
-    server_entity.remove::<DummyComponent>();
+    server_entity.remove::<TestComponent>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -866,7 +866,7 @@ fn with_removal() {
 
     let component = client_app
         .world_mut()
-        .query_filtered::<&BoolComponent, Without<DummyComponent>>()
+        .query_filtered::<&BoolComponent, Without<TestComponent>>()
         .single(client_app.world())
         .unwrap();
     assert!(component.0);
@@ -1008,23 +1008,23 @@ fn old_ignored() {
     server_app.exchange_with_client(&mut client_app);
 
     // Change the value, but don't process it on client.
-    let dummy_entity1 = server_app.world_mut().spawn_empty().id();
+    let new_entity1 = server_app.world_mut().spawn_empty().id();
     let mut component = server_app
         .world_mut()
         .get_mut::<MappedComponent>(server_entity)
         .unwrap();
-    component.0 = dummy_entity1;
+    component.0 = new_entity1;
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
 
     // Change the value again to trigger another message.
-    let dummy_entity2 = server_app.world_mut().spawn_empty().id();
+    let new_entity2 = server_app.world_mut().spawn_empty().id();
     let mut component = server_app
         .world_mut()
         .get_mut::<MappedComponent>(server_entity)
         .unwrap();
-    component.0 = dummy_entity2;
+    component.0 = new_entity2;
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -1032,7 +1032,7 @@ fn old_ignored() {
 
     let entity_map = client_app.world().resource::<ServerEntityMap>();
     assert!(
-        !entity_map.to_client().contains_key(&dummy_entity1),
+        !entity_map.to_client().contains_key(&new_entity1),
         "client should ignore older mutation"
     );
 
@@ -1234,7 +1234,7 @@ fn after_disconnect() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct TestComponent;
 
 #[derive(Clone, Component, Copy, Deserialize, Serialize)]
 struct BoolComponent(bool);

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -24,14 +24,14 @@ fn single() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     server_app.update();
@@ -39,13 +39,13 @@ fn single() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TestComponent>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<DummyComponent>();
+        .remove::<TestComponent>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -66,15 +66,15 @@ fn multiple() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>()
-        .replicate::<OtherComponent>();
+        .replicate::<ComponentA>()
+        .replicate::<ComponentB>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent, OtherComponent))
+        .spawn((Replicated, ComponentA, ComponentB))
         .id();
 
     server_app.update();
@@ -82,9 +82,7 @@ fn multiple() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app
-        .world_mut()
-        .query::<(&DummyComponent, &OtherComponent)>();
+    let mut components = client_app.world_mut().query::<(&ComponentA, &ComponentB)>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     let before_archetypes = client_app.world().archetypes().len();
@@ -92,7 +90,7 @@ fn multiple() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<(DummyComponent, OtherComponent)>();
+        .remove::<(ComponentA, ComponentB)>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -215,14 +213,14 @@ fn group() {
                 ..Default::default()
             }),
         ))
-        .replicate_bundle::<(GroupComponentA, GroupComponentB)>();
+        .replicate_bundle::<(ComponentA, ComponentB)>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, (GroupComponentA, GroupComponentB)))
+        .spawn((Replicated, (ComponentA, ComponentB)))
         .id();
 
     server_app.update();
@@ -232,22 +230,22 @@ fn group() {
 
     let client_entity = client_app
         .world_mut()
-        .query_filtered::<Entity, (With<GroupComponentA>, With<GroupComponentB>)>()
+        .query_filtered::<Entity, (With<ComponentA>, With<ComponentB>)>()
         .single(client_app.world())
         .unwrap();
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<(GroupComponentA, GroupComponentB)>();
+        .remove::<(ComponentA, ComponentB)>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<GroupComponentA>());
-    assert!(!client_entity.contains::<GroupComponentB>());
+    assert!(!client_entity.contains::<ComponentA>());
+    assert!(!client_entity.contains::<ComponentB>());
 }
 
 #[test]
@@ -312,14 +310,14 @@ fn after_insertion() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     server_app.update();
@@ -327,15 +325,15 @@ fn after_insertion() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&DummyComponent>();
+    let mut components = client_app.world_mut().query::<&TestComponent>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     // Insert and remove at the same time.
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .insert(DummyComponent)
-        .remove::<DummyComponent>();
+        .insert(TestComponent)
+        .remove::<TestComponent>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -356,15 +354,15 @@ fn with_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
-        .remove::<DummyComponent>();
+        .spawn((Replicated, TestComponent))
+        .remove::<TestComponent>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -372,7 +370,7 @@ fn with_spawn() {
 
     let mut components = client_app
         .world_mut()
-        .query_filtered::<&Replicated, Without<DummyComponent>>();
+        .query_filtered::<&Replicated, Without<TestComponent>>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 }
 
@@ -388,14 +386,14 @@ fn with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     server_app.update();
@@ -410,7 +408,7 @@ fn with_despawn() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<DummyComponent>()
+        .remove::<TestComponent>()
         .remove::<Replicated>();
 
     server_app.update();
@@ -432,14 +430,14 @@ fn confirm_history() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     server_app.update();
@@ -449,14 +447,14 @@ fn confirm_history() {
 
     let client_entity = client_app
         .world_mut()
-        .query_filtered::<Entity, With<DummyComponent>>()
+        .query_filtered::<Entity, With<TestComponent>>()
         .single(client_app.world())
         .unwrap();
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<DummyComponent>();
+        .remove::<TestComponent>();
 
     // Clear previous events.
     client_app
@@ -501,14 +499,14 @@ fn hidden() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     server_app.update();
@@ -519,7 +517,7 @@ fn hidden() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<DummyComponent>();
+        .remove::<TestComponent>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -534,16 +532,13 @@ fn hidden() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct TestComponent;
 
 #[derive(Component, Deserialize, Serialize)]
-struct OtherComponent;
+struct ComponentA;
 
 #[derive(Component, Deserialize, Serialize)]
-struct GroupComponentA;
-
-#[derive(Component, Deserialize, Serialize)]
-struct GroupComponentB;
+struct ComponentB;
 
 #[derive(Component, Deserialize, Serialize)]
 struct NotReplicatedComponent;

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -6,18 +6,18 @@ use serde::{Deserialize, Serialize};
 fn replicated_entity() {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins)
-        .register_type::<DummyComponent>()
+        .register_type::<TestComponent>()
         .register_type::<NonReflectedComponent>()
-        .replicate::<DummyComponent>()
-        .replicate::<OtherReflectedComponent>() // Reflected, but the type is not registered.
+        .replicate::<TestComponent>()
+        .replicate::<ReflectedComponent>() // Reflected, but the type is not registered.
         .replicate::<NonReflectedComponent>();
 
     let entity = app
         .world_mut()
         .spawn((
             Replicated,
-            DummyComponent,
-            OtherReflectedComponent,
+            TestComponent,
+            ReflectedComponent,
             NonReflectedComponent,
         ))
         .id();
@@ -60,10 +60,10 @@ fn empty_entity() {
 fn not_replicated_entity() {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins)
-        .register_type::<DummyComponent>()
-        .replicate::<DummyComponent>();
+        .register_type::<TestComponent>()
+        .replicate::<TestComponent>();
 
-    app.world_mut().spawn(DummyComponent);
+    app.world_mut().spawn(TestComponent);
 
     let mut scene = DynamicScene::default();
     scene::replicate_into(&mut scene, app.world());
@@ -76,18 +76,18 @@ fn not_replicated_entity() {
 fn entity_update() {
     let mut app = App::new();
     app.add_plugins(RepliconPlugins)
-        .register_type::<DummyComponent>()
-        .replicate::<DummyComponent>()
-        .register_type::<OtherReflectedComponent>();
+        .register_type::<TestComponent>()
+        .replicate::<TestComponent>()
+        .register_type::<ReflectedComponent>();
 
     let entity = app
         .world_mut()
-        .spawn((Replicated, DummyComponent, OtherReflectedComponent))
+        .spawn((Replicated, TestComponent, ReflectedComponent))
         .id();
 
     // Populate scene only with a single non-replicated component.
     let mut scene = DynamicSceneBuilder::from_world(app.world())
-        .allow_component::<OtherReflectedComponent>()
+        .allow_component::<ReflectedComponent>()
         .extract_entity(entity)
         .build();
 
@@ -104,11 +104,11 @@ fn entity_update() {
 
 #[derive(Component, Default, Deserialize, Reflect, Serialize)]
 #[reflect(Component)]
-struct DummyComponent;
+struct TestComponent;
 
 #[derive(Component, Default, Deserialize, Reflect, Serialize)]
 #[reflect(Component)]
-struct OtherReflectedComponent;
+struct ReflectedComponent;
 
 /// Component that have `Reflect` derive, but without `#[reflect(Component)]`
 #[derive(Component, Default, Deserialize, Reflect, Serialize)]

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -16,23 +16,23 @@ fn sending_receiving() {
                 ..Default::default()
             }),
         ))
-        .add_server_trigger::<DummyEvent>(Channel::Ordered)
+        .add_server_trigger::<TestEvent>(Channel::Ordered)
         .finish();
     }
-    client_app.init_resource::<TriggerReader<DummyEvent>>();
+    client_app.init_resource::<TriggerReader<TestEvent>>();
 
     server_app.connect_client(&mut client_app);
 
     server_app.world_mut().server_trigger(ToClients {
         mode: SendMode::Broadcast,
-        event: DummyEvent,
+        event: TestEvent,
     });
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let reader = client_app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = client_app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities, [Entity::PLACEHOLDER]);
 }
 
@@ -48,10 +48,10 @@ fn sending_receiving_with_target() {
                 ..Default::default()
             }),
         ))
-        .add_server_trigger::<DummyEvent>(Channel::Ordered)
+        .add_server_trigger::<TestEvent>(Channel::Ordered)
         .finish();
     }
-    client_app.init_resource::<TriggerReader<DummyEvent>>();
+    client_app.init_resource::<TriggerReader<TestEvent>>();
 
     server_app.connect_client(&mut client_app);
 
@@ -65,7 +65,7 @@ fn sending_receiving_with_target() {
     server_app.world_mut().server_trigger_targets(
         ToClients {
             mode: SendMode::Broadcast,
-            event: DummyEvent,
+            event: TestEvent,
         },
         server_entity,
     );
@@ -74,7 +74,7 @@ fn sending_receiving_with_target() {
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let reader = client_app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = client_app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities, [client_entity]);
 }
 
@@ -134,7 +134,7 @@ fn sending_receiving_without_plugins() {
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
-        .add_server_trigger::<DummyEvent>(Channel::Ordered)
+        .add_server_trigger::<TestEvent>(Channel::Ordered)
         .finish();
     client_app
         .add_plugins((
@@ -144,22 +144,22 @@ fn sending_receiving_without_plugins() {
                 .disable::<ServerPlugin>()
                 .disable::<ServerEventPlugin>(),
         ))
-        .add_server_trigger::<DummyEvent>(Channel::Ordered)
+        .add_server_trigger::<TestEvent>(Channel::Ordered)
         .finish();
-    client_app.init_resource::<TriggerReader<DummyEvent>>();
+    client_app.init_resource::<TriggerReader<TestEvent>>();
 
     server_app.connect_client(&mut client_app);
 
     server_app.world_mut().server_trigger(ToClients {
         mode: SendMode::Broadcast,
-        event: DummyEvent,
+        event: TestEvent,
     });
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    let reader = client_app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = client_app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities.len(), 1);
 }
 
@@ -173,13 +173,13 @@ fn local_resending() {
             ..Default::default()
         }),
     ))
-    .add_server_trigger::<DummyEvent>(Channel::Ordered)
+    .add_server_trigger::<TestEvent>(Channel::Ordered)
     .finish();
-    app.init_resource::<TriggerReader<DummyEvent>>();
+    app.init_resource::<TriggerReader<TestEvent>>();
 
     app.world_mut().server_trigger(ToClients {
         mode: SendMode::Broadcast,
-        event: DummyEvent,
+        event: TestEvent,
     });
 
     // Requires 2 updates because local resending runs
@@ -187,12 +187,12 @@ fn local_resending() {
     app.update();
     app.update();
 
-    let reader = app.world().resource::<TriggerReader<DummyEvent>>();
+    let reader = app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities.len(), 1);
 }
 
 #[derive(Event, Serialize, Deserialize, Clone)]
-struct DummyEvent;
+struct TestEvent;
 
 #[derive(Event, Deserialize, Serialize, Clone, MapEntities)]
 struct EntityEvent(#[entities] Entity);

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -60,12 +60,12 @@ fn with_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, TestComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -73,7 +73,7 @@ fn with_component() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -89,8 +89,8 @@ fn with_multiple_components() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>()
-        .replicate::<OtherComponent>();
+        .replicate::<ComponentA>()
+        .replicate::<ComponentB>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -99,7 +99,7 @@ fn with_multiple_components() {
 
     server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent, OtherComponent));
+        .spawn((Replicated, ComponentA, ComponentB));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -107,7 +107,7 @@ fn with_multiple_components() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent, &OtherComponent)>();
+        .query::<(&Replicated, &ComponentA, &ComponentB)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
     assert_eq!(
         client_app.world().archetypes().len() - before_archetypes,
@@ -128,13 +128,13 @@ fn with_old_component() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     // Spawn an entity with replicated component, but without a marker.
-    let server_entity = server_app.world_mut().spawn(DummyComponent).id();
+    let server_entity = server_app.world_mut().spawn(TestComponent).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -156,7 +156,7 @@ fn with_old_component() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -172,11 +172,11 @@ fn before_connection() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     // Spawn an entity before client connected.
-    server_app.world_mut().spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, TestComponent));
 
     server_app.connect_client(&mut client_app);
 
@@ -185,7 +185,7 @@ fn before_connection() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -201,7 +201,7 @@ fn pre_spawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -209,7 +209,7 @@ fn pre_spawn() {
     let client_entity = client_app.world_mut().spawn_empty().id();
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
@@ -245,7 +245,7 @@ fn pre_spawn() {
         "server should confirm replication of client entity"
     );
     assert!(
-        client_entity.contains::<DummyComponent>(),
+        client_entity.contains::<TestComponent>(),
         "component from server should be replicated"
     );
 
@@ -269,7 +269,7 @@ fn after_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -277,7 +277,7 @@ fn after_despawn() {
     // Remove and insert `Replicated` to trigger despawn and spawn for client at the same time.
     server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .remove::<Replicated>()
         .insert(Replicated);
 
@@ -287,12 +287,15 @@ fn after_despawn() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct TestComponent;
 
 #[derive(Component, Deserialize, Serialize)]
-struct OtherComponent;
+struct ComponentA;
+
+#[derive(Component, Deserialize, Serialize)]
+struct ComponentB;

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -17,7 +17,7 @@ fn client_stats() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -25,7 +25,7 @@ fn client_stats() {
     let client_entity = client_app.world_mut().spawn_empty().id();
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
@@ -44,7 +44,7 @@ fn client_stats() {
 
     server_app
         .world_mut()
-        .get_mut::<DummyComponent>(server_entity)
+        .get_mut::<TestComponent>(server_entity)
         .unwrap()
         .set_changed();
 
@@ -62,4 +62,4 @@ fn client_stats() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct TestComponent;

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -18,12 +18,12 @@ fn empty_blacklist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, TestComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -31,7 +31,7 @@ fn empty_blacklist() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -48,14 +48,14 @@ fn blacklist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
@@ -86,7 +86,7 @@ fn blacklist() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).count(), 1);
 }
 
@@ -103,7 +103,7 @@ fn blacklist_with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -145,12 +145,12 @@ fn empty_whitelist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, DummyComponent));
+    server_app.world_mut().spawn((Replicated, TestComponent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -177,14 +177,14 @@ fn whitelist() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, DummyComponent))
+        .spawn((Replicated, TestComponent))
         .id();
 
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
@@ -201,7 +201,7 @@ fn whitelist() {
 
     let mut components = client_app
         .world_mut()
-        .query::<(&Replicated, &DummyComponent)>();
+        .query::<(&Replicated, &TestComponent)>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
     // Reverse visibility.
@@ -235,7 +235,7 @@ fn whitelist_with_despawn() {
                 ..Default::default()
             }),
         ))
-        .replicate::<DummyComponent>();
+        .replicate::<TestComponent>();
     }
 
     server_app.connect_client(&mut client_app);
@@ -265,4 +265,4 @@ fn whitelist_with_despawn() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
-struct DummyComponent;
+struct TestComponent;


### PR DESCRIPTION
It looks like using "Dummy" is not considered good practice - see: https://github.com/projectharmonia/bevy_enhanced_input/issues/76

I've decided to adopt the following convention:
* Instead of `DummySomething`, use just `Something` unless it conflicts with a trait.
* If it conflicts with a trait, use `ExampleSomething` in docs and `TestSomething` in tests.
* Where possible, use more contextual names - e.g., `TableStorage` instead of `DummyComponent` in storage tests.
* If multiple types are involved, use `SomethingA`, `SomethingB`, etc.
* For variables, prefer `something` instead of `dummy_something`, or use more contextual names when necessary.

Overall, I think this makes things clearer and more concise. No API changes required, it just tests and doc examples.