### PR TITLE
Use `crate::prelude::*`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,31 +9,24 @@ use bytes::{Buf, Bytes};
 use log::{debug, error, trace};
 use postcard::experimental::max_size::MaxSize;
 
-use crate::shared::{
-    AuthMethod,
-    backend::{
-        replicon_channels::{ClientChannel, RepliconChannels, ServerChannel},
-        replicon_client::RepliconClient,
-    },
-    common_conditions::*,
-    entity_serde,
-    event::client_trigger::ClientTriggerExt,
-    postcard_utils,
-    protocol::{ProtocolHash, ProtocolMismatch},
-    replication::{
-        Replicated,
-        command_markers::{CommandMarkers, EntityMarkers},
-        deferred_entity::{DeferredChanges, DeferredEntity},
-        mutate_index::MutateIndex,
-        replication_registry::{
-            ReplicationRegistry,
-            ctx::{DespawnCtx, RemoveCtx, WriteCtx},
+use crate::{
+    prelude::*,
+    shared::{
+        backend::replicon_channels::{ClientChannel, ServerChannel},
+        entity_serde, postcard_utils,
+        replication::{
+            command_markers::{CommandMarkers, EntityMarkers},
+            deferred_entity::{DeferredChanges, DeferredEntity},
+            mutate_index::MutateIndex,
+            replication_registry::{
+                ReplicationRegistry,
+                ctx::{DespawnCtx, RemoveCtx, WriteCtx},
+            },
+            track_mutate_messages::TrackMutateMessages,
+            update_message_flags::UpdateMessageFlags,
         },
-        track_mutate_messages::TrackMutateMessages,
-        update_message_flags::UpdateMessageFlags,
+        server_entity_map::{EntityEntry, ServerEntityMap},
     },
-    replicon_tick::RepliconTick,
-    server_entity_map::{EntityEntry, ServerEntityMap},
 };
 use confirm_history::{ConfirmHistory, EntityReplicated};
 use server_mutate_ticks::{MutateTickReceived, ServerMutateTicks};
@@ -827,7 +820,7 @@ pub(super) struct BufferedMutate {
 /// Statistic will be collected only if the resource is present.
 /// The resource is not added by default.
 ///
-/// See also [`ClientDiagnosticsPlugin`](diagnostics::ClientDiagnosticsPlugin)
+/// See also [`ClientDiagnosticsPlugin`]
 /// for automatic integration with Bevy diagnostics.
 #[derive(Clone, Copy, Default, Resource, Debug)]
 pub struct ClientReplicationStats {

--- a/src/client/confirm_history.rs
+++ b/src/client/confirm_history.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Debug, Formatter};
 
 use bevy::prelude::*;
 
-use crate::shared::replicon_tick::RepliconTick;
+use crate::prelude::*;
 
 /// Received ticks from the server for an entity.
 ///

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -4,10 +4,7 @@ use bevy::{
     prelude::*,
 };
 
-use super::{ClientReplicationStats, ClientSet};
-use crate::shared::{
-    backend::replicon_client::RepliconClient, common_conditions::client_connected,
-};
+use crate::prelude::*;
 
 /// Plugin to write [`Diagnostics`] based on [`ClientReplicationStats`] every second.
 ///

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -1,21 +1,23 @@
-use super::{ClientSet, ServerUpdateTick};
-use crate::shared::{
-    backend::replicon_client::RepliconClient,
-    common_conditions::*,
-    event::{
-        ctx::{ClientReceiveCtx, ClientSendCtx},
-        remote_event_registry::RemoteEventRegistry,
-    },
-    server_entity_map::ServerEntityMap,
-};
 use bevy::{
     ecs::system::{FilteredResourcesMutParamBuilder, FilteredResourcesParamBuilder, ParamBuilder},
     prelude::*,
 };
 
+use super::ServerUpdateTick;
+use crate::{
+    prelude::*,
+    shared::{
+        event::{
+            ctx::{ClientReceiveCtx, ClientSendCtx},
+            remote_event_registry::RemoteEventRegistry,
+        },
+        server_entity_map::ServerEntityMap,
+    },
+};
+
 /// Sending events from a client to the server.
 ///
-/// Requires [`ClientPlugin`](super::ClientPlugin).
+/// Requires [`ClientPlugin`].
 /// Can be disabled for apps that act only as servers.
 pub struct ClientEventPlugin;
 

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -2,7 +2,7 @@ use alloc::collections::VecDeque;
 
 use bevy::prelude::*;
 
-use crate::shared::replicon_tick::RepliconTick;
+use crate::prelude::*;
 
 /// Received ticks for mutate message from server.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,7 @@ For implementation details see [`ServerChannel`](shared::backend::replicon_chann
 Typically updates are not sent every frame. Instead, they are sent at a certain interval
 to save traffic.
 
-On server current tick stored in [`RepliconTick`](shared::replicon_tick::RepliconTick) resource.
-Replication runs when this resource changes.
+On server current tick stored in [`RepliconTick`] resource. Replication runs when this resource changes.
 
 You can use [`TickPolicy::Manual`] and then add the [`increment_tick`](server::increment_tick)
 system to [`FixedUpdate`]:
@@ -654,6 +653,7 @@ pub mod prelude {
                 replication_registry::rule_fns::RuleFns,
                 replication_rules::{AppRuleExt, SendRate},
             },
+            replicon_tick::RepliconTick,
         },
     };
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,7 +1,7 @@
 use bevy::{ecs::entity::hash_map::EntityHashMap, prelude::*, scene::DynamicEntity};
 use log::debug;
 
-use crate::{Replicated, shared::replication::replication_rules::ReplicationRules};
+use crate::{prelude::*, shared::replication::replication_rules::ReplicationRules};
 
 /**
 Fills scene with all replicated entities and their components.

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,24 +22,12 @@ use bytes::Buf;
 use log::{debug, trace};
 
 use crate::{
-    prelude::ServerTriggerExt,
+    prelude::*,
     shared::{
-        AuthMethod,
-        backend::{
-            DisconnectRequest,
-            connected_client::ConnectedClient,
-            replicon_channels::{ClientChannel, RepliconChannels},
-            replicon_server::RepliconServer,
-        },
-        common_conditions::*,
-        event::{
-            client_event::FromClient,
-            server_event::{BufferedServerEvents, SendMode, ToClients},
-        },
+        backend::replicon_channels::ClientChannel,
+        event::server_event::BufferedServerEvents,
         postcard_utils,
-        protocol::{ProtocolHash, ProtocolMismatch},
         replication::{
-            Replicated,
             client_ticks::{ClientTicks, EntityBuffer},
             replication_registry::{
                 ReplicationRegistry, component_fns::ComponentFns, ctx::SerializeCtx,
@@ -48,11 +36,9 @@ use crate::{
             replication_rules::{ComponentRule, ReplicationRules},
             track_mutate_messages::TrackMutateMessages,
         },
-        replicon_tick::RepliconTick,
     },
 };
-use client_entity_map::ClientEntityMap;
-use client_visibility::{ClientVisibility, Visibility};
+use client_visibility::Visibility;
 use related_entities::RelatedEntities;
 use removal_buffer::{RemovalBuffer, RemovalReader};
 use replication_messages::{
@@ -794,11 +780,10 @@ pub enum TickPolicy {
 /// Marker that enables replication and all events for a client.
 ///
 /// Until authorization happened, the client and server can still exchange network events that are marked as
-/// independent via [`ServerEventAppExt::make_event_independent`](crate::shared::event::server_event::ServerEventAppExt::make_event_independent)
-/// or [`ServerTriggerAppExt::make_trigger_independent`](crate::shared::event::server_trigger::ServerTriggerAppExt::make_trigger_independent).
+/// independent via [`ServerEventAppExt::make_event_independent`] or [`ServerTriggerAppExt::make_trigger_independent`].
 /// **All other events will be ignored**.
 ///
-/// See also [`ConnectedClient`] and [`RepliconSharedPlugin::auth_method`](crate::shared::RepliconSharedPlugin::auth_method).
+/// See also [`ConnectedClient`] and [`RepliconSharedPlugin::auth_method`].
 #[derive(Component, Default)]
 #[require(ClientTicks, ClientEntityMap, Updates, Mutations)]
 pub struct AuthorizedClient;

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -3,21 +3,22 @@ use bevy::{
     prelude::*,
 };
 
-use super::{ServerSet, server_tick::ServerTick};
-use crate::shared::{
-    backend::{connected_client::ConnectedClient, replicon_server::RepliconServer},
-    common_conditions::*,
-    event::{
-        ctx::{ServerReceiveCtx, ServerSendCtx},
-        remote_event_registry::RemoteEventRegistry,
-        server_event::BufferedServerEvents,
+use super::server_tick::ServerTick;
+use crate::{
+    prelude::*,
+    shared::{
+        event::{
+            ctx::{ServerReceiveCtx, ServerSendCtx},
+            remote_event_registry::RemoteEventRegistry,
+            server_event::BufferedServerEvents,
+        },
+        replication::client_ticks::ClientTicks,
     },
-    replication::client_ticks::ClientTicks,
 };
 
 /// Sending events from the server to clients.
 ///
-/// Requires [`ServerPlugin`](super::ServerPlugin).
+/// Requires [`ServerPlugin`].
 /// Can be disabled for apps that act only as clients.
 pub struct ServerEventPlugin;
 

--- a/src/server/related_entities.rs
+++ b/src/server/related_entities.rs
@@ -14,12 +14,7 @@ use petgraph::{
     visit::EdgeRef,
 };
 
-use crate::{
-    server::ServerSet,
-    shared::{
-        backend::replicon_server::RepliconServer, common_conditions::*, replication::Replicated,
-    },
-};
+use crate::prelude::*;
 
 pub trait SyncRelatedAppExt {
     /// Ensures that entities related by `C` are replicated in sync.

--- a/src/server/removal_buffer.rs
+++ b/src/server/removal_buffer.rs
@@ -11,8 +11,9 @@ use bevy::{
     prelude::*,
 };
 
-use crate::shared::replication::{
-    Replicated, replication_registry::FnsId, replication_rules::ReplicationRules,
+use crate::{
+    prelude::*,
+    shared::replication::{replication_registry::FnsId, replication_rules::ReplicationRules},
 };
 
 /// Reader for removed components.
@@ -165,16 +166,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::{
-        server,
-        shared::{
-            protocol::ProtocolHasher,
-            replication::{
-                Replicated, replication_registry::ReplicationRegistry,
-                replication_rules::AppRuleExt,
-            },
-        },
-    };
+    use crate::{server, shared::replication::replication_registry::ReplicationRegistry};
 
     #[test]
     fn not_replicated() {

--- a/src/server/replication_messages/mutations.rs
+++ b/src/server/replication_messages/mutations.rs
@@ -4,14 +4,16 @@ use bevy::{ecs::component::Tick, prelude::*};
 use postcard::experimental::{max_size::MaxSize, serialized_size};
 
 use super::{change_ranges::ChangeRanges, serialized_data::SerializedData};
-use crate::shared::{
-    backend::{replicon_channels::ServerChannel, replicon_server::RepliconServer},
-    postcard_utils,
-    replication::{
-        client_ticks::{ClientTicks, EntityBuffer},
-        mutate_index::MutateIndex,
+use crate::{
+    prelude::*,
+    shared::{
+        backend::replicon_channels::ServerChannel,
+        postcard_utils,
+        replication::{
+            client_ticks::{ClientTicks, EntityBuffer},
+            mutate_index::MutateIndex,
+        },
     },
-    replicon_tick::RepliconTick,
 };
 
 /// Component mutations for the current tick.

--- a/src/server/replication_messages/serialized_data.rs
+++ b/src/server/replication_messages/serialized_data.rs
@@ -2,12 +2,14 @@ use core::ops::Range;
 
 use bevy::{prelude::*, ptr::Ptr};
 
-use crate::shared::{
-    entity_serde, postcard_utils,
-    replication::replication_registry::{
-        FnsId, component_fns::ComponentFns, ctx::SerializeCtx, rule_fns::UntypedRuleFns,
+use crate::{
+    prelude::*,
+    shared::{
+        entity_serde, postcard_utils,
+        replication::replication_registry::{
+            FnsId, component_fns::ComponentFns, ctx::SerializeCtx, rule_fns::UntypedRuleFns,
+        },
     },
-    replicon_tick::RepliconTick,
 };
 
 /// Single continuous buffer that stores serialized data for messages.

--- a/src/server/replication_messages/updates.rs
+++ b/src/server/replication_messages/updates.rs
@@ -4,11 +4,13 @@ use bevy::prelude::*;
 use postcard::experimental::serialized_size;
 
 use super::{change_ranges::ChangeRanges, mutations::Mutations, serialized_data::SerializedData};
-use crate::server::client_visibility::Visibility;
-use crate::shared::{
-    backend::{replicon_channels::ServerChannel, replicon_server::RepliconServer},
-    postcard_utils,
-    replication::update_message_flags::UpdateMessageFlags,
+use crate::{
+    prelude::*,
+    server::client_visibility::Visibility,
+    shared::{
+        backend::replicon_channels::ServerChannel, postcard_utils,
+        replication::update_message_flags::UpdateMessageFlags,
+    },
 };
 
 /// Entity updates for the current tick.

--- a/src/server/server_tick.rs
+++ b/src/server/server_tick.rs
@@ -1,15 +1,15 @@
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::shared::replicon_tick::RepliconTick;
+use crate::prelude::*;
 
 /// Stores current [`RepliconTick`].
 ///
-/// Used only on the server. The [`ServerPlugin`](super::ServerPlugin) sends replication data
+/// Used only on the server. The [`ServerPlugin`] sends replication data
 /// in [`PostUpdate`] any time this resource changes.
-/// By default, its incremented in [`PostUpdate`] per the [`TickPolicy`](super::TickPolicy).
+/// By default, its incremented in [`PostUpdate`] per the [`TickPolicy`].
 ///
-/// If you set [`TickPolicy::Manual`](super::TickPolicy::Manual), you can increment this resource
+/// If you set [`TickPolicy::Manual`], you can increment this resource
 /// at the start of your game loop (e.g. inside [`FixedMain`](bevy::app::FixedMain)).
 /// This value can be used to represent your simulation step, and is made available to the client in
 /// the custom deserialization, despawn, and component removal functions.

--- a/src/server/server_world.rs
+++ b/src/server/server_world.rs
@@ -12,9 +12,9 @@ use bevy::{
 };
 use log::{debug, trace};
 
-use crate::shared::replication::{
-    Replicated,
-    replication_rules::{ComponentRule, ReplicationRules},
+use crate::{
+    prelude::*,
+    shared::replication::replication_rules::{ComponentRule, ReplicationRules},
 };
 
 /// A [`SystemParam`] that wraps [`World`], but provides access only for replicated components.
@@ -228,10 +228,7 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::shared::{
-        protocol::ProtocolHasher,
-        replication::{replication_registry::ReplicationRegistry, replication_rules::AppRuleExt},
-    };
+    use crate::shared::replication::replication_registry::ReplicationRegistry;
 
     #[test]
     #[should_panic]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -10,18 +10,11 @@ pub mod server_entity_map;
 
 use bevy::prelude::*;
 
-use backend::{
-    DisconnectRequest,
-    connected_client::{ConnectedClient, NetworkIdMap, NetworkStats},
-    replicon_channels::{Channel, RepliconChannels},
-};
-use event::{
-    client_trigger::ClientTriggerAppExt, remote_event_registry::RemoteEventRegistry,
-    server_trigger::ServerTriggerAppExt,
-};
-use protocol::{ProtocolHash, ProtocolHasher, ProtocolMismatch};
+use crate::prelude::*;
+use backend::connected_client::NetworkIdMap;
+use event::remote_event_registry::RemoteEventRegistry;
 use replication::{
-    Replicated, command_markers::CommandMarkers, replication_registry::ReplicationRegistry,
+    command_markers::CommandMarkers, replication_registry::ReplicationRegistry,
     replication_rules::ReplicationRules, track_mutate_messages::TrackMutateMessages,
 };
 
@@ -173,10 +166,10 @@ impl Plugin for RepliconSharedPlugin {
 ///
 /// Equal to [`Entity::PLACEHOLDER`].
 ///
-/// See also [`ToClients`](event::server_event::ToClients) and [`FromClient`](event::client_event::FromClient) events.
+/// See also [`ToClients`] and [`FromClient`] events.
 pub const SERVER: Entity = Entity::PLACEHOLDER;
 
-/// Configures the insertion of [`AuthorizedClient`](crate::server::AuthorizedClient).
+/// Configures the insertion of [`AuthorizedClient`].
 ///
 /// Can be set via [`RepliconSharedPlugin::auth_method`].
 #[derive(Resource, Default, Debug, Clone, Copy, PartialEq, Eq)]
@@ -185,22 +178,19 @@ pub enum AuthMethod {
     ///
     /// - If the hash differs from the server's, the client will be notified with
     ///   a [`ProtocolMismatch`] event and disconnected.
-    /// - If the hash matches, the [`AuthorizedClient`](crate::server::AuthorizedClient)
-    ///   component will be inserted.
+    /// - If the hash matches, the [`AuthorizedClient`] component will be inserted.
     #[default]
     ProtocolCheck,
 
     /// Consider all connected clients immediately authorized.
     ///
-    /// [`AuthorizedClient`](crate::server::AuthorizedClient) will be configured as a
-    /// required component for [`ConnectedClient`].
+    /// [`AuthorizedClient`] will be configured as a required component for [`ConnectedClient`].
     ///
     /// Use with caution.
     None,
 
     /// Disable automatic insertion.
     ///
-    /// The user is responsible for manually inserting [`AuthorizedClient`](crate::server::AuthorizedClient)
-    /// on the server.
+    /// The user is responsible for manually inserting [`AuthorizedClient`] on the server.
     Custom,
 }

--- a/src/shared/backend.rs
+++ b/src/shared/backend.rs
@@ -42,11 +42,10 @@ pub struct DisconnectRequest {
 mod tests {
     use test_log::test;
 
-    use super::{
-        replicon_channels::{ClientChannel, RepliconChannels, ServerChannel},
-        replicon_client::{RepliconClient, RepliconClientStatus},
-        replicon_server::RepliconServer,
-        *,
+    use super::*;
+    use crate::{
+        prelude::*,
+        shared::backend::replicon_channels::{ClientChannel, ServerChannel},
     };
 
     #[test]

--- a/src/shared/backend/replicon_client.rs
+++ b/src/shared/backend/replicon_client.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bytes::Bytes;
 use log::{debug, trace, warn};
 
-use super::connected_client::NetworkStats;
+use crate::prelude::*;
 
 /// Stores information about a client independent from the messaging backend.
 ///
@@ -10,20 +10,18 @@ use super::connected_client::NetworkStats;
 /// - When the messaging client changes its status, [`Self::set_status`] should be used to
 ///   reflect this change:
 ///   - [`RepliconClientStatus::Connecting`] and [`RepliconClientStatus::Connected`] should
-///     be set in [`ClientSet::ReceivePackets`](crate::client::ClientSet::ReceivePackets) to
-///     allow the client to process received messages immediately.
-///   - [`RepliconClientStatus::Disconnected`] should be set before
-///     [`ClientSet::Send`](crate::client::ClientSet::Send) to allow the client to process
+///     be set in [`ClientSet::ReceivePackets`] to allow the client to process received
+///     messages immediately.
+///   - [`RepliconClientStatus::Disconnected`] should be set before [`ClientSet::Send`]
+///     to allow the client to process
 ///     all received messages before disconnecting.
 /// - For receiving messages, [`Self::insert_received`] should be to used.
-///   A system to forward backend messages to Replicon should run in
-///   [`ClientSet::ReceivePackets`](crate::client::ClientSet::ReceivePackets).
+///   A system to forward backend messages to Replicon should run in [`ClientSet::ReceivePackets`].
 /// - For sending messages, [`Self::drain_sent`] should be used to drain all sent messages.
-///   A system to forward Replicon messages to the backend should run in
-///   [`ClientSet::SendPackets`](crate::client::ClientSet::SendPackets).
+///   A system to forward Replicon messages to the backend should run in [`ClientSet::SendPackets`].
 /// - Optionally update statistic using [`Self::stats_mut`].
 ///
-/// Inserted as resource by [`ClientPlugin`](crate::client::ClientPlugin).
+/// Inserted as resource by [`ClientPlugin`].
 #[derive(Resource, Default)]
 pub struct RepliconClient {
     /// Client connection status.
@@ -235,9 +233,7 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::shared::backend::replicon_channels::{
-        ClientChannel, RepliconChannels, ServerChannel,
-    };
+    use crate::shared::backend::replicon_channels::{ClientChannel, ServerChannel};
 
     #[test]
     fn cleanup_on_disconnect() {

--- a/src/shared/backend/replicon_server.rs
+++ b/src/shared/backend/replicon_server.rs
@@ -185,8 +185,9 @@ mod tests {
     use test_log::test;
 
     use super::*;
-    use crate::shared::backend::replicon_channels::{
-        ClientChannel, RepliconChannels, ServerChannel,
+    use crate::{
+        prelude::*,
+        shared::backend::replicon_channels::{ClientChannel, ServerChannel},
     };
 
     #[test]

--- a/src/shared/common_conditions.rs
+++ b/src/shared/common_conditions.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 
-use super::backend::{replicon_client::RepliconClient, replicon_server::RepliconServer};
+use crate::prelude::*;
 
 /// Returns `true` if the server is running.
 pub fn server_running(server: Option<Res<RepliconServer>>) -> bool {

--- a/src/shared/event/client_event.rs
+++ b/src/shared/event/client_event.rs
@@ -14,16 +14,7 @@ use super::{
     event_fns::{EventDeserializeFn, EventFns, EventSerializeFn, UntypedEventFns},
     remote_event_registry::RemoteEventRegistry,
 };
-use crate::shared::{
-    SERVER,
-    backend::{
-        replicon_channels::{Channel, RepliconChannels},
-        replicon_client::RepliconClient,
-        replicon_server::RepliconServer,
-    },
-    postcard_utils,
-    protocol::ProtocolHasher,
-};
+use crate::{prelude::*, shared::postcard_utils};
 
 /// An extension trait for [`App`] for creating client events.
 pub trait ClientEventAppExt {
@@ -31,18 +22,16 @@ pub trait ClientEventAppExt {
     ///
     /// After emitting `E` event on the client, [`FromClient<E>`] event will be emitted on the server.
     ///
-    /// If [`ServerEventPlugin`](crate::server::event::ServerEventPlugin) is enabled and
-    /// [`RepliconClient`] is inactive, the event will be drained right after sending and
-    /// re-emitted locally as [`FromClient<E>`] event with [`FromClient::client_entity`]
+    /// If [`ServerEventPlugin`] is enabled and [`RepliconClient`] is inactive, the event will be drained
+    /// right after sending and re-emitted locally as [`FromClient<E>`] event with [`FromClient::client_entity`]
     /// equal to [`SERVER`].
     ///
     /// Calling [`App::add_event`] is not necessary. Can used for regular events that were
     /// previously registered. But be careful, since on listen servers all events `E` are drained,
     /// which could break other Bevy or third-party plugin systems that listen for `E`.
     ///
-    /// See also [`ClientTriggerAppExt::add_client_trigger`](super::client_trigger::ClientTriggerAppExt::add_client_trigger),
-    /// [`Self::add_client_event_with`] and the [corresponding section](../index.html#from-client-to-server)
-    /// from the quick start guide.
+    /// See also [`ClientTriggerAppExt::add_client_trigger`], [`Self::add_client_event_with`] and the
+    /// [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_client_event<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -84,8 +73,7 @@ pub trait ClientEventAppExt {
     /**
     Same as [`Self::add_client_event`], but uses the specified functions for serialization and deserialization.
 
-    See also [`postcard_utils`] and
-    [`ClientTriggerAppExt::add_client_trigger_with`](super::client_trigger::ClientTriggerAppExt::add_client_trigger_with)
+    See also [`postcard_utils`] and [`ClientTriggerAppExt::add_client_trigger_with`].
 
     # Examples
 
@@ -469,7 +457,7 @@ impl<E: Event> FromWorld for ClientEventReader<E> {
 pub struct FromClient<T> {
     /// Entity that represents a connected client.
     ///
-    /// See also [`ConnectedClient`](crate::shared::ConnectedClient).
+    /// See also [`ConnectedClient`].
     pub client_entity: Entity,
     /// Transmitted event.
     #[deref]

--- a/src/shared/event/client_trigger.rs
+++ b/src/shared/event/client_trigger.rs
@@ -6,14 +6,15 @@ use log::debug;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::{
-    client_event::{self, ClientEvent, FromClient},
+    client_event::{self, ClientEvent},
     ctx::{ClientSendCtx, ServerReceiveCtx},
     event_fns::{EventDeserializeFn, EventFns, EventSerializeFn},
     remote_event_registry::RemoteEventRegistry,
     remote_targets::RemoteTargets,
 };
-use crate::shared::{
-    backend::replicon_channels::Channel, entity_serde, postcard_utils, protocol::ProtocolHasher,
+use crate::{
+    prelude::*,
+    shared::{entity_serde, postcard_utils},
 };
 
 /// An extension trait for [`App`] for creating client triggers.
@@ -24,14 +25,11 @@ pub trait ClientTriggerAppExt {
     ///
     /// After triggering `E` event on the client, [`FromClient<E>`] event will be triggered on the server.
     ///
-    /// If [`ServerEventPlugin`](crate::server::event::ServerEventPlugin) is enabled and
-    /// [`RepliconClient`](crate::shared::backend::replicon_client::RepliconClient) is inactive, the event
-    /// will also be triggered locally as [`FromClient<E>`] event with [`FromClient::client_entity`]
-    /// equal to [`SERVER`](crate::shared::SERVER).
+    /// If [`ServerEventPlugin`] is enabled and [`RepliconClient`] is inactive, the event will also be triggered
+    /// locally as [`FromClient<E>`] event with [`FromClient::client_entity`] equal to [`SERVER`].
     ///
-    /// See also [`ClientEventAppExt::add_client_event`](super::client_event::ClientEventAppExt::add_client_event),
-    /// [`Self::add_client_trigger_with`] and the [corresponding section](../index.html#from-client-to-server)
-    /// from the quick start guide.
+    /// See also [`ClientEventAppExt::add_client_event`], [`Self::add_client_trigger_with`] and the
+    /// [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_client_trigger<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -59,7 +57,7 @@ pub trait ClientTriggerAppExt {
 
     /// Same as [`Self::add_client_trigger`], but uses the specified functions for serialization and deserialization.
     ///
-    /// See also [`ClientEventAppExt::add_client_event_with`](super::client_event::ClientEventAppExt::add_client_event_with).
+    /// See also [`ClientEventAppExt::add_client_event_with`].
     fn add_client_trigger_with<E: Event>(
         &mut self,
         channel: Channel,
@@ -194,12 +192,10 @@ fn trigger_deserialize<'a, E>(
 ///
 /// See also [`ClientTriggerAppExt`].
 pub trait ClientTriggerExt {
-    /// Like [`Commands::trigger`], but triggers [`FromClient`] on server and locally
-    /// if [`RepliconClient`](crate::shared::backend::replicon_client::RepliconClient) is inactive.
+    /// Like [`Commands::trigger`], but triggers [`FromClient`] on server and locally if [`RepliconClient`] is inactive.
     fn client_trigger(&mut self, event: impl Event);
 
-    /// Like [`Self::client_trigger`], but allows you to specify target entities, similar to
-    /// [`Commands::trigger_targets`].
+    /// Like [`Self::client_trigger`], but allows you to specify target entities, similar to [`Commands::trigger_targets`].
     fn client_trigger_targets(&mut self, event: impl Event, targets: impl RemoteTargets);
 }
 

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -14,6 +14,7 @@ use bevy::{
     ptr::{Ptr, PtrMut},
 };
 use bytes::Bytes;
+use client_event_queue::ClientEventQueue;
 use log::{debug, error, warn};
 use postcard::experimental::{max_size::MaxSize, serialized_size};
 use serde::{Serialize, de::DeserializeOwned};
@@ -23,19 +24,10 @@ use super::{
     event_fns::{EventDeserializeFn, EventFns, EventSerializeFn, UntypedEventFns},
     remote_event_registry::RemoteEventRegistry,
 };
-use crate::shared::{
-    ConnectedClient, SERVER,
-    backend::{
-        replicon_channels::{Channel, RepliconChannels},
-        replicon_client::RepliconClient,
-        replicon_server::RepliconServer,
-    },
-    postcard_utils,
-    protocol::ProtocolHasher,
-    replication::client_ticks::ClientTicks,
-    replicon_tick::RepliconTick,
+use crate::{
+    prelude::*,
+    shared::{postcard_utils, replication::client_ticks::ClientTicks},
 };
-use client_event_queue::ClientEventQueue;
 
 /// An extension trait for [`App`] for creating client events.
 pub trait ServerEventAppExt {
@@ -43,9 +35,9 @@ pub trait ServerEventAppExt {
     ///
     /// After emitting [`ToClients<E>`] event on the server, `E` event  will be emitted on clients.
     ///
-    /// If [`ClientEventPlugin`](crate::client::event::ClientEventPlugin) is enabled and
-    /// [`SERVER`] is a recipient of the event, then [`ToClients<E>`] event will be drained
-    /// after sending to clients and `E` event will be emitted on the server as well.
+    /// If [`ClientEventPlugin`] is enabled and [`SERVER`] is a recipient of the event, then
+    /// [`ToClients<E>`] event will be drained after sending to clients and `E` event will be emitted
+    /// on the server as well.
     ///
     /// Calling [`App::add_event`] is not necessary. Can used for regular events that were
     /// previously registered.
@@ -53,9 +45,8 @@ pub trait ServerEventAppExt {
     /// Unlike client events, server events are tied to replication. See [`Self::make_event_independent`]
     /// for more details.
     ///
-    /// See also [`ServerTriggerAppExt::add_server_trigger`](super::server_trigger::ServerTriggerAppExt::add_server_trigger),
-    /// [`Self::add_server_event_with`] and the [corresponding section](../index.html#from-server-to-client)
-    /// from the quick start guide.
+    /// See also [`ServerTriggerAppExt::add_server_trigger`], [`Self::add_server_event_with`] and the
+    /// [corresponding section](../index.html#from-server-to-client) from the quick start guide.
     fn add_server_event<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -81,8 +72,7 @@ pub trait ServerEventAppExt {
     /**
     Same as [`Self::add_server_event`], but uses the specified functions for serialization and deserialization.
 
-    See also [`postcard_utils`] and
-    [`ServerTriggerAppExt::add_server_trigger_with`](super::server_trigger::ServerTriggerAppExt::add_server_trigger_with)
+    See also [`postcard_utils`] and [`ServerTriggerAppExt::add_server_trigger_with`].
 
     # Examples
 

--- a/src/shared/event/server_event/client_event_queue.rs
+++ b/src/shared/event/server_event/client_event_queue.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 use bevy::prelude::*;
 use bytes::Bytes;
 
-use crate::shared::replicon_tick::RepliconTick;
+use crate::prelude::*;
 
 /// Stores all received events from server that arrived earlier then replication message with their tick.
 ///

--- a/src/shared/event/server_trigger.rs
+++ b/src/shared/event/server_trigger.rs
@@ -10,10 +10,11 @@ use super::{
     event_fns::{EventDeserializeFn, EventFns, EventSerializeFn},
     remote_event_registry::RemoteEventRegistry,
     remote_targets::RemoteTargets,
-    server_event::{self, ServerEvent, ToClients},
+    server_event::{self, ServerEvent},
 };
-use crate::shared::{
-    backend::replicon_channels::Channel, entity_serde, postcard_utils, protocol::ProtocolHasher,
+use crate::{
+    prelude::*,
+    shared::{entity_serde, postcard_utils},
 };
 
 /// An extension trait for [`App`] for creating server triggers.
@@ -24,9 +25,8 @@ pub trait ServerTriggerAppExt {
     ///
     /// After triggering [`ToClients<E>`] event on the server, `E` event will be triggered on clients.
     ///
-    /// If [`ClientEventPlugin`](crate::client::event::ClientEventPlugin) is enabled and
-    /// [`SERVER`](crate::shared::SERVER) is a recipient of the event (not to be confused with trigger target),
-    /// then `E` event will be emitted on the server as well.
+    /// If [`ClientEventPlugin`] is enabled and [`SERVER`] is a recipient of the event
+    /// (not to be confused with trigger target), then `E` event will be emitted on the server as well.
     ///
     /// See also [`Self::add_server_trigger_with`] and the [corresponding section](../index.html#from-server-to-client)
     /// from the quick start guide.
@@ -57,7 +57,7 @@ pub trait ServerTriggerAppExt {
 
     /// Same as [`Self::add_server_trigger`], but uses the specified functions for serialization and deserialization.
     ///
-    /// See also [`ServerEventAppExt::add_server_event_with`](super::server_event::ServerEventAppExt::add_server_event_with).
+    /// See also [`ServerEventAppExt::add_server_event_with`].
     fn add_server_trigger_with<E: Event>(
         &mut self,
         channel: Channel,
@@ -65,8 +65,7 @@ pub trait ServerTriggerAppExt {
         deserialize: EventDeserializeFn<ClientReceiveCtx, E>,
     ) -> &mut Self;
 
-    /// Like [`ServerEventAppExt::make_event_independent`](super::server_event::ServerEventAppExt::make_event_independent),
-    /// but for triggers.
+    /// Like [`ServerEventAppExt::make_event_independent`], but for triggers.
     fn make_trigger_independent<E: Event>(&mut self) -> &mut Self;
 }
 
@@ -218,7 +217,7 @@ fn trigger_deserialize<'a, E>(
 /// See also [`ServerTriggerAppExt`].
 pub trait ServerTriggerExt {
     /// Like [`Commands::trigger`], but triggers `E` on server and locally
-    /// if [`SERVER`](crate::shared::SERVER) is a recipient of the event).
+    /// if [`SERVER`] is a recipient of the event).
     fn server_trigger(&mut self, event: ToClients<impl Event>);
 
     /// Like [`Self::server_trigger`], but allows you to specify target entities, similar to

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -8,7 +8,7 @@ use bevy::{
 use log::{debug, trace};
 
 use super::mutate_index::MutateIndex;
-use crate::shared::replicon_tick::RepliconTick;
+use crate::prelude::*;
 
 /// Tracks replication ticks for a client.
 #[derive(Component, Default)]

--- a/src/shared/replication/replication_registry.rs
+++ b/src/shared/replication/replication_registry.rs
@@ -8,10 +8,11 @@ use bevy::{ecs::component::ComponentId, prelude::*};
 use serde::{Deserialize, Serialize};
 
 use super::command_markers::CommandMarkerIndex;
+use crate::prelude::*;
 use command_fns::{MutWrite, RemoveFn, UntypedCommandFns, WriteFn};
 use component_fns::ComponentFns;
 use ctx::DespawnCtx;
-use rule_fns::{RuleFns, UntypedRuleFns};
+use rule_fns::UntypedRuleFns;
 
 /// Stores configurable replication functions.
 #[derive(Resource)]

--- a/src/shared/replication/replication_registry/command_fns.rs
+++ b/src/shared/replication/replication_registry/command_fns.rs
@@ -9,11 +9,8 @@ use bevy::{
 };
 use bytes::Bytes;
 
-use super::{
-    ctx::{RemoveCtx, WriteCtx},
-    rule_fns::RuleFns,
-};
-use crate::shared::replication::deferred_entity::DeferredEntity;
+use super::ctx::{RemoveCtx, WriteCtx};
+use crate::{prelude::*, shared::replication::deferred_entity::DeferredEntity};
 
 /// Writing and removal functions for a component, like [`Commands`].
 #[derive(Clone, Copy)]

--- a/src/shared/replication/replication_registry/ctx.rs
+++ b/src/shared/replication/replication_registry/ctx.rs
@@ -4,7 +4,7 @@ use bevy::{
     reflect::TypeRegistry,
 };
 
-use crate::shared::{replicon_tick::RepliconTick, server_entity_map::ServerEntityMap};
+use crate::{prelude::*, shared::server_entity_map::ServerEntityMap};
 
 /// Replication context for serialization function.
 #[non_exhaustive]

--- a/src/shared/replication/replication_registry/test_fns.rs
+++ b/src/shared/replication/replication_registry/test_fns.rs
@@ -5,13 +5,15 @@ use super::{
     FnsId, ReplicationRegistry,
     ctx::{DespawnCtx, RemoveCtx, SerializeCtx, WriteCtx},
 };
-use crate::shared::{
-    replication::{
-        command_markers::{CommandMarkers, EntityMarkers},
-        deferred_entity::{DeferredChanges, DeferredEntity},
+use crate::{
+    prelude::*,
+    shared::{
+        replication::{
+            command_markers::{CommandMarkers, EntityMarkers},
+            deferred_entity::{DeferredChanges, DeferredEntity},
+        },
+        server_entity_map::ServerEntityMap,
     },
-    replicon_tick::RepliconTick,
-    server_entity_map::ServerEntityMap,
 };
 
 /**
@@ -76,7 +78,7 @@ pub trait TestFnsEntityExt {
     /// Deserializes a component using a registered function for it and
     /// writes it into an entity using a write function based on markers.
     ///
-    /// See also [`AppMarkerExt`](crate::shared::replication::command_markers::AppMarkerExt).
+    /// See also [`AppMarkerExt`].
     fn apply_write(
         &mut self,
         bytes: impl Into<Bytes>,
@@ -86,7 +88,7 @@ pub trait TestFnsEntityExt {
 
     /// Removes a component using a registered function for it.
     ///
-    /// See also [`AppMarkerExt`](crate::shared::replication::command_markers::AppMarkerExt).
+    /// See also [`AppMarkerExt`].
     fn apply_remove(&mut self, fns_id: FnsId, message_tick: RepliconTick) -> &mut Self;
 
     /// Despawns an entity using [`ReplicationRegistry::despawn`].

--- a/src/shared/replication/replication_rules.rs
+++ b/src/shared/replication/replication_rules.rs
@@ -7,16 +7,14 @@ use bevy::{
 };
 use serde::{Serialize, de::DeserializeOwned};
 
-use super::replication_registry::{
-    FnsId, ReplicationRegistry, command_fns::MutWrite, rule_fns::RuleFns,
-};
-use crate::shared::{protocol::ProtocolHasher, replicon_tick::RepliconTick};
+use super::replication_registry::{FnsId, ReplicationRegistry, command_fns::MutWrite};
+use crate::prelude::*;
 
 /// Replication functions for [`App`].
 pub trait AppRuleExt {
     /// Defines a [`ReplicationRule`] for a single component.
     ///
-    /// If present on an entity with [`Replicated`](super::Replicated) component,
+    /// If present on an entity with [`Replicated`] component,
     /// it will be serialized and deserialized as-is using [`postcard`]
     /// and sent at [`SendRate::EveryTick`]. To customize this, use [`Self::replicate_with`].
     ///
@@ -142,8 +140,7 @@ pub trait AppRuleExt {
 
     </div>
 
-    You can also override how the component will be written,
-    see [`AppMarkerExt`](super::command_markers::AppMarkerExt).
+    You can also override how the component will be written, see [`AppMarkerExt`].
 
     See also [`postcard_utils`](crate::shared::postcard_utils) for serialization helpers.
 
@@ -751,7 +748,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::AppRuleExt;
 
     #[test]
     fn registration() {

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -1,10 +1,6 @@
 use bevy::prelude::*;
 
-use crate::shared::backend::{
-    connected_client::ConnectedClient,
-    replicon_client::{RepliconClient, RepliconClientStatus},
-    replicon_server::RepliconServer,
-};
+use crate::prelude::*;
 
 /**
 Extension for [`App`] to communicate with other instances like it's a server.


### PR DESCRIPTION
From what I can tell, this is fairly idiomatic. Benefits:
- No need to type full paths in docs for items from the prelude.
- Rust Analyzer suggests items from the prelude, no need to fight the tooling.
- It's shorter, and our internals now resemble the public API more closely.