### PR TITLE
Independent triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `GroupReplication` into `BundleReplication`.
 - Rename `AppRuleExt::replicate_group` into `AppRuleExt::replicate_bundle`.
 - Rename `replication_registry::despawn_recursive` into `replication_registry::despawn`.
+- Rename `ServerEventAppExt::make_independent` into `ServerEventAppExt::make_event_independent`. It never worked for triggers.
 - `ReplicationRule` now stores `Vec<ComponentRule>` instead of `Vec<(ComponentId, FnsId)>`
 - `RuleFns` now available from prelude.
 - Initialize channels in `App::finish` instead of `Startup`. It's called automatically on `App::run`, but in tests you need to call `App::finish` manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable `SendRate` for deterministic replication. Use `SendRate::Once` to send only the initial value, or `SendRate::Periodic` to only sync the state periodically.
 - `AppRuleExt::replicate_with_priority` to configure replication rule priority.
 - `DisconnectRequest` event to queue a disconnection for a specific client on the server.
+- `ServerTriggerAppExt::make_trigger_independent`.
 
 ### Changed
 

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -32,12 +32,12 @@ impl Plugin for ClientEventPlugin {
 
         let send = (
             FilteredResourcesParamBuilder::new(|builder| {
-                for event in event_registry.iter_client_events() {
+                for event in event_registry.iter_all_client() {
                     builder.add_read_by_id(event.events_id());
                 }
             }),
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_client_events() {
+                for event in event_registry.iter_all_client() {
                     builder.add_write_by_id(event.reader_id());
                 }
             }),
@@ -51,12 +51,12 @@ impl Plugin for ClientEventPlugin {
 
         let receive = (
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_server_events() {
+                for event in event_registry.iter_all_server() {
                     builder.add_write_by_id(event.events_id());
                 }
             }),
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_server_events() {
+                for event in event_registry.iter_all_server() {
                     builder.add_write_by_id(event.queue_id());
                 }
             }),
@@ -83,12 +83,12 @@ impl Plugin for ClientEventPlugin {
 
         let resend_locally = (
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_client_events() {
+                for event in event_registry.iter_all_client() {
                     builder.add_write_by_id(event.client_events_id());
                 }
             }),
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_client_events() {
+                for event in event_registry.iter_all_client() {
                     builder.add_write_by_id(event.events_id());
                 }
             }),
@@ -99,12 +99,12 @@ impl Plugin for ClientEventPlugin {
 
         let reset = (
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_client_events() {
+                for event in event_registry.iter_all_client() {
                     builder.add_write_by_id(event.events_id());
                 }
             }),
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_server_events() {
+                for event in event_registry.iter_all_server() {
                     builder.add_write_by_id(event.queue_id());
                 }
             }),
@@ -154,7 +154,7 @@ fn send(
         invalid_entities: Vec::new(),
     };
 
-    for event in event_registry.iter_client_events() {
+    for event in event_registry.iter_all_client() {
         let events = events
             .get_by_id(event.events_id())
             .expect("events resource should be accessible");
@@ -184,7 +184,7 @@ fn receive(
         invalid_entities: Vec::new(),
     };
 
-    for event in event_registry.iter_server_events() {
+    for event in event_registry.iter_all_server() {
         let events = events
             .get_mut_by_id(event.events_id())
             .expect("events resource should be accessible");
@@ -223,7 +223,7 @@ fn resend_locally(
     mut events: FilteredResourcesMut,
     event_registry: Res<RemoteEventRegistry>,
 ) {
-    for event in event_registry.iter_client_events() {
+    for event in event_registry.iter_all_client() {
         let client_events = client_events
             .get_mut_by_id(event.client_events_id())
             .expect("client events resource should be accessible");
@@ -241,7 +241,7 @@ fn reset(
     mut queues: FilteredResourcesMut,
     event_registry: Res<RemoteEventRegistry>,
 ) {
-    for event in event_registry.iter_client_events() {
+    for event in event_registry.iter_all_client() {
         let events = events
             .get_mut_by_id(event.events_id())
             .expect("events resource should be accessible");
@@ -250,7 +250,7 @@ fn reset(
         unsafe { event.reset(events.into_inner()) };
     }
 
-    for event in event_registry.iter_server_events() {
+    for event in event_registry.iter_all_server() {
         let queue = queues
             .get_mut_by_id(event.queue_id())
             .expect("event queue resource should be accessible");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ and [`ServerTriggerAppExt::add_server_trigger_with`].
 
 We guarantee that clients will never receive events that point to an entity or require specific
 component to be presentt which client haven't received yet. For more details see the documentation on
-[`ServerEventAppExt::make_independent`].
+[`ServerEventAppExt::make_event_independent`].
 
 ## Abstracting over configurations
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,7 +71,7 @@ pub struct ServerPlugin {
     /// If disabled, replication should be started manually by inserting [`ReplicatedClient`] on the client entity.
     ///
     /// Until replication has started, the client and server can still exchange network events that are marked as
-    /// independent via [`ServerEventAppExt::make_independent`](crate::shared::event::server_event::ServerEventAppExt::make_independent).
+    /// independent via [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent).
     /// **All other events will be ignored**.
     pub replicate_after_connect: bool,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,7 +71,8 @@ pub struct ServerPlugin {
     /// If disabled, replication should be started manually by inserting [`ReplicatedClient`] on the client entity.
     ///
     /// Until replication has started, the client and server can still exchange network events that are marked as
-    /// independent via [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent).
+    /// independent via [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent)
+    /// or [`ServerTriggerAppExt::make_event_independent`](crate::shared::event::server_trigger::ServerTriggerAppExt::make_trigger_independent).
     /// **All other events will be ignored**.
     pub replicate_after_connect: bool,
 }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -34,7 +34,7 @@ impl Plugin for ServerEventPlugin {
 
         let send_or_buffer = (
             FilteredResourcesParamBuilder::new(|builder| {
-                for event in event_registry.iter_server_events() {
+                for event in event_registry.iter_all_server() {
                     builder.add_read_by_id(event.server_events_id());
                 }
             }),
@@ -49,7 +49,7 @@ impl Plugin for ServerEventPlugin {
 
         let receive = (
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_client_events() {
+                for event in event_registry.iter_all_client() {
                     builder.add_write_by_id(event.client_events_id());
                 }
             }),
@@ -74,12 +74,12 @@ impl Plugin for ServerEventPlugin {
 
         let resend_locally = (
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_server_events() {
+                for event in event_registry.iter_all_server() {
                     builder.add_write_by_id(event.server_events_id());
                 }
             }),
             FilteredResourcesMutParamBuilder::new(|builder| {
-                for event in event_registry.iter_server_events() {
+                for event in event_registry.iter_all_server() {
                     builder.add_write_by_id(event.events_id());
                 }
             }),
@@ -127,7 +127,7 @@ fn send_or_buffer(
         type_registry: &type_registry.read(),
     };
 
-    for event in event_registry.iter_server_events() {
+    for event in event_registry.iter_all_server() {
         let server_events = server_events
             .get_by_id(event.server_events_id())
             .expect("server events resource should be accessible");
@@ -165,7 +165,7 @@ fn receive(
         type_registry: &type_registry.read(),
     };
 
-    for event in event_registry.iter_client_events() {
+    for event in event_registry.iter_all_client() {
         let client_events = client_events
             .get_mut_by_id(event.client_events_id())
             .expect("client events resource should be accessible");
@@ -193,7 +193,7 @@ fn resend_locally(
     mut events: FilteredResourcesMut,
     event_registry: Res<RemoteEventRegistry>,
 ) {
-    for event in event_registry.iter_server_events() {
+    for event in event_registry.iter_all_server() {
         let server_events = server_events
             .get_mut_by_id(event.server_events_id())
             .expect("server events resource should be accessible");

--- a/src/shared/backend/replicon_channels.rs
+++ b/src/shared/backend/replicon_channels.rs
@@ -107,7 +107,7 @@ impl RepliconChannels {
 /// [`SyncRelatedAppExt::sync_related_entities`](crate::server::related_entities::SyncRelatedAppExt::sync_related_entities).
 ///
 /// Server events also have minimum required tick. For details, see the documentation on
-/// [`ServerEventAppExt::make_independent`](crate::shared::event::server_event::ServerEventAppExt::make_independent).
+/// [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent).
 ///
 /// See also [`RepliconChannels`], [`Channel`] and [corresponding section](../index.html#eventual-consistency)
 /// from the quick start guide.

--- a/src/shared/event/remote_event_registry.rs
+++ b/src/shared/event/remote_event_registry.rs
@@ -39,6 +39,10 @@ impl RemoteEventRegistry {
         self.server_events.iter_mut()
     }
 
+    pub(super) fn iter_server_triggers_mut(&mut self) -> impl Iterator<Item = &mut ServerTrigger> {
+        self.server_triggers.iter_mut()
+    }
+
     pub(crate) fn iter_all_server(&self) -> impl Iterator<Item = &ServerEvent> {
         self.server_events
             .iter()

--- a/src/shared/event/remote_event_registry.rs
+++ b/src/shared/event/remote_event_registry.rs
@@ -35,21 +35,17 @@ impl RemoteEventRegistry {
         self.client_triggers.push(trigger);
     }
 
-    pub(crate) fn iter_server_events_mut(&mut self) -> impl Iterator<Item = &mut ServerEvent> {
-        self.server_events.iter_mut().chain(
-            self.server_triggers
-                .iter_mut()
-                .map(|trigger| trigger.event_mut()),
-        )
+    pub(super) fn iter_server_events_mut(&mut self) -> impl Iterator<Item = &mut ServerEvent> {
+        self.server_events.iter_mut()
     }
 
-    pub(crate) fn iter_server_events(&self) -> impl Iterator<Item = &ServerEvent> {
+    pub(crate) fn iter_all_server(&self) -> impl Iterator<Item = &ServerEvent> {
         self.server_events
             .iter()
             .chain(self.server_triggers.iter().map(|trigger| trigger.event()))
     }
 
-    pub(crate) fn iter_client_events(&self) -> impl Iterator<Item = &ClientEvent> {
+    pub(crate) fn iter_all_client(&self) -> impl Iterator<Item = &ClientEvent> {
         self.client_events
             .iter()
             .chain(self.client_triggers.iter().map(|trigger| trigger.event()))
@@ -68,7 +64,7 @@ impl RemoteEventRegistry {
     /// See also [`ServerEventAppExt::add_server_event`](super::server_event::ServerEventAppExt::add_server_event)
     /// and [`ServerTriggerAppExt::add_server_trigger`](super::server_trigger::ServerTriggerAppExt::add_server_trigger).
     pub fn server_channel<E: Event>(&self) -> Option<usize> {
-        self.iter_server_events()
+        self.iter_all_server()
             .find(|event| event.type_id() == TypeId::of::<E>())
             .map(|event| event.channel_id())
     }
@@ -78,7 +74,7 @@ impl RemoteEventRegistry {
     /// See also [`ClientEventAppExt::add_client_event`](super::client_event::ClientEventAppExt::add_client_event)
     /// and [`ClientTriggerAppExt::add_client_trigger`](super::client_trigger::ClientTriggerAppExt::add_client_trigger).
     pub fn client_channel<E: Event>(&self) -> Option<usize> {
-        self.iter_client_events()
+        self.iter_all_client()
             .find(|event| event.type_id() == TypeId::of::<E>())
             .map(|event| event.channel_id())
     }

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -218,7 +218,7 @@ pub(crate) struct ServerEvent {
     /// Events like a chat message event do not have to wait for replication to
     /// be synced. If set to `true`, the event will always be applied
     /// immediately.
-    independent: bool,
+    pub(super) independent: bool,
 
     /// ID of [`Events<E>`].
     events_id: ComponentId,

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -49,7 +49,7 @@ pub trait ServerEventAppExt {
     /// Calling [`App::add_event`] is not necessary. Can used for regular events that were
     /// previously registered.
     ///
-    /// Unlike client events, server events are tied to replication. See [`Self::make_independent`]
+    /// Unlike client events, server events are tied to replication. See [`Self::make_event_independent`]
     /// for more details.
     ///
     /// See also [`ServerTriggerAppExt::add_server_trigger`](super::server_trigger::ServerTriggerAppExt::add_server_trigger),
@@ -160,7 +160,7 @@ pub trait ServerEventAppExt {
     /// very difficult to debug!
     ///
     /// </div>
-    fn make_independent<E: Event>(&mut self) -> &mut Self;
+    fn make_event_independent<E: Event>(&mut self) -> &mut Self;
 }
 
 impl ServerEventAppExt for App {
@@ -180,7 +180,7 @@ impl ServerEventAppExt for App {
         self
     }
 
-    fn make_independent<E: Event>(&mut self) -> &mut Self {
+    fn make_event_independent<E: Event>(&mut self) -> &mut Self {
         let events_id = self
             .world()
             .components()

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -288,10 +288,6 @@ impl ServerEvent {
         self.queue_id
     }
 
-    pub(super) fn is_independent(&self) -> bool {
-        self.independent
-    }
-
     pub(super) fn channel_id(&self) -> usize {
         self.channel_id
     }
@@ -337,7 +333,7 @@ impl ServerEvent {
         for ToClients { event, mode } in events.get_cursor().read(events) {
             debug!("sending event `{}` with `{mode:?}`", any::type_name::<E>());
 
-            if self.is_independent() {
+            if self.independent {
                 unsafe {
                     self.send_independent_event::<E, I>(ctx, event, mode, server, clients)
                         .expect("independent server event should be serializable");
@@ -484,7 +480,7 @@ impl ServerEvent {
         }
 
         for mut message in client.receive(self.channel_id) {
-            if !self.is_independent() {
+            if !self.independent {
                 let tick = match postcard_utils::from_buf(&mut message) {
                     Ok(tick) => tick,
                     Err(e) => {

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -160,6 +160,8 @@ pub trait ServerEventAppExt {
     /// very difficult to debug!
     ///
     /// </div>
+    ///
+    /// See also [`ServerTriggerAppExt::make_event_independent`](crate::shared::event::server_trigger::ServerTriggerAppExt::make_trigger_independent).
     fn make_event_independent<E: Event>(&mut self) -> &mut Self;
 }
 

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -453,7 +453,7 @@ fn independent() {
             }),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
-        .make_independent::<TestEvent>()
+        .make_event_independent::<TestEvent>()
         .finish();
     }
 
@@ -555,7 +555,7 @@ fn independent_before_started_replication() {
             }),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
-        .make_independent::<TestEvent>()
+        .make_event_independent::<TestEvent>()
         .finish();
     }
 

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -242,12 +242,12 @@ fn independent() {
     client_app.update();
 
     let reader = client_app.world().resource::<TriggerReader<TestEvent>>();
-    assert!(reader.entities.is_empty());
+    assert!(reader.events.is_empty());
 
     let independent_reader = client_app
         .world()
         .resource::<TriggerReader<IndependentEvent>>();
-    assert_eq!(independent_reader.entities, [Entity::PLACEHOLDER]);
+    assert_eq!(independent_reader.events.len(), 1);
 }
 
 #[derive(Event, Serialize, Deserialize, Clone)]

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -1,6 +1,7 @@
 use bevy::{ecs::entity::MapEntities, prelude::*, time::TimePlugin};
 use bevy_replicon::{
-    prelude::*, shared::server_entity_map::ServerEntityMap, test_app::ServerTestAppExt,
+    client::ServerUpdateTick, prelude::*, shared::server_entity_map::ServerEntityMap,
+    test_app::ServerTestAppExt,
 };
 use serde::{Deserialize, Serialize};
 
@@ -189,6 +190,52 @@ fn local_resending() {
 
     let reader = app.world().resource::<TriggerReader<TestEvent>>();
     assert_eq!(reader.entities.len(), 1);
+}
+
+#[test]
+fn independent() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            RepliconPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .add_server_trigger::<TestEvent>(Channel::Ordered)
+        .make_trigger_independent::<TestEvent>()
+        .finish();
+    }
+    client_app.init_resource::<TriggerReader<TestEvent>>();
+
+    server_app.connect_client(&mut client_app);
+
+    // Spawn entity to trigger world change.
+    server_app.world_mut().spawn(Replicated);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    // Artificially reset the update tick.
+    // Normal events would be queued and not triggered yet,
+    // but our independent event should be triggered immediately.
+    *client_app.world_mut().resource_mut::<ServerUpdateTick>() = Default::default();
+
+    server_app.world_mut().server_trigger(ToClients {
+        mode: SendMode::Broadcast,
+        event: TestEvent,
+    });
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let reader = client_app.world().resource::<TriggerReader<TestEvent>>();
+    assert_eq!(reader.entities, [Entity::PLACEHOLDER]);
 }
 
 #[derive(Event, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
I noticed that `make_independent` doesn't work for triggers. So in this PR I renamed it into `make_event_independent` and added `make_trigger_independent`.

Each commit is a separate change.