### PR TITLE
Improve event docs

### DIFF
--- a/src/shared/event/client_event.rs
+++ b/src/shared/event/client_event.rs
@@ -17,6 +17,8 @@ use super::{
 use crate::{prelude::*, shared::postcard_utils};
 
 /// An extension trait for [`App`] for creating client events.
+///
+/// See also [`ServerEventAppExt`] for server events and [`ClientTriggerAppExt`] for triggers.
 pub trait ClientEventAppExt {
     /// Registers a remote client event.
     ///
@@ -30,8 +32,7 @@ pub trait ClientEventAppExt {
     /// previously registered. But be careful, since on listen servers all events `E` are drained,
     /// which could break other Bevy or third-party plugin systems that listen for `E`.
     ///
-    /// See also [`ClientTriggerAppExt::add_client_trigger`], [`Self::add_client_event_with`] and the
-    /// [corresponding section](../index.html#from-client-to-server) from the quick start guide.
+    /// See also the [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_client_event<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -41,24 +42,11 @@ pub trait ClientEventAppExt {
 
     /// Same as [`Self::add_client_event`], but additionally maps client entities to server inside the event before sending.
     ///
-    /// Always use it for events that contain entities.
+    /// Always use it for events that contain entities. Entities must be annotated with `#[entities].
+    /// For details, see [`Component::map_entities`].
     ///
     /// [`Clone`] is required because, before sending, we need to map entities from the client to the server without
     /// modifying the original component.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy::{prelude::*, ecs::entity::MapEntities};
-    /// # use bevy_replicon::prelude::*;
-    /// # use serde::{Deserialize, Serialize};
-    /// # let mut app = App::new();
-    /// # app.add_plugins(RepliconPlugins);
-    /// app.add_mapped_client_event::<MappedEvent>(Channel::Ordered);
-    ///
-    /// #[derive(Debug, Deserialize, Event, Serialize, Clone, MapEntities)]
-    /// struct MappedEvent(#[entities] Entity);
-    /// ```
     fn add_mapped_client_event<E: Event + Serialize + DeserializeOwned + MapEntities + Clone>(
         &mut self,
         channel: Channel,

--- a/src/shared/event/client_trigger.rs
+++ b/src/shared/event/client_trigger.rs
@@ -19,7 +19,8 @@ use crate::{
 
 /// An extension trait for [`App`] for creating client triggers.
 ///
-/// See also [`ClientTriggerExt`].
+/// See also [`ClientTriggerExt`] for triggering, [`ServerTriggerAppExt`] for server triggers
+/// and [`ClientEventAppExt`] for events.
 pub trait ClientTriggerAppExt {
     /// Registers a remote event that can be triggered using [`ClientTriggerExt::client_trigger`].
     ///
@@ -28,8 +29,7 @@ pub trait ClientTriggerAppExt {
     /// If [`ServerEventPlugin`] is enabled and [`RepliconClient`] is inactive, the event will also be triggered
     /// locally as [`FromClient<E>`] event with [`FromClient::client`] equal to [`SERVER`].
     ///
-    /// See also [`ClientEventAppExt::add_client_event`], [`Self::add_client_trigger_with`] and the
-    /// [corresponding section](../index.html#from-client-to-server) from the quick start guide.
+    /// See also the [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_client_trigger<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -43,7 +43,8 @@ pub trait ClientTriggerAppExt {
 
     /// Same as [`Self::add_client_trigger`], but additionally maps client entities to server inside the event before sending.
     ///
-    /// Always use it for events that contain entities.
+    /// Always use it for events that contain entities. Entities must be annotated with `#[entities].
+    /// For details, see [`Component::map_entities`].
     fn add_mapped_client_trigger<E: Event + Serialize + DeserializeOwned + MapEntities + Clone>(
         &mut self,
         channel: Channel,

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -29,7 +29,9 @@ use crate::{
     shared::{postcard_utils, replication::client_ticks::ClientTicks},
 };
 
-/// An extension trait for [`App`] for creating client events.
+/// An extension trait for [`App`] for creating server events.
+///
+/// See also [`ClientEventAppExt`] for client events and [`ServerTriggerAppExt`] for triggers.
 pub trait ServerEventAppExt {
     /// Registers a remote server event.
     ///
@@ -45,8 +47,7 @@ pub trait ServerEventAppExt {
     /// Unlike client events, server events are tied to replication. See [`Self::make_event_independent`]
     /// for more details.
     ///
-    /// See also [`ServerTriggerAppExt::add_server_trigger`], [`Self::add_server_event_with`] and the
-    /// [corresponding section](../index.html#from-server-to-client) from the quick start guide.
+    /// See also the [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_server_event<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -56,8 +57,8 @@ pub trait ServerEventAppExt {
 
     /// Same as [`Self::add_server_event`], but additionally maps server entities to client inside the event after receiving.
     ///
-    /// Always use it for events that contain entities.
-    /// See also [`Self::add_server_event`].
+    /// Always use it for events that contain entities. Entities must be annotated with `#[entities].
+    /// For details, see [`Component::map_entities`].
     fn add_mapped_server_event<E: Event + Serialize + DeserializeOwned + MapEntities>(
         &mut self,
         channel: Channel,

--- a/src/shared/event/server_trigger.rs
+++ b/src/shared/event/server_trigger.rs
@@ -19,7 +19,8 @@ use crate::{
 
 /// An extension trait for [`App`] for creating server triggers.
 ///
-/// See also [`ServerTriggerExt`].
+/// See also [`ServerTriggerExt`] for triggering, [`ClientTriggerAppExt`] for client triggers
+/// and [`ServerEventAppExt`] for events.
 pub trait ServerTriggerAppExt {
     /// Registers a remote event that can be triggered using [`ServerTriggerExt::server_trigger`].
     ///
@@ -28,8 +29,7 @@ pub trait ServerTriggerAppExt {
     /// If [`ClientEventPlugin`] is enabled and [`SERVER`] is a recipient of the event
     /// (not to be confused with trigger target), then `E` event will be emitted on the server as well.
     ///
-    /// See also [`Self::add_server_trigger_with`] and the [corresponding section](../index.html#from-server-to-client)
-    /// from the quick start guide.
+    /// See also the [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_server_trigger<E: Event + Serialize + DeserializeOwned>(
         &mut self,
         channel: Channel,
@@ -43,7 +43,8 @@ pub trait ServerTriggerAppExt {
 
     /// Same as [`Self::add_server_trigger`], but additionally maps client entities to server inside the event before receiving.
     ///
-    /// Always use it for events that contain entities.
+    /// Always use it for events that contain entities. Entities must be annotated with `#[entities].
+    /// For details, see [`Component::map_entities`].
     fn add_mapped_server_trigger<E: Event + Serialize + DeserializeOwned + MapEntities>(
         &mut self,
         channel: Channel,


### PR DESCRIPTION
- Explain how to map entities and link to the Bevy docs.
- I removed an example with mapping since it doesn't add much, it's easier to just link to the Bevy docs instead of duplicating it.
- Remove useless cross-links.
- Add useful cross-links.
- Fix description for `ServerEventAppExt`.