### PR TITLE
Use shorter name

### DIFF
--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -350,10 +350,10 @@ fn marker() {
     let client_entity = client_app.world_mut().spawn(ReplaceMarker).id();
     assert_ne!(server_entity, client_entity);
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 
@@ -533,10 +533,10 @@ fn before_started_replication() {
         "no entities should have been sent to the client"
     );
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     server_app
         .world_mut()
-        .entity_mut(test_client_entity)
+        .entity_mut(client)
         .insert(AuthorizedClient);
 
     server_app.update();
@@ -569,10 +569,10 @@ fn after_started_replication() {
 
     server_app.connect_client(&mut client_app);
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     server_app
         .world_mut()
-        .entity_mut(test_client_entity)
+        .entity_mut(client)
         .insert(AuthorizedClient);
 
     server_app.update();

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -409,10 +409,10 @@ fn marker() {
 
     let client_entity = client_app.world_mut().spawn(ReplaceMarker).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 
@@ -472,10 +472,10 @@ fn marker_with_history() {
 
     let client_entity = client_app.world_mut().spawn(HistoryMarker).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 
@@ -556,10 +556,10 @@ fn marker_with_history_consume() {
 
     let client_entity = client_app.world_mut().spawn(HistoryMarker).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 
@@ -638,10 +638,10 @@ fn marker_with_history_old_update() {
 
     let client_entity = client_app.world_mut().spawn(HistoryMarker).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 
@@ -1183,11 +1183,8 @@ fn after_disconnect() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(test_client_entity)
-        .despawn();
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app.world_mut().entity_mut(client).despawn();
     server_app.update();
 }
 

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -166,10 +166,10 @@ fn marker() {
 
     let client_entity = client_app.world_mut().spawn(ReplaceMarker).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -52,13 +52,13 @@ fn regular() {
 
     server_app.connect_client(&mut client_app);
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
         (SendMode::Direct(ClientId::Server), 0),
-        (SendMode::Direct(test_client_entity.into()), 1),
+        (SendMode::Direct(client.into()), 1),
         (SendMode::BroadcastExcept(ClientId::Server), 1),
-        (SendMode::BroadcastExcept(test_client_entity.into()), 0),
+        (SendMode::BroadcastExcept(client.into()), 0),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,
@@ -153,13 +153,13 @@ fn without_plugins() {
 
     server_app.connect_client(&mut client_app);
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
         (SendMode::Direct(ClientId::Server), 0),
-        (SendMode::Direct(test_client_entity.into()), 1),
+        (SendMode::Direct(client.into()), 1),
         (SendMode::BroadcastExcept(ClientId::Server), 1),
-        (SendMode::BroadcastExcept(test_client_entity.into()), 0),
+        (SendMode::BroadcastExcept(client.into()), 0),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,
@@ -474,13 +474,13 @@ fn independent() {
     // but our independent event should be triggered immediately.
     *client_app.world_mut().resource_mut::<ServerUpdateTick>() = Default::default();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     for (mode, events_count) in [
         (SendMode::Broadcast, 1),
         (SendMode::Direct(ClientId::Server), 0),
-        (SendMode::Direct(test_client_entity.into()), 1),
+        (SendMode::Direct(client.into()), 1),
         (SendMode::BroadcastExcept(ClientId::Server), 1),
-        (SendMode::BroadcastExcept(test_client_entity.into()), 0),
+        (SendMode::BroadcastExcept(client.into()), 0),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,
@@ -534,11 +534,11 @@ fn before_started_replication() {
 
     server_app.connect_client(&mut client_app);
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     for mode in [
         SendMode::Broadcast,
         SendMode::BroadcastExcept(ClientId::Server),
-        SendMode::Direct(test_client_entity.into()),
+        SendMode::Direct(client.into()),
     ] {
         server_app.world_mut().send_event(ToClients {
             mode,

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -206,10 +206,10 @@ fn pre_spawn() {
     let client_entity = client_app.world_mut().spawn_empty().id();
     let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -30,10 +30,10 @@ fn client_stats() {
         .spawn((Replicated, TestComponent))
         .id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut entity_map = server_app
         .world_mut()
-        .get_mut::<ClientEntityMap>(test_client_entity)
+        .get_mut::<ClientEntityMap>(client)
         .unwrap();
     entity_map.insert(server_entity, client_entity);
 

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -61,10 +61,10 @@ fn blacklist() {
         .spawn((Replicated, TestComponent))
         .id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut visibility = server_app
         .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
+        .get_mut::<ClientVisibility>(client)
         .unwrap();
     visibility.set_visibility(server_entity, false);
 
@@ -79,7 +79,7 @@ fn blacklist() {
     // Reverse visibility back.
     let mut visibility = server_app
         .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
+        .get_mut::<ClientVisibility>(client)
         .unwrap();
     visibility.set_visibility(server_entity, true);
 
@@ -114,10 +114,10 @@ fn blacklist_with_despawn() {
 
     let server_entity = server_app.world_mut().spawn(Replicated).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut visibility = server_app
         .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
+        .get_mut::<ClientVisibility>(client)
         .unwrap();
     visibility.set_visibility(server_entity, false);
     server_app.world_mut().despawn(server_entity);
@@ -129,10 +129,7 @@ fn blacklist_with_despawn() {
     let mut replicated = client_app.world_mut().query::<&Replicated>();
     assert_eq!(replicated.iter(client_app.world()).len(), 0);
 
-    let visibility = server_app
-        .world()
-        .get::<ClientVisibility>(test_client_entity)
-        .unwrap();
+    let visibility = server_app.world().get::<ClientVisibility>(client).unwrap();
     assert!(visibility.is_visible(server_entity)); // The missing entity must be removed from the list, so this should return `true`.
 }
 
@@ -193,10 +190,10 @@ fn whitelist() {
         .spawn((Replicated, TestComponent))
         .id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut visibility = server_app
         .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
+        .get_mut::<ClientVisibility>(client)
         .unwrap();
     visibility.set_visibility(server_entity, true);
 
@@ -213,7 +210,7 @@ fn whitelist() {
     // Reverse visibility.
     let mut visibility = server_app
         .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
+        .get_mut::<ClientVisibility>(client)
         .unwrap();
     visibility.set_visibility(server_entity, false);
 
@@ -249,10 +246,10 @@ fn whitelist_with_despawn() {
 
     let server_entity = server_app.world_mut().spawn(Replicated).id();
 
-    let test_client_entity = **client_app.world().resource::<TestClientEntity>();
+    let client = **client_app.world().resource::<TestClientEntity>();
     let mut visibility = server_app
         .world_mut()
-        .get_mut::<ClientVisibility>(test_client_entity)
+        .get_mut::<ClientVisibility>(client)
         .unwrap();
     visibility.set_visibility(server_entity, true);
     server_app.world_mut().despawn(server_entity);
@@ -264,10 +261,7 @@ fn whitelist_with_despawn() {
     let mut replicated = client_app.world_mut().query::<&Replicated>();
     assert_eq!(replicated.iter(client_app.world()).len(), 0);
 
-    let visibility = server_app
-        .world()
-        .get::<ClientVisibility>(test_client_entity)
-        .unwrap();
+    let visibility = server_app.world().get::<ClientVisibility>(client).unwrap();
     assert!(!visibility.is_visible(server_entity));
 }
 


### PR DESCRIPTION
More consistent with the rest of the codebase.