### PR TITLE
Implement authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Authorization system. By default we just verify compatibility between client and server, but it's customizable via `RepliconSharedPlugin::auth_method`.
 - Configurable `SendRate` for deterministic replication. Use `SendRate::Once` to send only the initial value, or `SendRate::Periodic` to only sync the state periodically.
 - `AppRuleExt::replicate_with_priority` to configure replication rule priority.
 - `DisconnectRequest` event to queue a disconnection for a specific client on the server.
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `WriteCtx::commands`. You can now insert and remove components directly through `DeferredEntity`.
 - `RepliconClient::receive` and `RepliconServer::receive` are now private since they should only be called internally by Replicon.
+- `ServerPlugin::replicate_after_connect`. Use `RepliconSharedPlugin::auth_method` with `AuthMethod::Custom` instead.
 - Deprecated methods.
 
 ## [0.33.0] - 2025-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AppRuleExt::replicate_with` now accepts `IntoReplicationRule` trait that allows to define rules with multiple components.
 - Rename `GroupReplication` into `BundleReplication`.
+- Rename `ReplicatedClient` into `AuthorizedClient`.
 - Rename `AppRuleExt::replicate_group` into `AppRuleExt::replicate_bundle`.
 - Rename `replication_registry::despawn_recursive` into `replication_registry::despawn`.
 - Rename `shared::event::trigger` module into `shared::event::remote_targets`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you are new to networking, see [glossary](https://gist.github.com/maniwani/f9
 
 - Automatic world replication.
 - Remote events and triggers.
+- Authorization support.
 - Control over client visibility of entities and events.
 - Specify which entities should be replicated in sync using ECS relationships.
 - Replication into scene to save server state.

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -26,7 +26,9 @@ fn connect_disconnect() {
 
     assert!(server_app.world().resource::<RepliconServer>().is_running());
 
-    let mut clients = server_app.world_mut().query::<&ConnectedClient>();
+    let mut clients = server_app
+        .world_mut()
+        .query::<(&ConnectedClient, &AuthorizedClient)>();
     assert_eq!(clients.iter(server_app.world()).len(), 1);
 
     let replicon_client = client_app.world().resource::<RepliconClient>();
@@ -241,6 +243,8 @@ fn setup(server_app: &mut App, client_app: &mut App) -> io::Result<()> {
     server_app.insert_resource(server_socket);
     client_app.insert_resource(client_socket);
 
+    server_app.update();
+    client_app.update();
     server_app.update();
     client_app.update();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,12 @@ To enable logging, you can temporarily set `RUST_LOG` environment variable to `b
 RUST_LOG=bevy_replicon=debug cargo run
 ```
 
+You can also filter by specific module like this:
+
+```bash
+RUST_LOG=bevy_replicon::shared::protocol=debug cargo run
+```
+
 The exact method depends on the OS shell.
 
 Alternatively you can configure `LogPlugin` from Bevy to make it permanent.

--- a/src/server.rs
+++ b/src/server.rs
@@ -177,7 +177,7 @@ impl Plugin for ServerPlugin {
             AuthMethod::ProtocolCheck => {
                 app.add_observer(check_protocol);
             }
-            AuthMethod::Disabled => {
+            AuthMethod::None => {
                 app.register_required_components::<ConnectedClient, AuthorizedClient>();
             }
             AuthMethod::Custom => (),

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,26 +21,35 @@ use bevy::{
 use bytes::Buf;
 use log::{debug, trace};
 
-use crate::shared::{
-    backend::{
-        connected_client::ConnectedClient,
-        replicon_channels::{ClientChannel, RepliconChannels},
-        replicon_server::RepliconServer,
-    },
-    common_conditions::*,
-    event::server_event::BufferedServerEvents,
-    postcard_utils,
-    replication::{
-        Replicated,
-        client_ticks::{ClientTicks, EntityBuffer},
-        replication_registry::{
-            ReplicationRegistry, component_fns::ComponentFns, ctx::SerializeCtx,
-            rule_fns::UntypedRuleFns,
+use crate::{
+    prelude::ServerTriggerExt,
+    shared::{
+        AuthMethod,
+        backend::{
+            DisconnectRequest,
+            connected_client::ConnectedClient,
+            replicon_channels::{ClientChannel, RepliconChannels},
+            replicon_server::RepliconServer,
         },
-        replication_rules::{ComponentRule, ReplicationRules},
-        track_mutate_messages::TrackMutateMessages,
+        common_conditions::*,
+        event::{
+            client_event::FromClient,
+            server_event::{BufferedServerEvents, SendMode, ToClients},
+        },
+        postcard_utils,
+        protocol::{ProtocolHash, ProtocolMismatch},
+        replication::{
+            Replicated,
+            client_ticks::{ClientTicks, EntityBuffer},
+            replication_registry::{
+                ReplicationRegistry, component_fns::ComponentFns, ctx::SerializeCtx,
+                rule_fns::UntypedRuleFns,
+            },
+            replication_rules::{ComponentRule, ReplicationRules},
+            track_mutate_messages::TrackMutateMessages,
+        },
+        replicon_tick::RepliconTick,
     },
-    replicon_tick::RepliconTick,
 };
 use client_entity_map::ClientEntityMap;
 use client_visibility::{ClientVisibility, Visibility};
@@ -65,16 +74,6 @@ pub struct ServerPlugin {
     ///
     /// In practice mutations will live at least `mutations_timeout`, and at most `2*mutations_timeout`.
     pub mutations_timeout: Duration,
-
-    /// If enabled, replication will be started automatically after connection.
-    ///
-    /// If disabled, replication should be started manually by inserting [`ReplicatedClient`] on the client entity.
-    ///
-    /// Until replication has started, the client and server can still exchange network events that are marked as
-    /// independent via [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent)
-    /// or [`ServerTriggerAppExt::make_event_independent`](crate::shared::event::server_trigger::ServerTriggerAppExt::make_trigger_independent).
-    /// **All other events will be ignored**.
-    pub replicate_after_connect: bool,
 }
 
 impl Default for ServerPlugin {
@@ -83,7 +82,6 @@ impl Default for ServerPlugin {
             tick_policy: TickPolicy::MaxTickRate(30),
             visibility_policy: Default::default(),
             mutations_timeout: Duration::from_secs(10),
-            replicate_after_connect: true,
         }
     }
 }
@@ -162,19 +160,27 @@ impl Plugin for ServerPlugin {
         match self.visibility_policy {
             VisibilityPolicy::All => {}
             VisibilityPolicy::Blacklist => {
-                app.register_required_components_with::<ReplicatedClient, _>(
+                app.register_required_components_with::<AuthorizedClient, _>(
                     ClientVisibility::blacklist,
                 );
             }
             VisibilityPolicy::Whitelist => {
-                app.register_required_components_with::<ReplicatedClient, _>(
+                app.register_required_components_with::<AuthorizedClient, _>(
                     ClientVisibility::whitelist,
                 );
             }
         }
 
-        if self.replicate_after_connect {
-            app.register_required_components::<ConnectedClient, ReplicatedClient>();
+        let auth_method = app.world().resource::<AuthMethod>();
+        debug!("using authorization method `{auth_method:?}`");
+        match auth_method {
+            AuthMethod::ProtocolCheck => {
+                app.add_observer(check_protocol);
+            }
+            AuthMethod::Disabled => {
+                app.register_required_components::<ConnectedClient, AuthorizedClient>();
+            }
+            AuthMethod::Custom => (),
         }
     }
 
@@ -207,6 +213,32 @@ fn handle_disconnects(
 ) {
     debug!("client `{}` disconnected", trigger.target());
     server.remove_client(trigger.target());
+}
+
+fn check_protocol(
+    trigger: Trigger<FromClient<ProtocolHash>>,
+    mut commands: Commands,
+    mut events: EventWriter<DisconnectRequest>,
+    protocol: Res<ProtocolHash>,
+) {
+    if **trigger == *protocol {
+        debug!("marking client `{}` as authorized", trigger.client_entity);
+        commands
+            .entity(trigger.client_entity)
+            .insert(AuthorizedClient);
+    } else {
+        debug!(
+            "disconnecting client `{}` due to protocol mismatch (client: `{:?}`, server: `{:?}`)",
+            trigger.client_entity, **trigger, *protocol
+        );
+        commands.server_trigger(ToClients {
+            mode: SendMode::Direct(trigger.client_entity),
+            event: ProtocolMismatch,
+        });
+        events.write(DisconnectRequest {
+            client_entity: trigger.client_entity,
+        });
+    }
 }
 
 fn cleanup_acks(
@@ -759,15 +791,17 @@ pub enum TickPolicy {
     Manual,
 }
 
-/// Marker that enables replication for client entity.
+/// Marker that enables replication and all events for a client.
 ///
-/// If [`ServerPlugin::replicate_after_connect`] is set, it will be marked as required
-/// for [`ConnectedClient`].
+/// Until authorization happened, the client and server can still exchange network events that are marked as
+/// independent via [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent)
+/// or [`ServerTriggerAppExt::make_trigger_independent`](crate::shared::event::server_trigger::ServerTriggerAppExt::make_trigger_independent).
+/// **All other events will be ignored**.
 ///
-/// Pausing replication by temporarily removing this component is not supported.
+/// See also [`ConnectedClient`] and [`RepliconSharedPlugin::auth_method`](crate::shared::RepliconSharedPlugin::auth_method).
 #[derive(Component, Default)]
 #[require(ClientTicks, ClientEntityMap, Updates, Mutations)]
-pub struct ReplicatedClient;
+pub struct AuthorizedClient;
 
 /// Controls how visibility will be managed via [`ClientVisibility`].
 #[derive(Default, Debug, Clone, Copy)]

--- a/src/server/client_entity_map.rs
+++ b/src/server/client_entity_map.rs
@@ -19,7 +19,7 @@ be inserted into the client's [`ServerEntityMap`](crate::shared::server_entity_m
 to propagate the mappings ensures any replication messages related to the pre-mapped
 server entities will synchronize with updating the client's [`ServerEntityMap`](crate::shared::server_entity_map::ServerEntityMap).
 
-It's a required component for [`ReplicatedClient`](super::ReplicatedClient). So if you want to map entities before enabling
+It's a required component for [`AuthorizedClient`](super::AuthorizedClient). So if you want to map entities before enabling
 replication, you need to insert this component, already filled with entities.
 
 ### Examples
@@ -64,6 +64,8 @@ client entity.
 
 If client's original entity is not found, a new entity will be spawned on the client,
 just the same as when no client entity is provided.
+
+See also [`RepliconSharedPlugin::auth_method`](crate::shared::RepliconSharedPlugin::auth_method).
 **/
 #[derive(Debug, Default, Deref, Component)]
 pub struct ClientEntityMap(pub(super) Vec<(Entity, Entity)>);

--- a/src/server/client_visibility.rs
+++ b/src/server/client_visibility.rs
@@ -6,7 +6,7 @@ use bevy::{
 
 /// Entity visibility settings for a client.
 ///
-/// Dynamically marked as required for [`ReplicatedClient`](super::ReplicatedClient)
+/// Dynamically marked as required for [`AuthorizedClient`](super::AuthorizedClient)
 /// if [`ServerPlugin::visibility_policy`](super::ServerPlugin::visibility_policy)
 /// is not set to [`VisibilityPolicy::All`](super::VisibilityPolicy::All).
 ///

--- a/src/server/removal_buffer.rs
+++ b/src/server/removal_buffer.rs
@@ -167,8 +167,12 @@ mod tests {
     use super::*;
     use crate::{
         server,
-        shared::replication::{
-            Replicated, replication_registry::ReplicationRegistry, replication_rules::AppRuleExt,
+        shared::{
+            protocol::ProtocolHasher,
+            replication::{
+                Replicated, replication_registry::ReplicationRegistry,
+                replication_rules::AppRuleExt,
+            },
         },
     };
 
@@ -195,7 +199,8 @@ mod tests {
     #[test]
     fn component() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
@@ -221,7 +226,8 @@ mod tests {
     #[test]
     fn bundle() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
@@ -247,7 +253,8 @@ mod tests {
     #[test]
     fn part_of_bundle() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
@@ -273,7 +280,8 @@ mod tests {
     #[test]
     fn bundle_with_subset() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
@@ -300,7 +308,8 @@ mod tests {
     #[test]
     fn part_of_bundle_with_subset() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)
@@ -327,7 +336,8 @@ mod tests {
     #[test]
     fn despawn() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .init_resource::<RemovalBuffer>()
             .add_systems(PostUpdate, server::buffer_removals)

--- a/src/server/server_world.rs
+++ b/src/server/server_world.rs
@@ -228,15 +228,17 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::shared::replication::{
-        replication_registry::ReplicationRegistry, replication_rules::AppRuleExt,
+    use crate::shared::{
+        protocol::ProtocolHasher,
+        replication::{replication_registry::ReplicationRegistry, replication_rules::AppRuleExt},
     };
 
     #[test]
     #[should_panic]
     fn query_after() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<Transform>()
             .add_systems(Update, |_: ServerWorld, _: Query<&mut Transform>| {});
@@ -248,7 +250,8 @@ mod tests {
     #[should_panic]
     fn query_before() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<Transform>()
             .add_systems(Update, |_: Query<&mut Transform>, _: ServerWorld| {});
@@ -259,7 +262,8 @@ mod tests {
     #[test]
     fn readonly_query() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<Transform>()
             .add_systems(Update, |_: ServerWorld, _: Query<&Transform>| {});
@@ -270,7 +274,8 @@ mod tests {
     #[test]
     fn replicate_after_system() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .add_systems(Update, |world: ServerWorld| {
                 assert_eq!(world.state.rules.len(), 1);
@@ -311,7 +316,8 @@ mod tests {
     #[test]
     fn not_replicated() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<ComponentA>()
             .add_systems(Update, |world: ServerWorld| {
@@ -327,7 +333,8 @@ mod tests {
     #[test]
     fn component() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<ComponentA>()
             .add_systems(Update, |world: ServerWorld| {
@@ -343,7 +350,8 @@ mod tests {
     #[test]
     fn bundle() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate_bundle::<(ComponentA, ComponentB)>()
             .add_systems(Update, |world: ServerWorld| {
@@ -359,7 +367,8 @@ mod tests {
     #[test]
     fn part_of_bundle() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate_bundle::<(ComponentA, ComponentB)>()
             .add_systems(Update, |world: ServerWorld| {
@@ -375,7 +384,8 @@ mod tests {
     #[test]
     fn bundle_with_subset() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<ComponentA>()
             .replicate_bundle::<(ComponentA, ComponentB)>()
@@ -392,7 +402,8 @@ mod tests {
     #[test]
     fn bundle_with_multiple_subsets() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate::<ComponentA>()
             .replicate::<ComponentB>()
@@ -410,7 +421,8 @@ mod tests {
     #[test]
     fn bundle_with_overlap() {
         let mut app = App::new();
-        app.init_resource::<ReplicationRules>()
+        app.init_resource::<ProtocolHasher>()
+            .init_resource::<ReplicationRules>()
             .init_resource::<ReplicationRegistry>()
             .replicate_bundle::<(ComponentA, ComponentC)>()
             .replicate_bundle::<(ComponentA, ComponentB)>()

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -196,7 +196,7 @@ pub enum AuthMethod {
     /// required component for [`ConnectedClient`].
     ///
     /// Use with caution.
-    Disabled,
+    None,
 
     /// Disable automatic insertion.
     ///

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -3,6 +3,7 @@ pub mod common_conditions;
 pub mod entity_serde;
 pub mod event;
 pub mod postcard_utils;
+pub mod protocol;
 pub mod replication;
 pub mod replicon_tick;
 pub mod server_entity_map;
@@ -12,16 +13,127 @@ use bevy::prelude::*;
 use backend::{
     DisconnectRequest,
     connected_client::{ConnectedClient, NetworkIdMap, NetworkStats},
-    replicon_channels::RepliconChannels,
+    replicon_channels::{Channel, RepliconChannels},
 };
-use event::remote_event_registry::RemoteEventRegistry;
+use event::{
+    client_trigger::ClientTriggerAppExt, remote_event_registry::RemoteEventRegistry,
+    server_trigger::ServerTriggerAppExt,
+};
+use protocol::{ProtocolHash, ProtocolHasher, ProtocolMismatch};
 use replication::{
     Replicated, command_markers::CommandMarkers, replication_registry::ReplicationRegistry,
     replication_rules::ReplicationRules, track_mutate_messages::TrackMutateMessages,
 };
 
-/// Initializes types and resources needed for both client and server.
-pub struct RepliconSharedPlugin;
+/// Initializes types, resources and events needed for both client and server.
+#[derive(Default)]
+pub struct RepliconSharedPlugin {
+    /**
+    Configures the authorization process.
+
+    # Examples
+
+    Custom authorization to send chess square entities. The board is deterministically spawned
+    on both client and server, and we wire their IDs to receive replication without sending the
+    entire board data through the network. We re-use [`ProtocolMismatch`] that is registered
+    only with [`AuthMethod::ProtocolCheck`], but it could be any event.
+
+    ```
+    use bevy::prelude::*;
+    use bevy_replicon::prelude::*;
+    use serde::{Deserialize, Serialize};
+
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        RepliconPlugins.set(RepliconSharedPlugin {
+            auth_method: AuthMethod::Custom,
+        }),
+    ))
+    .add_client_trigger::<ClientInfo>(Channel::Ordered)
+    .add_server_trigger::<ProtocolMismatch>(Channel::Unreliable)
+    .make_trigger_independent::<ProtocolMismatch>() // Let client receive it without replication.
+    .add_observer(start_game)
+    .add_systems(Update, send_info.run_if(client_just_connected));
+
+    fn send_info(
+        mut commands: Commands,
+        protocol: Res<ProtocolHash>,
+        squares: Query<(Entity, &Square)>,
+    ) {
+        // Sort deterministically to enable matching them on the server.
+        let mut squares: Vec<_> = squares.iter().collect();
+        squares.sort_by(|(_, a), (_, b)| (a.x, a.y).cmp(&(b.x, b.y)));
+
+        let info = ClientInfo {
+            protocol: *protocol,
+            squares: squares.into_iter().map(|(entity, _)| entity).collect(),
+        };
+        commands.client_trigger(info);
+    }
+
+    fn start_game(
+        trigger: Trigger<FromClient<ClientInfo>>,
+        mut commands: Commands,
+        mut events: EventWriter<DisconnectRequest>,
+        protocol: Res<ProtocolHash>,
+        squares: Query<(Entity, &Square)>,
+    ) {
+        // Since we using custom authorization,
+        // we need to verify the protocol manually.
+        if trigger.protocol != *protocol {
+            // Notify client about the problem. No delivery
+            // guarantee since we disconnect after sending.
+            commands.server_trigger(ToClients {
+                mode: SendMode::Direct(trigger.client_entity),
+                event: ProtocolMismatch,
+            });
+            events.write(DisconnectRequest {
+                client_entity: trigger.client_entity,
+            });
+        }
+
+        // Sort local square entities to match them with the received.
+        let mut squares: Vec<_> = squares.iter().collect();
+        squares.sort_by(|(_, a), (_, b)| (a.x, a.y).cmp(&(b.x, b.y)));
+
+        // This map is a required component for `AuthorizedClient`.
+        // By default it's empty, but we can initialize it with the
+        // received entities.
+        let mut entity_map = ClientEntityMap::default();
+        for (&server_entity, &client_entity) in squares
+            .iter()
+            .map(|(entity, _)| entity)
+            .zip(&trigger.squares)
+        {
+            entity_map.insert(server_entity, client_entity);
+        }
+
+        // Manually mark client as authorized and insert mappings.
+        commands
+            .entity(trigger.client_entity)
+            .insert((AuthorizedClient, entity_map));
+
+        // Run other commands to start the game...
+    }
+
+    /// A client trigger with protocol information and client's chess board entities.
+    #[derive(Event, Serialize, Deserialize)]
+    struct ClientInfo {
+        protocol: ProtocolHash,
+        squares: Vec<Entity>,
+    }
+
+    /// A chessboard square.
+    #[derive(Component, Serialize, Deserialize)]
+    struct Square {
+        x: u8,
+        y: u8,
+    }
+    ```
+    **/
+    pub auth_method: AuthMethod,
+}
 
 impl Plugin for RepliconSharedPlugin {
     fn build(&self, app: &mut App) {
@@ -29,6 +141,7 @@ impl Plugin for RepliconSharedPlugin {
             .register_type::<ConnectedClient>()
             .register_type::<NetworkIdMap>()
             .register_type::<NetworkStats>()
+            .init_resource::<ProtocolHasher>()
             .init_resource::<NetworkIdMap>()
             .init_resource::<TrackMutateMessages>()
             .init_resource::<RepliconChannels>()
@@ -36,7 +149,23 @@ impl Plugin for RepliconSharedPlugin {
             .init_resource::<ReplicationRules>()
             .init_resource::<CommandMarkers>()
             .init_resource::<RemoteEventRegistry>()
+            .insert_resource(self.auth_method)
             .add_event::<DisconnectRequest>();
+
+        if self.auth_method == AuthMethod::ProtocolCheck {
+            app.add_client_trigger::<ProtocolHash>(Channel::Ordered)
+                .add_server_trigger::<ProtocolMismatch>(Channel::Unreliable)
+                .make_trigger_independent::<ProtocolMismatch>();
+        }
+    }
+
+    fn finish(&self, app: &mut App) {
+        let protocol_hasher = app
+            .world_mut()
+            .remove_resource::<ProtocolHasher>()
+            .expect("protocol hasher should be initialized at the plugin build");
+
+        app.world_mut().insert_resource(protocol_hasher.finish());
     }
 }
 
@@ -46,3 +175,32 @@ impl Plugin for RepliconSharedPlugin {
 ///
 /// See also [`ToClients`](event::server_event::ToClients) and [`FromClient`](event::client_event::FromClient) events.
 pub const SERVER: Entity = Entity::PLACEHOLDER;
+
+/// Configures the insertion of [`AuthorizedClient`](crate::server::AuthorizedClient).
+///
+/// Can be set via [`RepliconSharedPlugin::auth_method`].
+#[derive(Resource, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMethod {
+    /// Wait for receiving [`ProtocolHash`] event from the client.
+    ///
+    /// - If the hash differs from the server's, the client will be notified with
+    ///   a [`ProtocolMismatch`] event and disconnected.
+    /// - If the hash matches, the [`AuthorizedClient`](crate::server::AuthorizedClient)
+    ///   component will be inserted.
+    #[default]
+    ProtocolCheck,
+
+    /// Consider all connected clients immediately authorized.
+    ///
+    /// [`AuthorizedClient`](crate::server::AuthorizedClient) will be configured as a
+    /// required component for [`ConnectedClient`].
+    ///
+    /// Use with caution.
+    Disabled,
+
+    /// Disable automatic insertion.
+    ///
+    /// The user is responsible for manually inserting [`AuthorizedClient`](crate::server::AuthorizedClient)
+    /// on the server.
+    Custom,
+}

--- a/src/shared/backend/connected_client.rs
+++ b/src/shared/backend/connected_client.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// </div>
 ///
-/// See also [`ReplicatedClient`](crate::server::ReplicatedClient).
+/// See also [`AuthorizedClient`](crate::server::AuthorizedClient).
 #[derive(Component, Reflect)]
 #[require(Name::new("Connected client"), NetworkStats)]
 pub struct ConnectedClient {

--- a/src/shared/event/client_event.rs
+++ b/src/shared/event/client_event.rs
@@ -149,8 +149,6 @@ impl ClientEventAppExt for App {
         serialize: EventSerializeFn<ClientSendCtx, E>,
         deserialize: EventDeserializeFn<ServerReceiveCtx, E>,
     ) -> &mut Self {
-        debug!("registering event `{}`", any::type_name::<E>());
-
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
             .add_client_event::<E>();

--- a/src/shared/event/client_event.rs
+++ b/src/shared/event/client_event.rs
@@ -22,6 +22,7 @@ use crate::shared::{
         replicon_server::RepliconServer,
     },
     postcard_utils,
+    protocol::ProtocolHasher,
 };
 
 /// An extension trait for [`App`] for creating client events.
@@ -149,6 +150,10 @@ impl ClientEventAppExt for App {
         deserialize: EventDeserializeFn<ServerReceiveCtx, E>,
     ) -> &mut Self {
         debug!("registering event `{}`", any::type_name::<E>());
+
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .add_client_event::<E>();
 
         let event_fns = EventFns::new(serialize, deserialize);
         let event = ClientEvent::new(self, channel, event_fns);

--- a/src/shared/event/client_trigger.rs
+++ b/src/shared/event/client_trigger.rs
@@ -12,7 +12,9 @@ use super::{
     remote_event_registry::RemoteEventRegistry,
     remote_targets::RemoteTargets,
 };
-use crate::shared::{backend::replicon_channels::Channel, entity_serde, postcard_utils};
+use crate::shared::{
+    backend::replicon_channels::Channel, entity_serde, postcard_utils, protocol::ProtocolHasher,
+};
 
 /// An extension trait for [`App`] for creating client triggers.
 ///
@@ -74,6 +76,10 @@ impl ClientTriggerAppExt for App {
         deserialize: EventDeserializeFn<ServerReceiveCtx, E>,
     ) -> &mut Self {
         debug!("registering trigger `{}`", any::type_name::<E>());
+
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .add_client_trigger::<E>();
 
         let event_fns = EventFns::new(serialize, deserialize)
             .with_outer(trigger_serialize, trigger_deserialize);

--- a/src/shared/event/client_trigger.rs
+++ b/src/shared/event/client_trigger.rs
@@ -75,8 +75,6 @@ impl ClientTriggerAppExt for App {
         serialize: EventSerializeFn<ClientSendCtx, E>,
         deserialize: EventDeserializeFn<ServerReceiveCtx, E>,
     ) -> &mut Self {
-        debug!("registering trigger `{}`", any::type_name::<E>());
-
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
             .add_client_trigger::<E>();

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -817,7 +817,7 @@ impl BufferedServerEvents {
                                 event.send(server, client_entity, ticks)?;
                             } else {
                                 debug!(
-                                    "ignoring broadcast for channel {} for non-replicated client `{client_entity}`",
+                                    "ignoring broadcast for channel {} for non-authorized client `{client_entity}`",
                                     event.channel_id
                                 );
                             }
@@ -834,7 +834,7 @@ impl BufferedServerEvents {
                                 event.send(server, client_entity, ticks)?;
                             } else {
                                 debug!(
-                                    "ignoring broadcast except `{entity}` for channel {} for non-replicated client `{client_entity}`",
+                                    "ignoring broadcast except `{entity}` for channel {} for non-authorized client `{client_entity}`",
                                     event.channel_id
                                 );
                             }
@@ -847,7 +847,7 @@ impl BufferedServerEvents {
                                     event.send(server, client_entity, ticks)?;
                                 } else {
                                     error!(
-                                        "ignoring direct event for non-replicated client `{client_entity}`, \
+                                        "ignoring direct event for non-authorized client `{client_entity}`, \
                                          mark it as independent to allow this"
                                     );
                                 }

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -31,6 +31,7 @@ use crate::shared::{
         replicon_server::RepliconServer,
     },
     postcard_utils,
+    protocol::ProtocolHasher,
     replication::client_ticks::ClientTicks,
     replicon_tick::RepliconTick,
 };
@@ -173,6 +174,10 @@ impl ServerEventAppExt for App {
         deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
     ) -> &mut Self {
         debug!("registering event `{}`", any::type_name::<E>());
+
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .add_server_event::<E>();
 
         let event_fns = EventFns::new(serialize, deserialize);
         let event = ServerEvent::new(self, channel, event_fns);

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -173,8 +173,6 @@ impl ServerEventAppExt for App {
         serialize: EventSerializeFn<ServerSendCtx, E>,
         deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
     ) -> &mut Self {
-        debug!("registering event `{}`", any::type_name::<E>());
-
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
             .add_server_event::<E>();

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -186,6 +186,10 @@ impl ServerEventAppExt for App {
     }
 
     fn make_event_independent<E: Event>(&mut self) -> &mut Self {
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .make_event_independent::<E>();
+
         let events_id = self
             .world()
             .components()

--- a/src/shared/event/server_trigger.rs
+++ b/src/shared/event/server_trigger.rs
@@ -91,6 +91,10 @@ impl ServerTriggerAppExt for App {
     }
 
     fn make_trigger_independent<E: Event>(&mut self) -> &mut Self {
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .make_trigger_independent::<E>();
+
         let events_id = self
             .world()
             .components()

--- a/src/shared/event/server_trigger.rs
+++ b/src/shared/event/server_trigger.rs
@@ -12,7 +12,9 @@ use super::{
     remote_targets::RemoteTargets,
     server_event::{self, ServerEvent, ToClients},
 };
-use crate::shared::{backend::replicon_channels::Channel, entity_serde, postcard_utils};
+use crate::shared::{
+    backend::replicon_channels::Channel, entity_serde, postcard_utils, protocol::ProtocolHasher,
+};
 
 /// An extension trait for [`App`] for creating server triggers.
 ///
@@ -76,6 +78,10 @@ impl ServerTriggerAppExt for App {
         deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
     ) -> &mut Self {
         debug!("registering trigger `{}`", any::type_name::<E>());
+
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .add_server_trigger::<E>();
 
         let event_fns = EventFns::new(serialize, deserialize)
             .with_outer(trigger_serialize, trigger_deserialize);

--- a/src/shared/event/server_trigger.rs
+++ b/src/shared/event/server_trigger.rs
@@ -77,8 +77,6 @@ impl ServerTriggerAppExt for App {
         serialize: EventSerializeFn<ServerSendCtx, E>,
         deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
     ) -> &mut Self {
-        debug!("registering trigger `{}`", any::type_name::<E>());
-
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
             .add_server_trigger::<E>();

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -1,0 +1,168 @@
+use core::{
+    any,
+    hash::{BuildHasher, Hash, Hasher},
+};
+
+use bevy::{
+    platform::hash::{DefaultHasher, FixedHasher},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+
+/// Hashes all protocol registrations to calculate [`ProtocolHash`].
+///
+/// The hash is computed using type names and their use in the protocol. We can't detect
+/// things like different function registrations because there is no portable way of
+/// doing so. But this at least prevents users from common mistakes such as using
+/// different registration order or accidentally registering different things on
+/// the client and server, which are very difficult to debug.
+///
+/// You can include custom data (e.g., a game version) via [`Self::add_custom`].
+///
+/// Only available during the [`Plugin::build`] stage. Computes [`ProtocolHash`] resource.
+#[derive(Resource)]
+pub struct ProtocolHasher(DefaultHasher);
+
+impl ProtocolHasher {
+    /// Adds custom data to the protocol hash calculation.
+    ///
+    /// # Examples
+    ///
+    /// Include a game version.
+    ///
+    /// ```
+    /// use bevy::prelude::*;
+    /// use bevy_replicon::prelude::*;
+    /// let mut app = App::new();
+    /// app.add_plugins((MinimalPlugins, RepliconPlugins));
+    ///
+    /// // Should be called before `app.run()` or `app.finish()`.
+    /// // Can also be done inside your game's plugin.
+    /// let mut hasher = app.world_mut().resource_mut::<ProtocolHasher>();
+    /// hasher.add_custom(env!("CARGO_PKG_VERSION"));
+    /// ```
+    pub fn add_custom<T: Hash>(&mut self, value: T) {
+        value.hash(&mut self.0);
+    }
+
+    pub(crate) fn add_replication_rule<R>(&mut self) {
+        self.hash::<R>(ProtocolPart::ReplicationRule);
+    }
+
+    pub(crate) fn add_client_event<E>(&mut self) {
+        self.hash::<E>(ProtocolPart::ClientEvent);
+    }
+
+    pub(crate) fn add_client_trigger<E>(&mut self) {
+        self.hash::<E>(ProtocolPart::ClientTrigger);
+    }
+
+    pub(crate) fn add_server_event<E>(&mut self) {
+        self.hash::<E>(ProtocolPart::ServerEvent);
+    }
+
+    pub(crate) fn add_server_trigger<E>(&mut self) {
+        self.hash::<E>(ProtocolPart::ServerTrigger);
+    }
+
+    fn hash<T>(&mut self, part: ProtocolPart) {
+        part.hash(&mut self.0);
+        any::type_name::<T>().hash(&mut self.0);
+    }
+
+    pub(crate) fn finish(self) -> ProtocolHash {
+        ProtocolHash(self.0.finish())
+    }
+}
+
+impl Default for ProtocolHasher {
+    fn default() -> Self {
+        Self(FixedHasher.build_hasher())
+    }
+}
+
+/// Part of protocol registration.
+///
+/// Needed to distinguish between different registrations for the same type.
+/// For example, the same type could be used for a client and a server event.
+#[derive(Hash)]
+enum ProtocolPart {
+    ReplicationRule,
+    ClientEvent,
+    ClientTrigger,
+    ServerEvent,
+    ServerTrigger,
+}
+
+/// Hash of all registered events and replication rules.
+///
+/// Used to verify compatibility between client and server.
+///
+/// Calculated by [`ProtocolHasher`] and available only after [`Plugin::finish`].
+#[derive(Resource, Event, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProtocolHash(u64);
+
+/// A server trigger to notify client for the protocol mismatch.
+///
+/// Registered and sent only if [`RepliconSharedPlugin::auth_method`](super::RepliconSharedPlugin::auth_method)
+/// set to [`AuthMethod::ProtocolCheck`](super::AuthMethod::ProtocolCheck). The server will immediately
+/// disconnect after sending it, so there is no delivery guarantee.
+#[derive(Event, Serialize, Deserialize)]
+pub struct ProtocolMismatch;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        assert_eq!(
+            ProtocolHasher::default().finish(),
+            ProtocolHasher::default().finish()
+        );
+    }
+
+    #[test]
+    fn wrong_order() {
+        let mut hasher1 = ProtocolHasher::default();
+        hasher1.add_replication_rule::<StructA>();
+        hasher1.add_replication_rule::<StructB>();
+
+        let mut hasher2 = ProtocolHasher::default();
+        hasher2.add_replication_rule::<StructB>();
+        hasher2.add_replication_rule::<StructA>();
+
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn different_parts() {
+        let mut hasher1 = ProtocolHasher::default();
+        hasher1.add_server_event::<StructA>();
+
+        let mut hasher2 = ProtocolHasher::default();
+        hasher2.add_client_event::<StructA>();
+
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn full_match() {
+        let mut hasher1 = ProtocolHasher::default();
+        let mut hasher2 = ProtocolHasher::default();
+
+        for protocol in [&mut hasher1, &mut hasher2] {
+            protocol.add_replication_rule::<StructA>();
+            protocol.add_server_event::<StructB>();
+            protocol.add_server_trigger::<StructC>();
+            protocol.add_client_event::<StructB>();
+            protocol.add_client_trigger::<StructC>();
+        }
+
+        assert_eq!(hasher1.finish(), hasher2.finish());
+    }
+
+    struct StructA;
+    struct StructB;
+    struct StructC;
+}

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -84,6 +84,16 @@ impl ProtocolHasher {
         self.hash::<E>(ProtocolPart::ServerTrigger);
     }
 
+    pub(crate) fn make_event_independent<E>(&mut self) {
+        debug!("making event `{}` independent", any::type_name::<E>());
+        self.hash::<E>(ProtocolPart::IndependentEvent);
+    }
+
+    pub(crate) fn make_trigger_independent<E>(&mut self) {
+        debug!("making trigger `{}` independent", any::type_name::<E>());
+        self.hash::<E>(ProtocolPart::IndependentTrigger);
+    }
+
     fn hash<T>(&mut self, part: ProtocolPart) {
         part.hash(&mut self.0);
         any::type_name::<T>().hash(&mut self.0);
@@ -112,6 +122,8 @@ enum ProtocolPart {
     ClientTrigger,
     ServerEvent,
     ServerTrigger,
+    IndependentEvent,
+    IndependentTrigger,
 }
 
 /// Hash of all registered events and replication rules.

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -147,6 +147,24 @@ mod tests {
     }
 
     #[test]
+    fn mismatch() {
+        let mut hasher1 = ProtocolHasher::default();
+        let mut hasher2 = ProtocolHasher::default();
+
+        for hasher in [&mut hasher1, &mut hasher2] {
+            hasher.add_replication_rule::<StructA>();
+            hasher.add_server_event::<StructB>();
+            hasher.add_server_trigger::<StructC>();
+            hasher.add_client_event::<StructB>();
+            hasher.add_client_trigger::<StructC>();
+        }
+        hasher1.add_custom(0);
+        hasher2.add_custom(1);
+
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
     fn full_match() {
         let mut hasher1 = ProtocolHasher::default();
         let mut hasher2 = ProtocolHasher::default();

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -151,12 +151,13 @@ mod tests {
         let mut hasher1 = ProtocolHasher::default();
         let mut hasher2 = ProtocolHasher::default();
 
-        for protocol in [&mut hasher1, &mut hasher2] {
-            protocol.add_replication_rule::<StructA>();
-            protocol.add_server_event::<StructB>();
-            protocol.add_server_trigger::<StructC>();
-            protocol.add_client_event::<StructB>();
-            protocol.add_client_trigger::<StructC>();
+        for hasher in [&mut hasher1, &mut hasher2] {
+            hasher.add_replication_rule::<StructA>();
+            hasher.add_server_event::<StructB>();
+            hasher.add_server_trigger::<StructC>();
+            hasher.add_client_event::<StructB>();
+            hasher.add_client_trigger::<StructC>();
+            hasher.add_custom(0);
         }
 
         assert_eq!(hasher1.finish(), hasher2.finish());

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -439,7 +439,7 @@ impl AppRuleExt for App {
 
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
-            .add_replication_rule::<R>();
+            .replicate::<R>(priority);
 
         let rule =
             self.world_mut()
@@ -459,7 +459,7 @@ impl AppRuleExt for App {
 
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
-            .add_replication_rule::<B>();
+            .replicate_bundle::<B>();
 
         let rule =
             self.world_mut()

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -1,11 +1,10 @@
-use core::{any, cmp::Reverse};
+use core::cmp::Reverse;
 
 use bevy::{
     ecs::{archetype::Archetype, component::ComponentId},
     platform::collections::HashSet,
     prelude::*,
 };
-use log::debug;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::replication_registry::{
@@ -435,8 +434,6 @@ impl AppRuleExt for App {
         priority: usize,
         rule: R,
     ) -> &mut Self {
-        debug!("registering rule for '{}'", any::type_name::<R>());
-
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
             .replicate::<R>(priority);
@@ -455,8 +452,6 @@ impl AppRuleExt for App {
     }
 
     fn replicate_bundle<B: ReplicationBundle>(&mut self) -> &mut Self {
-        debug!("registering rule for bundle '{}'", any::type_name::<B>());
-
         self.world_mut()
             .resource_mut::<ProtocolHasher>()
             .replicate_bundle::<B>();

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -104,7 +104,11 @@ impl ServerTestAppExt for App {
             .world_mut()
             .insert_resource(TestClientEntity(client_entity));
 
+        // Exchange messages to perform handshake.
+        client_app.update();
+        self.exchange_with_client(client_app);
         self.update();
+        self.exchange_with_client(client_app);
         client_app.update();
     }
 

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -29,7 +29,7 @@ fn channels() {
 
     let event_registry = app.world().resource::<RemoteEventRegistry>();
     assert_eq!(event_registry.client_channel::<NonRemoteEvent>(), None);
-    assert_eq!(event_registry.client_channel::<TestEvent>(), Some(1));
+    assert_eq!(event_registry.client_channel::<TestEvent>(), Some(2));
 }
 
 #[test]

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use bevy::prelude::*;
 use bevy_replicon::{
     prelude::*,
@@ -5,6 +7,7 @@ use bevy_replicon::{
     shared::backend::connected_client::{ConnectedClient, NetworkId, NetworkIdMap},
     test_app::ServerTestAppExt,
 };
+use serde::{Deserialize, Serialize};
 use test_log::test;
 
 #[test]
@@ -19,12 +22,38 @@ fn client_connect_disconnect() {
 
     let mut clients = server_app
         .world_mut()
-        .query_filtered::<Entity, With<ConnectedClient>>();
+        .query_filtered::<Entity, With<AuthorizedClient>>();
     assert_eq!(clients.iter(server_app.world()).len(), 1);
 
     server_app.disconnect_client(&mut client_app);
 
     assert_eq!(clients.iter(server_app.world()).len(), 0);
+}
+
+#[test]
+fn protocol_mismatch() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    server_app
+        .add_plugins((MinimalPlugins, RepliconPlugins))
+        .add_client_event::<TestEvent>(Channel::Ordered)
+        .finish();
+    client_app
+        .init_resource::<TriggerCounter<ProtocolMismatch>>()
+        .add_plugins((MinimalPlugins, RepliconPlugins))
+        .finish();
+
+    server_app.connect_client(&mut client_app);
+
+    let mut clients = server_app
+        .world_mut()
+        .query_filtered::<Entity, With<AuthorizedClient>>();
+    assert_eq!(clients.iter(server_app.world()).len(), 0);
+
+    let counter = client_app
+        .world()
+        .resource::<TriggerCounter<ProtocolMismatch>>();
+    assert_eq!(counter.triggers, 1);
 }
 
 #[test]
@@ -34,11 +63,14 @@ fn server_start_stop() {
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((
             MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                replicate_after_connect: false,
-                ..Default::default()
-            }),
+            RepliconPlugins
+                .set(RepliconSharedPlugin {
+                    auth_method: AuthMethod::Custom,
+                })
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                }),
         ))
         .finish();
     }
@@ -80,11 +112,14 @@ fn deferred_replication() {
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((
             MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                replicate_after_connect: false,
-                ..Default::default()
-            }),
+            RepliconPlugins
+                .set(RepliconSharedPlugin {
+                    auth_method: AuthMethod::Custom,
+                })
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                }),
         ))
         .finish();
     }
@@ -93,6 +128,28 @@ fn deferred_replication() {
 
     let mut clients = server_app
         .world_mut()
-        .query_filtered::<&ConnectedClient, Without<ReplicatedClient>>();
+        .query_filtered::<&ConnectedClient, Without<AuthorizedClient>>();
     assert_eq!(clients.iter(server_app.world()).count(), 1);
+}
+
+#[derive(Event, Serialize, Deserialize)]
+struct TestEvent;
+
+#[derive(Resource)]
+struct TriggerCounter<E: Event> {
+    triggers: usize,
+    marker: PhantomData<E>,
+}
+
+impl<E: Event> FromWorld for TriggerCounter<E> {
+    fn from_world(world: &mut World) -> Self {
+        world.add_observer(|_trigger: Trigger<E>, mut counter: ResMut<Self>| {
+            counter.triggers += 1;
+        });
+
+        Self {
+            triggers: 0,
+            marker: PhantomData,
+        }
+    }
 }

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -121,7 +121,7 @@ fn disabled_auth() {
     app.add_plugins((
         MinimalPlugins,
         RepliconPlugins.set(RepliconSharedPlugin {
-            auth_method: AuthMethod::Disabled,
+            auth_method: AuthMethod::None,
         }),
     ))
     .finish();

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -513,11 +513,14 @@ fn before_started_replication() {
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((
             MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                replicate_after_connect: false,
-                ..Default::default()
-            }),
+            RepliconPlugins
+                .set(RepliconSharedPlugin {
+                    auth_method: AuthMethod::Custom,
+                })
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                }),
         ))
         .replicate::<TestComponent>()
         .finish();
@@ -543,7 +546,7 @@ fn before_started_replication() {
     server_app
         .world_mut()
         .entity_mut(test_client_entity)
-        .insert(ReplicatedClient);
+        .insert(AuthorizedClient);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -560,11 +563,14 @@ fn after_started_replication() {
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((
             MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                replicate_after_connect: false,
-                ..Default::default()
-            }),
+            RepliconPlugins
+                .set(RepliconSharedPlugin {
+                    auth_method: AuthMethod::Custom,
+                })
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                }),
         ))
         .replicate::<TestComponent>()
         .finish();
@@ -576,7 +582,7 @@ fn after_started_replication() {
     server_app
         .world_mut()
         .entity_mut(test_client_entity)
-        .insert(ReplicatedClient);
+        .insert(AuthorizedClient);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -31,7 +31,7 @@ fn channels() {
 
     let event_registry = app.world().resource::<RemoteEventRegistry>();
     assert_eq!(event_registry.server_channel::<NonRemoteEvent>(), None);
-    assert_eq!(event_registry.server_channel::<TestEvent>(), Some(2));
+    assert_eq!(event_registry.server_channel::<TestEvent>(), Some(3));
 }
 
 #[test]
@@ -519,11 +519,14 @@ fn before_started_replication() {
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((
             MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                replicate_after_connect: false,
-                ..Default::default()
-            }),
+            RepliconPlugins
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                })
+                .set(RepliconSharedPlugin {
+                    auth_method: AuthMethod::Custom,
+                }),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .finish();
@@ -559,11 +562,14 @@ fn independent_before_started_replication() {
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((
             MinimalPlugins,
-            RepliconPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                replicate_after_connect: false,
-                ..Default::default()
-            }),
+            RepliconPlugins
+                .set(ServerPlugin {
+                    tick_policy: TickPolicy::EveryFrame,
+                    ..Default::default()
+                })
+                .set(RepliconSharedPlugin {
+                    auth_method: AuthMethod::Custom,
+                }),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .add_server_event::<IndependentEvent>(Channel::Ordered)


### PR DESCRIPTION
It superseds `replicate_after_connect`. By default we just verify compatibility between client and server, but it's customizable via `RepliconSharedPlugin::auth_method`.