### PR TITLE
Cleanup backends description

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Depending on your game, you may need additional features. We provide an API that
 
 #### Messaging backends
 
-- [`bevy_replicon_renet2`](https://github.com/UkoeHB/renet2/tree/main/bevy_replicon_renet2) - integration for [`bevy_renet2`](https://github.com/UkoeHB/renet2/tree/main/bevy_renet2). Includes a WebTransport backend for browsers, and enables servers that can manage multi-platform clients simultaneously.
+- [`bevy_replicon_renet2`](https://github.com/UkoeHB/renet2/tree/main/bevy_replicon_renet2) - integration for [`bevy_renet2`](https://github.com/UkoeHB/renet2/tree/main/bevy_renet2).
 - [`bevy_replicon_quinnet`](https://github.com/Henauxg/bevy_replicon_quinnet) - integration for [`bevy_quinnet`](https://github.com/Henauxg/bevy_quinnet).
-- [`aeronet_replicon`](https://github.com/aecsocket/aeronet/tree/main/crates/aeronet_replicon) - integration for [`aeronet`](https://github.com/aecsocket/aeronet). Works on any IO layer supported by `aeronet_io`, but requires `aeronet_transport`.
+- [`aeronet_replicon`](https://github.com/aecsocket/aeronet/tree/main/crates/aeronet_replicon) - integration for [`aeronet`](https://github.com/aecsocket/aeronet).
 - [`bevy_replicon_matchbox`](https://github.com/Occuros/bevy_replicon_matchbox) - integration for [`matchbox`](https://github.com/johanhelsing/matchbox).
 - [`bevy_replicon_renet`](https://github.com/projectharmonia/bevy_replicon_renet) - integration for [`bevy_renet`](https://github.com/lucaspoffo/renet/tree/master/bevy_renet).
 


### PR DESCRIPTION
Previously, renet2’s description highlighted its differences from renet, but this is now mentioned in the readme, and renet itself is listed last. For aeronet, the previous wording sounded like an implementation detail.