### PR TITLE
Iterate only over client entities for events sending

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -148,7 +148,7 @@ fn send_or_buffer(
 fn send_buffered(
     mut server: ResMut<RepliconServer>,
     mut buffered_events: ResMut<BufferedServerEvents>,
-    clients: Query<(Entity, Option<&ClientTicks>)>,
+    clients: Query<(Entity, Option<&ClientTicks>), With<ConnectedClient>>,
 ) {
     buffered_events
         .send_all(&mut server, &clients)

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -799,7 +799,7 @@ impl BufferedServerEvents {
     pub(crate) fn send_all(
         &mut self,
         server: &mut RepliconServer,
-        clients: &Query<(Entity, Option<&ClientTicks>)>,
+        clients: &Query<(Entity, Option<&ClientTicks>), With<ConnectedClient>>,
     ) -> Result<()> {
         for mut set in self.buffer.drain(..) {
             for mut event in set.events.drain(..) {


### PR DESCRIPTION
I noticed that we iterated over all entities in the world.