### PR TITLE
Spawn all allocated entities after processing each replicated entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Log replication errors instead of panicking. We use panics only for things that should never happen, but users could sometimes trigger them by messing with entities, so we now log these errors to simplify debugging in those cases.
+- Spawn all allocated entities after processing each replicated entity.
 
 ## [0.34.0] - 2025-06-15
 

--- a/src/shared/replication/deferred_entity.rs
+++ b/src/shared/replication/deferred_entity.rs
@@ -57,8 +57,12 @@ impl<'w> DeferredEntity<'w> {
         unsafe { self.entity.world_mut().register_component::<C>() }
     }
 
-    /// Applies all buffered changes.
+    /// Flushes the world and applies all buffered changes.
+    ///
+    /// Flushing is needed to spawn all allocated entities from mappings.
     pub(crate) fn flush(&mut self) {
+        // SAFETY: entity location is unchanged because all changes applied after.
+        unsafe { self.entity.world_mut().flush() };
         self.changes.apply(&mut self.entity);
     }
 }


### PR DESCRIPTION
We allocate entities during mappings using `Entities::reserve`, which are flushed as empty entities after `World::flush`. This works, but to access those entities inside an observer, we need to call `flush` before applying changes so observers can see the previosly mapped entities.