### PR TITLE
Add `DisconnectRequest` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configurable `SendRate` for deterministic replication. Use `SendRate::Once` to send only the initial value, or `SendRate::Periodic` to only sync the state periodically.
 - `AppRuleExt::replicate_with_priority` to configure replication rule priority.
+- `DisconnectRequest` event to queue a disconnection for a specific client on the server.
 
 ### Changed
 

--- a/bevy_replicon_example_backend/src/client.rs
+++ b/bevy_replicon_example_backend/src/client.rs
@@ -20,9 +20,9 @@ impl Plugin for RepliconExampleClientPlugin {
         app.add_systems(
             PreUpdate,
             (
-                set_disconnected.run_if(resource_removed::<ExampleClient>),
                 set_connected.run_if(resource_added::<ExampleClient>),
                 receive_packets.run_if(resource_exists::<ExampleClient>),
+                set_disconnected.run_if(resource_removed::<ExampleClient>),
             )
                 .chain()
                 .in_set(ClientSet::ReceivePackets),

--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -20,9 +20,9 @@ impl Plugin for RepliconExampleServerPlugin {
         app.add_systems(
             PreUpdate,
             (
-                set_stopped.run_if(resource_removed::<ExampleServer>),
                 set_running.run_if(resource_added::<ExampleServer>),
                 receive_packets.run_if(resource_exists::<ExampleServer>),
+                set_stopped.run_if(resource_removed::<ExampleServer>),
             )
                 .chain()
                 .in_set(ServerSet::ReceivePackets),
@@ -120,6 +120,7 @@ fn receive_packets(
 
 fn send_packets(
     mut commands: Commands,
+    mut disconnect_events: EventReader<DisconnectRequest>,
     mut replicon_server: ResMut<RepliconServer>,
     mut clients: Query<&mut ExampleConnection>,
 ) {
@@ -131,6 +132,10 @@ fn send_packets(
             commands.entity(client_entity).despawn();
             error!("disconnecting client `{client_entity}` due to error: {e}");
         }
+    }
+
+    for event in disconnect_events.read() {
+        commands.entity(event.client_entity).despawn();
     }
 }
 

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -51,6 +51,40 @@ fn connect_disconnect() {
 }
 
 #[test]
+fn disconnect_request() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+            RepliconExampleBackendPlugins,
+        ));
+    }
+
+    setup(&mut server_app, &mut client_app).unwrap();
+
+    let mut clients = server_app
+        .world_mut()
+        .query_filtered::<Entity, With<ConnectedClient>>();
+    let client_entity = clients.single(server_app.world()).unwrap();
+    server_app
+        .world_mut()
+        .send_event(DisconnectRequest { client_entity });
+
+    server_app.update();
+    client_app.update();
+
+    assert_eq!(clients.iter(server_app.world()).len(), 0);
+
+    let client = client_app.world().resource::<RepliconClient>();
+    assert!(client.is_disconnected());
+}
+
+#[test]
 fn replication() {
     let mut server_app = App::new();
     let mut client_app = App::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ On server connected clients represented as entities with [`ConnectedClient`] com
 Their data represented as components, such as [`NetworkStats`]. Users can also attach their
 own metadata to them or even replicate these entiteis back to clients.
 
+These entities are spawned and despawned by the messaging backend. To request
+a disconnection, use the [`DisconnectRequest`] event.
+
 You can use [`Trigger<OnAdd, ConnectedClient>`] to react to new connections,
 or use backend-provided events if you need the disconnect reason.
 
@@ -619,6 +622,7 @@ pub mod prelude {
         shared::{
             RepliconSharedPlugin, SERVER,
             backend::{
+                DisconnectRequest,
                 connected_client::{ConnectedClient, NetworkStats},
                 replicon_channels::{Channel, RepliconChannels},
                 replicon_client::{RepliconClient, RepliconClientStatus},

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -10,6 +10,7 @@ pub mod server_entity_map;
 use bevy::prelude::*;
 
 use backend::{
+    DisconnectRequest,
     connected_client::{ConnectedClient, NetworkIdMap, NetworkStats},
     replicon_channels::RepliconChannels,
 };
@@ -34,7 +35,8 @@ impl Plugin for RepliconSharedPlugin {
             .init_resource::<ReplicationRegistry>()
             .init_resource::<ReplicationRules>()
             .init_resource::<CommandMarkers>()
-            .init_resource::<RemoteEventRegistry>();
+            .init_resource::<RemoteEventRegistry>()
+            .add_event::<DisconnectRequest>();
     }
 }
 

--- a/src/shared/backend.rs
+++ b/src/shared/backend.rs
@@ -1,11 +1,15 @@
 //! API for messaging backends.
 //!
-//! We don't provide any traits to avoid Rust's "orphan rule". Instead, backends need to create channels defined in the
-//! [`RepliconChannels`](replicon_channels::RepliconChannels) resource and then manage the
-//! [`RepliconServer`](replicon_server::RepliconServer) and [`RepliconClient`](replicon_client::RepliconClient) resources,
-//! along with the [`ConnectedClient`](connected_client::ConnectedClient) component. This way, integrations can be provided
-//! as separate crates without requiring us or crate authors to maintain them under a feature. See the documentation on
-//! types in this module for details.
+//! We don't provide any traits to avoid Rust's orphan rule. Instead, backends are expected to:
+//!
+//! - Create channels defined in the [`RepliconChannels`](replicon_channels::RepliconChannels) resource.
+//!   This can be done via an extension trait that provides a conversion which the user needs to call manually to get channels for the backend.
+//! - Update the [`RepliconServer`](replicon_server::RepliconServer) and [`RepliconClient`](replicon_client::RepliconClient) resources.
+//! - Spawn and despawn entities with [`ConnectedClient`](connected_client::ConnectedClient) component.
+//! - React on [`DisconnectRequest`] event.
+//!
+//! This way, integrations can be provided as separate crates without requiring us or crate authors to maintain them under a feature.
+//! See the documentation on types in this module for details.
 //!
 //! It's also recommended to split the crate into client and server plugins, along with `server` and `client` features.
 //! This way, plugins can be conveniently disabled at compile time, which is useful for dedicated server or client
@@ -20,3 +24,16 @@ pub mod connected_client;
 pub mod replicon_channels;
 pub mod replicon_client;
 pub mod replicon_server;
+
+use bevy::prelude::*;
+
+/// An event for the messaging backend to queue a disconnection
+/// for a specific client on the server.
+///
+/// The disconnection should occur **after** all pending messages
+/// for this client have been sent. The actual delivery of these
+/// messages is not guaranteed.
+#[derive(Event, Clone, Copy, Debug)]
+pub struct DisconnectRequest {
+    pub client_entity: Entity,
+}


### PR DESCRIPTION
Allows sending a message to a client and disconnecting afterward, ensuring the client receives the message before the connection closes.

This can be used to send a proper disconnect reason, for example: https://github.com/projectharmonia/bevy_replicon/issues/420