### PR TITLE
Add ClientSet::PrepareSend/ServerSet::PrepareSend system sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ClientSet::PrepareSend` and `ServerSet::PrepareSend` system sets. Backends should use these sets to add `PostUpdate` logic that needs to run before sending data on clients and servers.
+
 ## [0.34.0] - 2025-06-15
 
 ### Added

--- a/bevy_replicon_example_backend/src/client.rs
+++ b/bevy_replicon_example_backend/src/client.rs
@@ -30,7 +30,7 @@ impl Plugin for RepliconExampleClientPlugin {
             PostUpdate,
             (
                 set_disconnected
-                    .before(ClientSet::Send)
+                    .in_set(ClientSet::PrepareSend)
                     .run_if(resource_removed::<ExampleClient>),
                 send_packets
                     .in_set(ClientSet::SendPackets)

--- a/bevy_replicon_example_backend/src/server.rs
+++ b/bevy_replicon_example_backend/src/server.rs
@@ -30,7 +30,7 @@ impl Plugin for RepliconExampleServerPlugin {
             PostUpdate,
             (
                 set_stopped
-                    .before(ServerSet::Send)
+                    .in_set(ServerSet::PrepareSend)
                     .run_if(resource_removed::<ExampleServer>),
                 send_packets
                     .in_set(ServerSet::SendPackets)

--- a/src/client.rs
+++ b/src/client.rs
@@ -752,7 +752,7 @@ pub enum ClientSet {
     Diagnostics,
     /// Systems that prepare for sending data to [`RepliconClient`].
     ///
-    /// Can be used by backends to add custom logic before sending data.
+    /// Can be used by backends to add custom logic before sending data, such as transition to a disconnected or connecting state.
     PrepareSend,
     /// Systems that send data to [`RepliconClient`].
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,7 +59,12 @@ impl Plugin for ClientPlugin {
             )
             .configure_sets(
                 PostUpdate,
-                (ClientSet::Send, ClientSet::SendPackets).chain(),
+                (
+                    ClientSet::PrepareSend,
+                    ClientSet::Send,
+                    ClientSet::SendPackets,
+                )
+                    .chain(),
             )
             .add_systems(
                 PreUpdate,
@@ -745,6 +750,10 @@ pub enum ClientSet {
     ///
     /// Runs in [`PreUpdate`].
     Diagnostics,
+    /// Systems that prepare for sending data to [`RepliconClient`].
+    ///
+    /// Can be used by backends to add custom logic before sending data.
+    PrepareSend,
     /// Systems that send data to [`RepliconClient`].
     ///
     /// Used by `bevy_replicon`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -782,7 +782,7 @@ pub enum ServerSet {
     Receive,
     /// Systems that prepare for sending data to [`RepliconServer`].
     ///
-    /// Can be used by backends to add custom logic before sending data.
+    /// Can be used by backends to add custom logic before sending data, such as transition to a stopped state.
     PrepareSend,
     /// Systems that send data to [`RepliconServer`].
     ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -90,7 +90,12 @@ impl Plugin for ServerPlugin {
             )
             .configure_sets(
                 PostUpdate,
-                (ServerSet::Send, ServerSet::SendPackets).chain(),
+                (
+                    ServerSet::PrepareSend,
+                    ServerSet::Send,
+                    ServerSet::SendPackets,
+                )
+                    .chain(),
             )
             .add_observer(handle_connects)
             .add_observer(handle_disconnects)
@@ -775,6 +780,10 @@ pub enum ServerSet {
     ///
     /// Runs in [`PreUpdate`].
     Receive,
+    /// Systems that prepare for sending data to [`RepliconServer`].
+    ///
+    /// Can be used by backends to add custom logic before sending data.
+    PrepareSend,
     /// Systems that send data to [`RepliconServer`].
     ///
     /// Used by `bevy_replicon`.


### PR DESCRIPTION
All `bevy_replicon` and backend systems should be in system sets.