### PR TITLE
Process all received data with a disconnect 

### DIFF
--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -20,9 +20,9 @@ impl Plugin for RepliconExampleServerPlugin {
         app.add_systems(
             PreUpdate,
             (
+                set_stopped.run_if(resource_removed::<ExampleServer>),
                 set_running.run_if(resource_added::<ExampleServer>),
                 receive_packets.run_if(resource_exists::<ExampleServer>),
-                set_stopped.run_if(resource_removed::<ExampleServer>),
             )
                 .chain()
                 .in_set(ServerSet::ReceivePackets),

--- a/src/shared/backend/replicon_client.rs
+++ b/src/shared/backend/replicon_client.rs
@@ -7,8 +7,14 @@ use super::connected_client::NetworkStats;
 /// Stores information about a client independent from the messaging backend.
 ///
 /// The messaging backend is responsible for updating this resource:
-/// - When the messaging client changes its status (connected, connecting and disconnected),
-///   [`Self::set_status`] should be used to reflect this.
+/// - When the messaging client changes its status, [`Self::set_status`] should be used to
+///   reflect this change:
+///   - [`RepliconClientStatus::Connecting`] and [`RepliconClientStatus::Connected`] should
+///     be set in [`ClientSet::ReceivePackets`](crate::client::ClientSet::ReceivePackets) to
+///     allow the client to process received messages immediately.
+///   - [`RepliconClientStatus::Disconnected`] should be set before
+///     [`ClientSet::Send`](crate::client::ClientSet::Send) to allow the client to process
+///     all received messages before disconnecting.
 /// - For receiving messages, [`Self::insert_received`] should be to used.
 ///   A system to forward backend messages to Replicon should run in
 ///   [`ClientSet::ReceivePackets`](crate::client::ClientSet::ReceivePackets).


### PR DESCRIPTION
This should be handled by the messaging backend. Instead of marking the client as disconnected immediately, backends should defer this until `PostUpdate`.

I attempted to implement this on Replicon's side in https://github.com/projectharmonia/bevy_replicon/pull/493,
but this approach forces users to use `client_just_disconnected.or(client_connected)` conditions to receive messages on disconnect, which is error-prone.

I've documented this behavior and added tests for the example backend.