### PR TITLE
Make `ProtocolHash` deterministic across platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,24 @@ jobs:
       - name: Check compilation
         run: cargo check --target thumbv6m-none-eabi --no-default-features --features client,server,bevy/critical-section
 
+  wasi:
+    name: WASI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Instal stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache crates
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check compilation
+        run: cargo test --target wasm32-wasip1
+        env:
+          CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -157,7 +175,16 @@ jobs:
   codecov:
     name: Upload to Codecov
     if: github.actor != 'dependabot[bot]'
-    needs: [typos, format, lint, no-std-portable-atomic, feature-combinations, doctest, test]
+    needs:
+      [
+        typos,
+        format,
+        lint,
+        no-std-portable-atomic,
+        feature-combinations,
+        doctest,
+        test,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All contexts now store `AppTypeRegistry` instead of `TypeRegistry`. To get `TypeRegistry`, call `AppTypeRegistry::read`.
 - `AppTypeRegistry` now available on replication for observers.
 
+### Fixed
+
+- Make `ProtocolHash` deterministic across platforms.
+
 ## [0.34.1] - 2025-06-21
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bitflags = { version = "2.6", features = ["serde"] }
 postcard = { version = "1.1", default-features = false, features = [
   "experimental-derive",
 ] }
+fnv = "1.0"
 
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]
 bytes = { version = "1.10", default-features = false, features = [

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -1,13 +1,11 @@
 use core::{
     any,
     fmt::Debug,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
 };
 
-use bevy::{
-    platform::hash::{DefaultHasher, FixedHasher},
-    prelude::*,
-};
+use bevy::prelude::*;
+use fnv::FnvHasher;
 use log::debug;
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +20,8 @@ use serde::{Deserialize, Serialize};
 /// You can include custom data (e.g., a game version) via [`Self::add_custom`].
 ///
 /// Only available during the [`Plugin::build`] stage. Computes [`ProtocolHash`] resource.
-#[derive(Resource)]
-pub struct ProtocolHasher(DefaultHasher);
+#[derive(Resource, Default)]
+pub struct ProtocolHasher(FnvHasher);
 
 impl ProtocolHasher {
     /// Adds custom data to the protocol hash calculation.
@@ -53,7 +51,9 @@ impl ProtocolHasher {
             "adding replication rule `{}` with priority {priority}",
             any::type_name::<R>()
         );
-        self.hash::<R>(ProtocolPart::Replicate { priority });
+        self.hash::<R>(ProtocolPart::Replicate {
+            priority: priority as u64,
+        });
     }
 
     pub(crate) fn replicate_bundle<B>(&mut self) {
@@ -106,19 +106,16 @@ impl ProtocolHasher {
     }
 }
 
-impl Default for ProtocolHasher {
-    fn default() -> Self {
-        Self(FixedHasher.build_hasher())
-    }
-}
-
 /// Part of protocol registration.
 ///
 /// Needed to distinguish between different registrations for the same type.
 /// For example, the same type could be used for a client and a server event.
+///
+/// Fixed-sized for deterministic hash across platforms.
 #[derive(Hash)]
+#[repr(u8)]
 enum ProtocolPart {
-    Replicate { priority: usize },
+    Replicate { priority: u64 },
     ReplicateBundle,
     ClientEvent,
     ClientTrigger,
@@ -228,6 +225,20 @@ mod tests {
         }
 
         assert_eq!(hasher1.finish(), hasher2.finish());
+    }
+
+    #[test]
+    fn determinism() {
+        let mut hasher = ProtocolHasher::default();
+
+        hasher.replicate::<StructA>(1);
+        hasher.add_server_event::<StructB>();
+        hasher.add_server_trigger::<StructC>();
+        hasher.add_client_event::<StructB>();
+        hasher.add_client_trigger::<StructC>();
+        hasher.add_custom(0);
+
+        assert_eq!(hasher.finish(), ProtocolHash(11462723744753766090));
     }
 
     struct StructA;


### PR DESCRIPTION
`FoldHash` from Bevy is not deterministic. I also checked `rustc_hasher` in our dependency tree, but it’s non-deterministic as well.

Found that `fnv` from Servo works, and set up CI to verify determinism.