### PR TITLE
Rename `ComponentRule` into `RuleComponent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `postcard_utils` a top-level module. Instead of `bevy_replicon::shared::postcard_utils`, it's now just `bevy_replicon::postcard_utils`.
 - Rename `FromClient::client_entity` into `FromClient::client_id`.
 - Rename `DisconnectRequest::client_entity` into `DisconnectRequest::client`.
+- Rename `ComponentRule` into `RuleComponent` and `IntoComponentRule` into `IntoRuleComponent`.
 - Rename `replicon_channels` module into `channels`.
 - Rename `replication_rules` module into `rules`.
 - Rename `replication_registry` module into `registry`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,7 @@ use crate::{
                 ReplicationRegistry, component_fns::ComponentFns, ctx::SerializeCtx,
                 rule_fns::UntypedRuleFns,
             },
-            rules::{ComponentRule, ReplicationRules},
+            rules::{ReplicationRules, RuleComponent},
             track_mutate_messages::TrackMutateMessages,
         },
     },
@@ -732,7 +732,7 @@ fn write_component_cached(
     rule_fns: &UntypedRuleFns,
     component_fns: &ComponentFns,
     ctx: &SerializeCtx,
-    component_rule: ComponentRule,
+    component_rule: RuleComponent,
     component: Ptr<'_>,
 ) -> Result<Range<usize>> {
     if let Some(component_range) = component_range.clone() {

--- a/src/server/server_world.rs
+++ b/src/server/server_world.rs
@@ -14,7 +14,7 @@ use log::{debug, trace};
 
 use crate::{
     prelude::*,
-    shared::replication::rules::{ComponentRule, ReplicationRules},
+    shared::replication::rules::{ReplicationRules, RuleComponent},
 };
 
 /// A [`SystemParam`] that wraps [`World`], but provides access only for replicated components.
@@ -209,7 +209,7 @@ pub(crate) struct ReplicatedArchetype {
     pub(super) id: ArchetypeId,
 
     /// Components marked as replicated.
-    pub(super) components: Vec<(ComponentRule, StorageType)>,
+    pub(super) components: Vec<(RuleComponent, StorageType)>,
 }
 
 impl ReplicatedArchetype {


### PR DESCRIPTION
And `IntoComponentRule` into `IntoRuleComponent`. It's a part of a `ReplicationRule` and contains only a single component.

Working on filters and need to adjust the naming to make it consistent with the upcoming filters.