### PR TITLE
Hide `BufferedMutations` from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `IntoComponentRule::register_component` to `IntoComponentRule::into_rule` and move it to the `shared::replication::rules::component` module.
 - Replace `IntoReplicationRule` with `IntoComponentRules`, which returns only `Vec<ComponentRule>`.
 - Replace `ReplicationBundle` with `BundleRules`, which returns only `Vec<ComponentRule>` and uses an associated constant to customize the priority.
+- Hide `BufferedMutations` from public API.
 
 ## Removed
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -810,13 +810,11 @@ pub enum ClientSet {
 pub struct ServerUpdateTick(RepliconTick);
 
 /// Cached buffered mutate messages, used to synchronize mutations with update messages.
-///
-/// If [`ClientSet::Reset`] is disabled, then this needs to be cleaned up manually with [`Self::clear`].
 #[derive(Default, Resource)]
-pub struct BufferedMutations(Vec<BufferedMutate>);
+pub(crate) struct BufferedMutations(Vec<BufferedMutate>);
 
 impl BufferedMutations {
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         self.0.clear();
     }
 


### PR DESCRIPTION
Was only exposed to call `clear` without the access to its elements.

But since we no longer encourage state repair, let's hide it. The smaller the public API surface we have, the easier it is to make patch releases without breaking changes.