### PR TITLE
Prefer to use the name directly instead of `name_entity`

### DIFF
--- a/bevy_replicon_example_backend/examples/tic_tac_toe.rs
+++ b/bevy_replicon_example_backend/examples/tic_tac_toe.rs
@@ -352,13 +352,11 @@ fn init_client(
     // By default it's empty, but we can initialize it with the
     // received entities.
     let mut entity_map = ClientEntityMap::default();
-    for (&server_entity, &client_entity) in
-        cells.iter().map(|(entity, _)| entity).zip(&trigger.cells)
-    {
-        entity_map.insert(server_entity, client_entity);
+    for (&server, &client) in cells.iter().map(|(entity, _)| entity).zip(&trigger.cells) {
+        entity_map.insert(server, client);
     }
 
-    // Utilize client entity as a player for convenient lookups by `client_entity`.
+    // Utilize client entity as a player for convenient lookups by `client`.
     commands.entity(trigger.client).insert((
         Player,
         server_symbol.next(),
@@ -464,42 +462,39 @@ fn update_buttons_background(
     }
 }
 
-fn show_turn_text(mut writer: TextUiWriter, text_entity: Single<Entity, With<BottomText>>) {
-    *writer.text(*text_entity, TEXT_SECTION) = "Current turn: ".into();
+fn show_turn_text(mut writer: TextUiWriter, text: Single<Entity, With<BottomText>>) {
+    *writer.text(*text, TEXT_SECTION) = "Current turn: ".into();
 }
 
 fn show_turn_symbol(
     mut writer: TextUiWriter,
     turn_symbol: Res<TurnSymbol>,
-    text_entity: Single<Entity, With<BottomText>>,
+    text: Single<Entity, With<BottomText>>,
 ) {
-    *writer.text(*text_entity, SYMBOL_SECTION) = turn_symbol.glyph().into();
-    *writer.color(*text_entity, SYMBOL_SECTION) = turn_symbol.color().into();
+    *writer.text(*text, SYMBOL_SECTION) = turn_symbol.glyph().into();
+    *writer.color(*text, SYMBOL_SECTION) = turn_symbol.color().into();
 }
 
-fn show_disconnected_text(mut writer: TextUiWriter, text_entity: Single<Entity, With<BottomText>>) {
-    *writer.text(*text_entity, TEXT_SECTION) = "Disconnected".into();
-    writer.text(*text_entity, SYMBOL_SECTION).clear();
+fn show_disconnected_text(mut writer: TextUiWriter, text: Single<Entity, With<BottomText>>) {
+    *writer.text(*text, TEXT_SECTION) = "Disconnected".into();
+    writer.text(*text, SYMBOL_SECTION).clear();
 }
 
-fn show_winner_text(mut writer: TextUiWriter, text_entity: Single<Entity, With<BottomText>>) {
-    *writer.text(*text_entity, TEXT_SECTION) = "Winner: ".into();
+fn show_winner_text(mut writer: TextUiWriter, text: Single<Entity, With<BottomText>>) {
+    *writer.text(*text, TEXT_SECTION) = "Winner: ".into();
 }
 
-fn show_tie_text(mut writer: TextUiWriter, text_entity: Single<Entity, With<BottomText>>) {
-    *writer.text(*text_entity, TEXT_SECTION) = "Tie".into();
-    writer.text(*text_entity, SYMBOL_SECTION).clear();
+fn show_tie_text(mut writer: TextUiWriter, text: Single<Entity, With<BottomText>>) {
+    *writer.text(*text, TEXT_SECTION) = "Tie".into();
+    writer.text(*text, SYMBOL_SECTION).clear();
 }
 
-fn show_connecting_text(mut writer: TextUiWriter, text_entity: Single<Entity, With<BottomText>>) {
-    *writer.text(*text_entity, TEXT_SECTION) = "Connecting".into();
+fn show_connecting_text(mut writer: TextUiWriter, text: Single<Entity, With<BottomText>>) {
+    *writer.text(*text, TEXT_SECTION) = "Connecting".into();
 }
 
-fn show_waiting_client_text(
-    mut writer: TextUiWriter,
-    text_entity: Single<Entity, With<BottomText>>,
-) {
-    *writer.text(*text_entity, TEXT_SECTION) = "Waiting client".into();
+fn show_waiting_client_text(mut writer: TextUiWriter, text: Single<Entity, With<BottomText>>) {
+    *writer.text(*text, TEXT_SECTION) = "Waiting client".into();
 }
 
 /// Returns `true` if the local player can select cells.

--- a/src/server.rs
+++ b/src/server.rs
@@ -248,22 +248,24 @@ fn receive_acks(
     mut clients: Query<&mut ClientTicks>,
     mut entity_buffer: ResMut<EntityBuffer>,
 ) {
-    for (client_entity, mut message) in server.receive(ClientChannel::MutationAcks) {
+    for (client, mut message) in server.receive(ClientChannel::MutationAcks) {
         while message.has_remaining() {
             match postcard_utils::from_buf(&mut message) {
                 Ok(mutate_index) => {
-                    let mut ticks = clients.get_mut(client_entity).unwrap_or_else(|_| {
-                        panic!("messages from client `{client_entity}` should have been removed on disconnect")
+                    let mut ticks = clients.get_mut(client).unwrap_or_else(|_| {
+                        panic!(
+                            "messages from client `{client}` should have been removed on disconnect"
+                        )
                     });
                     ticks.ack_mutate_message(
-                        client_entity,
+                        client,
                         &mut entity_buffer,
                         change_tick.this_run(),
                         mutate_index,
                     );
                 }
                 Err(e) => {
-                    debug!("unable to deserialize mutate index from client `{client_entity}`: {e}")
+                    debug!("unable to deserialize mutate index from client `{client}`: {e}")
                 }
             }
         }

--- a/src/server/client_entity_map.rs
+++ b/src/server/client_entity_map.rs
@@ -51,8 +51,8 @@ fn confirm_bullet(
 ) {
     for event in bullet_events.read() {
         let mut entity_map = clients.get_mut(event.client).unwrap();
-        let server_entity = commands.spawn(Bullet).id(); // You can insert more components, they will be sent to the client's entity correctly.
-        entity_map.insert(server_entity, event.0);
+        let bullet = commands.spawn(Bullet).id(); // You can insert more components, they will be sent to the client's entity correctly.
+        entity_map.insert(bullet, event.0);
     }
 }
 ```

--- a/src/server/replication_messages/mutations.rs
+++ b/src/server/replication_messages/mutations.rs
@@ -155,7 +155,7 @@ impl Mutations {
     pub(crate) fn send(
         &mut self,
         server: &mut RepliconServer,
-        client_entity: Entity,
+        client: Entity,
         ticks: &mut ClientTicks,
         entity_buffer: &mut EntityBuffer,
         serialized: &SerializedData,
@@ -213,7 +213,7 @@ impl Mutations {
 
         if self.messages.len() > 1 {
             trace!(
-                "splitting into {} messages for client `{client_entity}`",
+                "splitting into {} messages for client `{client}`",
                 self.messages.len()
             );
         }
@@ -241,7 +241,7 @@ impl Mutations {
 
             debug_assert_eq!(message.len(), message_size);
 
-            server.send(client_entity, ServerChannel::Mutations, message);
+            server.send(client, ServerChannel::Mutations, message);
         }
 
         Ok(self.messages.len())

--- a/src/server/replication_messages/updates.rs
+++ b/src/server/replication_messages/updates.rs
@@ -194,7 +194,7 @@ impl Updates {
     pub(crate) fn send(
         &self,
         server: &mut RepliconServer,
-        client_entity: Entity,
+        client: Entity,
         serialized: &SerializedData,
         server_tick: Range<usize>,
     ) -> Result<()> {
@@ -284,7 +284,7 @@ impl Updates {
 
         debug_assert_eq!(message.len(), message_size);
 
-        server.send(client_entity, ServerChannel::Updates, message);
+        server.send(client, ServerChannel::Updates, message);
 
         Ok(())
     }

--- a/src/shared/backend/connected_client.rs
+++ b/src/shared/backend/connected_client.rs
@@ -95,10 +95,8 @@ impl NetworkId {
 fn on_id_add(mut world: DeferredWorld, ctx: HookContext) {
     let network_id = *world.get::<NetworkId>(ctx.entity).unwrap();
     let mut network_map = world.resource_mut::<NetworkIdMap>();
-    if let Some(old_entity) = network_map.0.insert(network_id, ctx.entity) {
-        error!(
-            "backend-provided `{network_id:?}` that was already mapped to client `{old_entity}`"
-        );
+    if let Some(old_client) = network_map.0.insert(network_id, ctx.entity) {
+        error!("backend-provided `{network_id:?}` was already mapped to client `{old_client}`");
     }
 }
 

--- a/src/shared/backend/replicon_server.rs
+++ b/src/shared/backend/replicon_server.rs
@@ -40,12 +40,11 @@ impl RepliconServer {
     }
 
     /// Removes a disconnected client.
-    pub(crate) fn remove_client(&mut self, client_entity: Entity) {
+    pub(crate) fn remove_client(&mut self, client: Entity) {
         for receive_channel in &mut self.received_messages {
-            receive_channel.retain(|&(entity, _)| entity != client_entity);
+            receive_channel.retain(|&(entity, _)| entity != client);
         }
-        self.sent_messages
-            .retain(|&(entity, ..)| entity != client_entity);
+        self.sent_messages.retain(|&(entity, ..)| entity != client);
     }
 
     /// Receives all available messages from clients over a channel.
@@ -89,7 +88,7 @@ impl RepliconServer {
     /// </div>
     pub fn send<I: Into<usize>, B: Into<Bytes>>(
         &mut self,
-        client_entity: Entity,
+        client: Entity,
         channel_id: I,
         message: B,
     ) {
@@ -103,8 +102,7 @@ impl RepliconServer {
 
         trace!("sending {} bytes over channel {channel_id}", message.len());
 
-        self.sent_messages
-            .push((client_entity, channel_id, message));
+        self.sent_messages.push((client, channel_id, message));
     }
 
     /// Marks the server as running or stopped.
@@ -163,7 +161,7 @@ impl RepliconServer {
     /// </div>
     pub fn insert_received<I: Into<usize>, B: Into<Bytes>>(
         &mut self,
-        client_entity: Entity,
+        client: Entity,
         channel_id: I,
         message: B,
     ) {
@@ -178,7 +176,7 @@ impl RepliconServer {
             .get_mut(channel_id)
             .unwrap_or_else(|| panic!("server should have a receive channel with id {channel_id}"));
 
-        receive_channel.push((client_entity, message.into()));
+        receive_channel.push((client, message.into()));
     }
 }
 

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -92,13 +92,13 @@ impl ClientTicks {
     /// Keeps allocated memory in the buffers for reuse.
     pub(crate) fn ack_mutate_message(
         &mut self,
-        client_entity: Entity,
+        client: Entity,
         entity_buffer: &mut EntityBuffer,
         tick: Tick,
         mutate_index: MutateIndex,
     ) {
         let Some(mutate_info) = self.mutations.remove(&mutate_index) else {
-            debug!("received unknown `{mutate_index:?}` from client `{client_entity}`");
+            debug!("received unknown `{mutate_index:?}` from client `{client}`");
             return;
         };
 
@@ -117,7 +117,7 @@ impl ClientTicks {
         entity_buffer.push(mutate_info.entities);
 
         trace!(
-            "acknowledged mutate message with `{:?}` from client `{client_entity}`",
+            "acknowledged mutate message with `{:?}` from client `{client}`",
             mutate_info.tick,
         );
     }


### PR DESCRIPTION
A small follow-up to #517, but this time just variable names.