### PR TITLE
Use `rustc_hash` instead of `fold_hash`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All contexts now store `AppTypeRegistry` instead of `TypeRegistry`. To get `TypeRegistry`, call `AppTypeRegistry::read`.
 - `AppTypeRegistry` now available on replication for observers.
+- Use `rustc-hash` instead of `foldhash` for consistent `ProtocolHash` across different platforms.
 
 ## [0.34.1] - 2025-06-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bitflags = { version = "2.6", features = ["serde"] }
 postcard = { version = "1.1", default-features = false, features = [
   "experimental-derive",
 ] }
+rustc-hash = "2.1"
 
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 bytes = { version = "1.10", default-features = false, features = [

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -1,14 +1,12 @@
 use core::{
     any,
     fmt::Debug,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
 };
 
-use bevy::{
-    platform::hash::{DefaultHasher, FixedHasher},
-    prelude::*,
-};
+use bevy::prelude::*;
 use log::debug;
+use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 
 /// Hashes all protocol registrations to calculate [`ProtocolHash`].
@@ -22,8 +20,8 @@ use serde::{Deserialize, Serialize};
 /// You can include custom data (e.g., a game version) via [`Self::add_custom`].
 ///
 /// Only available during the [`Plugin::build`] stage. Computes [`ProtocolHash`] resource.
-#[derive(Resource)]
-pub struct ProtocolHasher(DefaultHasher);
+#[derive(Resource, Default)]
+pub struct ProtocolHasher(FxHasher);
 
 impl ProtocolHasher {
     /// Adds custom data to the protocol hash calculation.
@@ -103,12 +101,6 @@ impl ProtocolHasher {
         let hash = self.0.finish();
         debug!("calculated hash: {hash}");
         ProtocolHash(hash)
-    }
-}
-
-impl Default for ProtocolHasher {
-    fn default() -> Self {
-        Self(FixedHasher.build_hasher())
     }
 }
 


### PR DESCRIPTION
For consistent `ProtocolHash` across different platforms.