### PR TITLE
Use strongly-typed client identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - All contexts now store `AppTypeRegistry` instead of `TypeRegistry`. To get `TypeRegistry`, call `AppTypeRegistry::read`.
+- All events now use `ClientId` wrapper instead of `Entity`.
 - `AppTypeRegistry` now available on replication for observers.
-- Rename `FromClient::client_entity` into `FromClient::client`.
+- Rename `FromClient::client_entity` into `FromClient::client_id`.
 - Rename `DisconnectRequest::client_entity` into `DisconnectRequest::client`.
 - Rename `replicon_channels` module into `channels`.
+
+## Removed
+
+- `SERVER`. Use `ClientId::Server` instead.
 
 ## [0.34.4] - 2025-07-29
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,8 +266,8 @@ fn send_events(mut events: EventWriter<ExampleEvent>) {
 }
 
 fn receive_events(mut events: EventReader<FromClient<ExampleEvent>>) {
-    for FromClient { client, event } in events.read() {
-        info!("received event `{event:?}` from client `{client}`");
+    for FromClient { client_id, event } in events.read() {
+        info!("received event `{event:?}` from client `{client_id}`");
     }
 }
 
@@ -302,7 +302,7 @@ fn send_events(mut commands: Commands) {
 }
 
 fn receive_events(trigger: Trigger<FromClient<ExampleEvent>>) {
-    info!("received event `{:?}` from client `{}`", **trigger, trigger.client);
+    info!("received event `{:?}` from client `{}`", **trigger, trigger.client_id);
 }
 # #[derive(Event, Debug, Deserialize, Serialize)]
 # struct ExampleEvent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,8 +450,8 @@ only if [`client_connected`]. This way for singleplayer replication systems won'
 for listen server replication will only be sending (server world is already in the correct state).
 
 For events it's a bit trickier. For all client events we internally drain events as `E` and re-emit
-them as [`FromClient<E>`] locally with a special [`SERVER`] entity if [`server_or_singleplayer`].
-For server events we drain [`ToClients<E>`] and, if the [`SERVER`] entity is the recipient of the event,
+them as [`FromClient<E>`] locally with [`ClientId::Server`] if [`server_or_singleplayer`] is `true`.
+For server events we drain [`ToClients<E>`] and, if the [`ClientId::Server`] is the recipient of the event,
 re-emit it as `E` locally.
 
 ## Organizing your game code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ pub mod prelude {
     pub use super::{
         RepliconPlugins,
         shared::{
-            AuthMethod, RepliconSharedPlugin, SERVER,
+            AuthMethod, RepliconSharedPlugin,
             backend::{
                 DisconnectRequest,
                 channels::{Channel, RepliconChannels},
@@ -639,6 +639,7 @@ pub mod prelude {
                 replicon_client::{RepliconClient, RepliconClientStatus},
                 replicon_server::RepliconServer,
             },
+            client_id::ClientId,
             common_conditions::*,
             event::{
                 client_event::{ClientEventAppExt, FromClient},

--- a/src/server.rs
+++ b/src/server.rs
@@ -211,21 +211,24 @@ fn check_protocol(
     mut events: EventWriter<DisconnectRequest>,
     protocol: Res<ProtocolHash>,
 ) {
+    let client = trigger
+        .client_id
+        .entity()
+        .expect("protocol hash sent only from clients");
+
     if **trigger == *protocol {
-        debug!("marking client `{}` as authorized", trigger.client);
-        commands.entity(trigger.client).insert(AuthorizedClient);
+        debug!("marking client `{client}` as authorized");
+        commands.entity(client).insert(AuthorizedClient);
     } else {
         debug!(
-            "disconnecting client `{}` due to protocol mismatch (client: `{:?}`, server: `{:?}`)",
-            trigger.client, **trigger, *protocol
+            "disconnecting client `{client}` due to protocol mismatch (client: `{:?}`, server: `{:?}`)",
+            **trigger, *protocol
         );
         commands.server_trigger(ToClients {
-            mode: SendMode::Direct(trigger.client),
+            mode: SendMode::Direct(trigger.client_id),
             event: ProtocolMismatch,
         });
-        events.write(DisconnectRequest {
-            client: trigger.client,
-        });
+        events.write(DisconnectRequest { client });
     }
 }
 

--- a/src/server/client_entity_map.rs
+++ b/src/server/client_entity_map.rs
@@ -50,9 +50,11 @@ fn confirm_bullet(
     mut clients: Query<&mut ClientEntityMap>,
 ) {
     for event in bullet_events.read() {
-        let mut entity_map = clients.get_mut(event.client).unwrap();
         let bullet = commands.spawn(Bullet).id(); // You can insert more components, they will be sent to the client's entity correctly.
-        entity_map.insert(bullet, event.0);
+        if let ClientId::Client(client) = event.client_id {
+            let mut entity_map = clients.get_mut(client).unwrap();
+            entity_map.insert(bullet, event.0);
+        }
     }
 }
 ```

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod client_id;
 pub mod common_conditions;
 pub mod entity_serde;
 pub mod event;
@@ -161,13 +162,6 @@ impl Plugin for RepliconSharedPlugin {
         app.world_mut().insert_resource(protocol_hasher.finish());
     }
 }
-
-/// A placeholder entity for a connected client that refers to the listen server (when the server is also a client).
-///
-/// Equal to [`Entity::PLACEHOLDER`].
-///
-/// See also [`ToClients`] and [`FromClient`] events.
-pub const SERVER: Entity = Entity::PLACEHOLDER;
 
 /// Configures the insertion of [`AuthorizedClient`].
 ///

--- a/src/shared/client_id.rs
+++ b/src/shared/client_id.rs
@@ -1,0 +1,41 @@
+use core::fmt::{self, Display, Formatter};
+
+use bevy::prelude::*;
+
+/// Unique client ID for the current session.
+///
+/// Used for [`ToClients`](super::event::server_event::ToClients) and [`FromClient`](super::event::client_event::FromClient) events.
+///
+/// See also [`NetworkId`](super::backend::connected_client::NetworkId) for a persistent identifier.
+#[derive(Reflect, Debug, Hash, PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
+pub enum ClientId {
+    /// Connected client entity.
+    Client(Entity),
+    /// Server that is also a client (listen server).
+    Server,
+}
+
+impl ClientId {
+    /// Returns associated entity for [`Self::Client`].
+    pub fn entity(self) -> Option<Entity> {
+        match self {
+            ClientId::Client(entity) => Some(entity),
+            ClientId::Server => None,
+        }
+    }
+}
+
+impl From<Entity> for ClientId {
+    fn from(value: Entity) -> Self {
+        Self::Client(value)
+    }
+}
+
+impl Display for ClientId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ClientId::Client(entity) => entity.fmt(f),
+            ClientId::Server => write!(f, "Server"),
+        }
+    }
+}

--- a/src/shared/event/client_event.rs
+++ b/src/shared/event/client_event.rs
@@ -25,8 +25,8 @@ pub trait ClientEventAppExt {
     /// After emitting `E` event on the client, [`FromClient<E>`] event will be emitted on the server.
     ///
     /// If [`ServerEventPlugin`] is enabled and [`RepliconClient`] is inactive, the event will be drained
-    /// right after sending and re-emitted locally as [`FromClient<E>`] event with [`FromClient::client`]
-    /// equal to [`SERVER`].
+    /// right after sending and re-emitted locally as [`FromClient<E>`] event with [`FromClient::client_id`]
+    /// equal to [`ClientId::Server`].
     ///
     /// Calling [`App::add_event`] is not necessary. Can used for regular events that were
     /// previously registered. But be careful, since on listen servers all events `E` are drained,

--- a/src/shared/event/client_event.rs
+++ b/src/shared/event/client_event.rs
@@ -300,7 +300,10 @@ impl ClientEvent {
                         "applying event `{}` from client `{client}`",
                         any::type_name::<E>()
                     );
-                    client_events.send(FromClient { client, event });
+                    client_events.send(FromClient {
+                        client_id: client.into(),
+                        event,
+                    });
                 }
                 Err(e) => debug!(
                     "ignoring event `{}` from client `{client}` that failed to deserialize: {e}",
@@ -335,7 +338,7 @@ impl ClientEvent {
                 any::type_name::<E>()
             );
             client_events.send_batch(events.drain().map(|event| FromClient {
-                client: SERVER,
+                client_id: ClientId::Server,
                 event,
             }));
         }
@@ -442,10 +445,10 @@ impl<E: Event> FromWorld for ClientEventReader<E> {
 /// Emitted only on server.
 #[derive(Clone, Copy, Event, Deref, DerefMut)]
 pub struct FromClient<T> {
-    /// Entity representing a connected client or [`SERVER`] that sent the event.
+    /// Sender of the event.
     ///
     /// See also [`ConnectedClient`].
-    pub client: Entity,
+    pub client_id: ClientId,
 
     /// Transmitted event.
     #[deref]

--- a/src/shared/event/client_trigger.rs
+++ b/src/shared/event/client_trigger.rs
@@ -122,14 +122,14 @@ impl ClientTrigger {
     unsafe fn trigger_typed<E: Event>(commands: &mut Commands, client_events: PtrMut) {
         let client_events: &mut Events<FromClient<ClientTriggerEvent<E>>> =
             unsafe { client_events.deref_mut() };
-        for FromClient { client, event } in client_events.drain() {
+        for FromClient { client_id, event } in client_events.drain() {
             debug!(
-                "triggering `{}` from `{client}`",
+                "triggering `{}` from `{client_id}`",
                 any::type_name::<FromClient<E>>()
             );
             commands.trigger_targets(
                 FromClient {
-                    client,
+                    client_id,
                     event: event.event,
                 },
                 event.targets,

--- a/src/shared/event/client_trigger.rs
+++ b/src/shared/event/client_trigger.rs
@@ -27,7 +27,7 @@ pub trait ClientTriggerAppExt {
     /// After triggering `E` event on the client, [`FromClient<E>`] event will be triggered on the server.
     ///
     /// If [`ServerEventPlugin`] is enabled and [`RepliconClient`] is inactive, the event will also be triggered
-    /// locally as [`FromClient<E>`] event with [`FromClient::client`] equal to [`SERVER`].
+    /// locally as [`FromClient<E>`] event with [`FromClient::client_id`] equal to [`ClientId::Server`].
     ///
     /// See also the [corresponding section](../index.html#from-client-to-server) from the quick start guide.
     fn add_client_trigger<E: Event + Serialize + DeserializeOwned>(

--- a/src/shared/event/server_event.rs
+++ b/src/shared/event/server_event.rs
@@ -37,7 +37,7 @@ pub trait ServerEventAppExt {
     ///
     /// After emitting [`ToClients<E>`] event on the server, `E` event  will be emitted on clients.
     ///
-    /// If [`ClientEventPlugin`] is enabled and [`SERVER`] is a recipient of the event, then
+    /// If [`ClientEventPlugin`] is enabled and [`ClientId::Server`] is a recipient of the event, then
     /// [`ToClients<E>`] event will be drained after sending to clients and `E` event will be emitted
     /// on the server as well.
     ///

--- a/src/shared/event/server_trigger.rs
+++ b/src/shared/event/server_trigger.rs
@@ -26,7 +26,7 @@ pub trait ServerTriggerAppExt {
     ///
     /// After triggering [`ToClients<E>`] event on the server, `E` event will be triggered on clients.
     ///
-    /// If [`ClientEventPlugin`] is enabled and [`SERVER`] is a recipient of the event
+    /// If [`ClientEventPlugin`] is enabled and [`ClientId::Server`] is a recipient of the event
     /// (not to be confused with trigger target), then `E` event will be emitted on the server as well.
     ///
     /// See also the [corresponding section](../index.html#from-client-to-server) from the quick start guide.
@@ -218,7 +218,7 @@ fn trigger_deserialize<'a, E>(
 /// See also [`ServerTriggerAppExt`].
 pub trait ServerTriggerExt {
     /// Like [`Commands::trigger`], but triggers `E` on server and locally
-    /// if [`SERVER`] is a recipient of the event).
+    /// if [`ClientId::Server`] is a recipient of the event).
     fn server_trigger(&mut self, event: ToClients<impl Event>);
 
     /// Like [`Self::server_trigger`], but allows you to specify target entities, similar to

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -55,10 +55,10 @@ fn regular() {
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
-        (SendMode::Direct(SERVER), 0),
-        (SendMode::Direct(test_client_entity), 1),
-        (SendMode::BroadcastExcept(SERVER), 1),
-        (SendMode::BroadcastExcept(test_client_entity), 0),
+        (SendMode::Direct(ClientId::Server), 0),
+        (SendMode::Direct(test_client_entity.into()), 1),
+        (SendMode::BroadcastExcept(ClientId::Server), 1),
+        (SendMode::BroadcastExcept(test_client_entity.into()), 0),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,
@@ -156,10 +156,10 @@ fn without_plugins() {
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
-        (SendMode::Direct(SERVER), 0),
-        (SendMode::Direct(test_client_entity), 1),
-        (SendMode::BroadcastExcept(SERVER), 1),
-        (SendMode::BroadcastExcept(test_client_entity), 0),
+        (SendMode::Direct(ClientId::Server), 0),
+        (SendMode::Direct(test_client_entity.into()), 1),
+        (SendMode::BroadcastExcept(ClientId::Server), 1),
+        (SendMode::BroadcastExcept(test_client_entity.into()), 0),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,
@@ -193,12 +193,12 @@ fn local_resending() {
     .add_server_event::<TestEvent>(Channel::Ordered)
     .finish();
 
-    const PLACEHOLDER_CLIENT_ID: Entity = Entity::from_raw(1);
+    const PLACEHOLDER_CLIENT_ID: ClientId = ClientId::Client(Entity::from_raw(1));
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
-        (SendMode::Direct(SERVER), 1),
+        (SendMode::Direct(ClientId::Server), 1),
         (SendMode::Direct(PLACEHOLDER_CLIENT_ID), 0),
-        (SendMode::BroadcastExcept(SERVER), 0),
+        (SendMode::BroadcastExcept(ClientId::Server), 0),
         (SendMode::BroadcastExcept(PLACEHOLDER_CLIENT_ID), 1),
     ] {
         app.world_mut().send_event(ToClients {
@@ -477,10 +477,10 @@ fn independent() {
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
-        (SendMode::Direct(SERVER), 0),
-        (SendMode::Direct(test_client_entity), 1),
-        (SendMode::BroadcastExcept(SERVER), 1),
-        (SendMode::BroadcastExcept(test_client_entity), 0),
+        (SendMode::Direct(ClientId::Server), 0),
+        (SendMode::Direct(test_client_entity.into()), 1),
+        (SendMode::BroadcastExcept(ClientId::Server), 1),
+        (SendMode::BroadcastExcept(test_client_entity.into()), 0),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,
@@ -537,8 +537,8 @@ fn before_started_replication() {
     let test_client_entity = **client_app.world().resource::<TestClientEntity>();
     for mode in [
         SendMode::Broadcast,
-        SendMode::BroadcastExcept(SERVER),
-        SendMode::Direct(test_client_entity),
+        SendMode::BroadcastExcept(ClientId::Server),
+        SendMode::Direct(test_client_entity.into()),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,


### PR DESCRIPTION
We switched to `Entity` for client identifiers, but using `Entity::PLACEHOLDER` for server is bug-prone and confusing (especially since it's logged as `PLACEHOLDER`).