### PR TITLE
Add `ServerPlugin::new`

### DIFF
--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -1,10 +1,7 @@
 use core::time::Duration;
 
 use bevy::{
-    ecs::{component::Mutable, schedule::ScheduleLabel},
-    platform::time::Instant,
-    prelude::*,
-    state::app::StatesPlugin,
+    ecs::component::Mutable, platform::time::Instant, prelude::*, state::app::StatesPlugin,
 };
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -190,10 +187,7 @@ fn create_app<C: BenchmarkComponent>() -> App {
     app.add_plugins((
         MinimalPlugins,
         StatesPlugin,
-        RepliconPlugins.set(ServerPlugin {
-            tick_schedule: PostUpdate.intern(),
-            ..Default::default()
-        }),
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
     ))
     .replicate::<C>()
     .finish();

--- a/bevy_replicon_example_backend/tests/backend.rs
+++ b/bevy_replicon_example_backend/tests/backend.rs
@@ -1,6 +1,6 @@
 use std::{io, net::Ipv4Addr};
 
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::prelude::*;
 use bevy_replicon_example_backend::{ExampleClient, ExampleServer, RepliconExampleBackendPlugins};
 use serde::{Deserialize, Serialize};
@@ -14,10 +14,7 @@ fn connect_disconnect() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
             RepliconExampleBackendPlugins,
         ))
         .finish();
@@ -58,10 +55,7 @@ fn disconnect_request() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
             RepliconExampleBackendPlugins,
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
@@ -111,10 +105,7 @@ fn server_stop() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
             RepliconExampleBackendPlugins,
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
@@ -161,10 +152,7 @@ fn replication() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
             RepliconExampleBackendPlugins,
         ))
         .finish();
@@ -189,10 +177,7 @@ fn server_event() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
             RepliconExampleBackendPlugins,
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
@@ -221,10 +206,7 @@ fn client_event() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
             RepliconExampleBackendPlugins,
         ))
         .add_client_event::<TestEvent>(Channel::Ordered)

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,6 +55,8 @@ pub struct ServerPlugin {
     ///
     /// By default it's set to [`FixedPostUpdate`].
     ///
+    /// You can also use [`Self::new`].
+    ///
     /// # Examples
     ///
     /// Run every frame.
@@ -85,13 +87,20 @@ pub struct ServerPlugin {
     pub mutations_timeout: Duration,
 }
 
-impl Default for ServerPlugin {
-    fn default() -> Self {
+impl ServerPlugin {
+    /// Creates a plugin with the given [`Self::tick_schedule`].
+    pub fn new(tick_schedule: impl ScheduleLabel) -> Self {
         Self {
-            tick_schedule: FixedPostUpdate.intern(),
+            tick_schedule: tick_schedule.intern(),
             visibility_policy: Default::default(),
             mutations_timeout: Duration::from_secs(10),
         }
+    }
+}
+
+impl Default for ServerPlugin {
+    fn default() -> Self {
+        Self::new(FixedPostUpdate)
     }
 }
 

--- a/src/test_app.rs
+++ b/src/test_app.rs
@@ -8,7 +8,7 @@ Extension for [`App`] to communicate with other instances like it's a server.
 # Example
 
 ```
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 
 let mut server_app = App::new();
@@ -18,10 +18,7 @@ for app in [&mut server_app, &mut client_app] {
         MinimalPlugins,
         StatesPlugin,
         // No messaging library plugin required.
-        RepliconPlugins.set(ServerPlugin {
-            tick_schedule: PostUpdate.intern(), // Tick each app update.
-            ..Default::default()
-        }),
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)), // Tick each app update.
     ))
     .finish(); // Don't forget to call `finish`.
 }

--- a/tests/bidirectional_event.rs
+++ b/tests/bidirectional_event.rs
@@ -1,8 +1,4 @@
-use bevy::{
-    ecs::{event::Events, schedule::ScheduleLabel},
-    prelude::*,
-    state::app::StatesPlugin,
-};
+use bevy::{ecs::event::Events, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 use serde::{Deserialize, Serialize};
 use test_log::test;
@@ -51,10 +47,7 @@ fn trigger() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_client_trigger::<TestEvent>(Channel::Ordered)
         .add_server_trigger::<TestEvent>(Channel::Ordered)

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{entity::MapEntities, event::Events, schedule::ScheduleLabel},
+    ecs::{entity::MapEntities, event::Events},
     prelude::*,
     state::app::StatesPlugin,
     time::TimePlugin,
@@ -20,10 +20,7 @@ fn channels() {
     app.add_plugins((
         MinimalPlugins,
         StatesPlugin,
-        RepliconPlugins.set(ServerPlugin {
-            tick_schedule: PostUpdate.intern(),
-            ..Default::default()
-        }),
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
     ))
     .add_event::<NonRemoteEvent>()
     .add_client_event::<TestEvent>(Channel::Ordered)
@@ -66,10 +63,7 @@ fn mapped() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_mapped_client_event::<EntityEvent>(Channel::Ordered)
         .finish();

--- a/tests/client_trigger.rs
+++ b/tests/client_trigger.rs
@@ -1,9 +1,4 @@
-use bevy::{
-    ecs::{entity::MapEntities, schedule::ScheduleLabel},
-    prelude::*,
-    state::app::StatesPlugin,
-    time::TimePlugin,
-};
+use bevy::{ecs::entity::MapEntities, prelude::*, state::app::StatesPlugin, time::TimePlugin};
 use bevy_replicon::{
     prelude::*, shared::server_entity_map::ServerEntityMap, test_app::ServerTestAppExt,
 };
@@ -41,10 +36,7 @@ fn with_target() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_client_trigger::<TestEvent>(Channel::Ordered)
         .finish();
@@ -86,10 +78,7 @@ fn mapped() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_mapped_client_trigger::<EntityEvent>(Channel::Ordered)
         .finish();

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     server::server_tick::ServerTick,
@@ -43,10 +43,7 @@ fn server_start_stop() {
                 .set(RepliconSharedPlugin {
                     auth_method: AuthMethod::Custom,
                 })
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                }),
+                .set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*, shared::server_entity_map::ServerEntityMap, test_app::ServerTestAppExt,
 };
@@ -13,10 +13,7 @@ fn single() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }
@@ -58,10 +55,7 @@ fn with_relations() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }
@@ -98,10 +92,7 @@ fn after_spawn() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<TestComponent>()
         .finish();
@@ -131,10 +122,7 @@ fn signature() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }
@@ -173,9 +161,8 @@ fn hidden() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .finish();

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -1,8 +1,4 @@
-use bevy::{
-    ecs::{schedule::ScheduleLabel, system::SystemState},
-    prelude::*,
-    state::app::StatesPlugin,
-};
+use bevy::{ecs::system::SystemState, prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
@@ -28,10 +24,7 @@ fn table_storage() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<Table>()
         .finish();
@@ -67,10 +60,7 @@ fn sparse_set_storage() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<SparseSet>()
         .finish();
@@ -106,10 +96,7 @@ fn immutable() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<Immutable>()
         .finish();
@@ -158,10 +145,7 @@ fn mapped_existing_entity() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<MappedComponent>()
         .finish();
@@ -209,10 +193,7 @@ fn mapped_new_entity() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<MappedComponent>()
         .finish();
@@ -256,10 +237,7 @@ fn multiple_components() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .replicate::<B>()
@@ -303,10 +281,7 @@ fn command_fns() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<Original>()
         .set_command_fns(replace, command_fns::default_remove::<Replaced>)
@@ -345,10 +320,7 @@ fn marker() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker::<ReplaceMarker>()
         .replicate::<Original>()
@@ -395,10 +367,7 @@ fn group() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate_bundle::<(A, B)>()
         .finish();
@@ -434,10 +403,7 @@ fn not_replicated() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }
@@ -469,10 +435,7 @@ fn after_removal() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -523,10 +486,7 @@ fn before_started_replication() {
                 .set(RepliconSharedPlugin {
                     auth_method: AuthMethod::Custom,
                 })
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                }),
+                .set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -574,10 +534,7 @@ fn after_started_replication() {
                 .set(RepliconSharedPlugin {
                     auth_method: AuthMethod::Custom,
                 })
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                }),
+                .set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -615,10 +572,7 @@ fn confirm_history() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();

--- a/tests/mutate_ticks.rs
+++ b/tests/mutate_ticks.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::server_mutate_ticks::{MutateTickReceived, ServerMutateTicks},
     prelude::*,
@@ -17,10 +17,7 @@ fn without_changes() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .track_mutate_messages()
         .replicate::<BoolComponent>()
@@ -53,10 +50,7 @@ fn one_message() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .track_mutate_messages()
         .replicate::<BoolComponent>()
@@ -121,10 +115,7 @@ fn multiple_messages() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .track_mutate_messages()
         .replicate::<BoolComponent>()

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 use test_log::test;
 
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::{
         ServerUpdateTick,
@@ -30,10 +30,7 @@ fn small_component() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();
@@ -78,10 +75,7 @@ fn package_size_component() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<VecComponent>()
         .finish();
@@ -132,10 +126,7 @@ fn many_components() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .replicate::<VecComponent>()
@@ -189,10 +180,7 @@ fn once() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate_once::<BoolComponent>()
         .finish();
@@ -237,10 +225,7 @@ fn filtered() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate_filtered::<BoolComponent, Without<TestComponent>>()
         .finish();
@@ -297,10 +282,7 @@ fn related() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .sync_related_entities::<ChildOf>()
         .replicate::<BoolComponent>()
@@ -344,10 +326,7 @@ fn command_fns() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<OriginalComponent>()
         .set_command_fns(replace, command_fns::default_remove::<ReplacedComponent>)
@@ -394,10 +373,7 @@ fn marker() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker::<ReplaceMarker>()
         .replicate::<OriginalComponent>()
@@ -451,10 +427,7 @@ fn marker_with_history() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker_with::<HistoryMarker>(MarkerConfig {
             need_history: true,
@@ -524,10 +497,7 @@ fn marker_with_history_consume() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker_with::<HistoryMarker>(MarkerConfig {
             need_history: true,
@@ -611,10 +581,7 @@ fn marker_with_history_old_update() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker_with::<HistoryMarker>(MarkerConfig {
             need_history: true,
@@ -685,10 +652,7 @@ fn many_entities() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();
@@ -739,10 +703,7 @@ fn with_insertion() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .replicate::<TestComponent>()
@@ -785,10 +746,7 @@ fn with_removal() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .replicate::<TestComponent>()
@@ -831,10 +789,7 @@ fn with_despawn() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();
@@ -881,10 +836,7 @@ fn buffering() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();
@@ -940,10 +892,7 @@ fn old_ignored() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<MappedComponent>()
         .finish();
@@ -1009,9 +958,8 @@ fn acknowledgment() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 mutations_timeout: Duration::ZERO, // Will cause dropping updates after each frame.
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<BoolComponent>()
@@ -1087,10 +1035,7 @@ fn confirm_history() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();
@@ -1154,10 +1099,7 @@ fn after_disconnect() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();

--- a/tests/priority.rs
+++ b/tests/priority.rs
@@ -1,6 +1,6 @@
 use test_log::test;
 
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     test_app::{ServerTestAppExt, TestClientEntity},
@@ -15,10 +15,7 @@ fn regular() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();
@@ -75,10 +72,7 @@ fn with_miss() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<BoolComponent>()
         .finish();

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
@@ -21,10 +21,7 @@ fn single() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -62,10 +59,7 @@ fn multiple() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .replicate::<B>()
@@ -111,10 +105,7 @@ fn command_fns() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<Original>()
         .set_command_fns(replace, command_fns::default_remove::<Replaced>)
@@ -153,10 +144,7 @@ fn marker() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker::<ReplaceMarker>()
         .replicate::<Original>()
@@ -202,10 +190,7 @@ fn group() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate_bundle::<(A, B)>()
         .finish();
@@ -248,10 +233,7 @@ fn not_replicated() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }
@@ -300,10 +282,7 @@ fn after_insertion() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -343,10 +322,7 @@ fn with_spawn() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -374,10 +350,7 @@ fn with_despawn() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -417,10 +390,7 @@ fn confirm_history() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -485,9 +455,8 @@ fn hidden() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist, // Hide all spawned entities by default.
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<A>()

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    ecs::{entity::MapEntities, event::Events, schedule::ScheduleLabel},
+    ecs::{entity::MapEntities, event::Events},
     prelude::*,
     state::app::StatesPlugin,
     time::TimePlugin,
@@ -22,10 +22,7 @@ fn channels() {
     app.add_plugins((
         MinimalPlugins,
         StatesPlugin,
-        RepliconPlugins.set(ServerPlugin {
-            tick_schedule: PostUpdate.intern(),
-            ..Default::default()
-        }),
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
     ))
     .add_event::<NonRemoteEvent>()
     .add_server_event::<TestEvent>(Channel::Ordered)
@@ -44,10 +41,7 @@ fn regular() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .finish();
@@ -90,10 +84,7 @@ fn mapped() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_mapped_server_event::<EntityEvent>(Channel::Ordered)
         .finish();
@@ -138,10 +129,7 @@ fn without_plugins() {
             StatesPlugin,
             RepliconPlugins
                 .build()
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                })
+                .set(ServerPlugin::new(PostUpdate))
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
@@ -194,10 +182,7 @@ fn local_resending() {
     app.add_plugins((
         TimePlugin,
         StatesPlugin,
-        RepliconPlugins.set(ServerPlugin {
-            tick_schedule: PostUpdate.intern(),
-            ..Default::default()
-        }),
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
     ))
     .add_server_event::<TestEvent>(Channel::Ordered)
     .finish();
@@ -277,10 +262,7 @@ fn client_queue() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .finish();
@@ -328,10 +310,7 @@ fn client_queue_and_mapping() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_mapped_server_event::<EntityEvent>(Channel::Ordered)
         .finish();
@@ -392,10 +371,7 @@ fn multiple_client_queues() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .add_server_event::<EntityEvent>(Channel::Ordered) // Use as a regular event with a different serialization size.
@@ -455,10 +431,7 @@ fn independent() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .add_server_event::<IndependentEvent>(Channel::Ordered)
@@ -528,10 +501,7 @@ fn before_started_replication() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                })
+                .set(ServerPlugin::new(PostUpdate))
                 .set(RepliconSharedPlugin {
                     auth_method: AuthMethod::Custom,
                 }),
@@ -572,10 +542,7 @@ fn independent_before_started_replication() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                })
+                .set(ServerPlugin::new(PostUpdate))
                 .set(RepliconSharedPlugin {
                     auth_method: AuthMethod::Custom,
                 }),
@@ -621,10 +588,7 @@ fn different_ticks() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_event::<TestEvent>(Channel::Ordered)
         .finish();

--- a/tests/server_trigger.rs
+++ b/tests/server_trigger.rs
@@ -1,9 +1,4 @@
-use bevy::{
-    ecs::{entity::MapEntities, schedule::ScheduleLabel},
-    prelude::*,
-    state::app::StatesPlugin,
-    time::TimePlugin,
-};
+use bevy::{ecs::entity::MapEntities, prelude::*, state::app::StatesPlugin, time::TimePlugin};
 use bevy_replicon::{
     client::ServerUpdateTick, prelude::*, shared::server_entity_map::ServerEntityMap,
     test_app::ServerTestAppExt,
@@ -19,10 +14,7 @@ fn regular() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_trigger::<TestEvent>(Channel::Ordered)
         .finish();
@@ -52,10 +44,7 @@ fn with_target() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_trigger::<TestEvent>(Channel::Ordered)
         .finish();
@@ -97,10 +86,7 @@ fn mapped() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_mapped_server_trigger::<EntityEvent>(Channel::Ordered)
         .finish();
@@ -142,10 +128,7 @@ fn without_plugins() {
             StatesPlugin,
             RepliconPlugins
                 .build()
-                .set(ServerPlugin {
-                    tick_schedule: PostUpdate.intern(),
-                    ..Default::default()
-                })
+                .set(ServerPlugin::new(PostUpdate))
                 .disable::<ClientPlugin>()
                 .disable::<ClientEventPlugin>(),
         ))
@@ -185,10 +168,7 @@ fn local_resending() {
     app.add_plugins((
         TimePlugin,
         StatesPlugin,
-        RepliconPlugins.set(ServerPlugin {
-            tick_schedule: PostUpdate.intern(),
-            ..Default::default()
-        }),
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
     ))
     .add_server_trigger::<TestEvent>(Channel::Ordered)
     .finish();
@@ -216,10 +196,7 @@ fn independent() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_server_trigger::<TestEvent>(Channel::Ordered)
         .add_server_trigger::<IndependentEvent>(Channel::Ordered)

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     client::confirm_history::ConfirmHistory,
     prelude::*,
@@ -16,10 +16,7 @@ fn empty() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .finish();
     }
@@ -59,10 +56,7 @@ fn with_component() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -88,10 +82,7 @@ fn with_multiple_components() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .replicate::<B>()
@@ -125,10 +116,7 @@ fn with_old_component() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -169,10 +157,7 @@ fn before_connection() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -201,10 +186,7 @@ fn signature() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -264,10 +246,7 @@ fn signature_before_connection() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();
@@ -298,10 +277,7 @@ fn signature_for_client() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<A>()
         .finish();

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
 use serde::{Deserialize, Serialize};
 use test_log::test;
@@ -11,10 +11,7 @@ fn client_stats() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<TestComponent>()
         .finish();

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, state::app::StatesPlugin};
+use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_replicon::{
     prelude::*,
     test_app::{ServerTestAppExt, TestClientEntity},
@@ -15,9 +15,8 @@ fn empty_blacklist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Blacklist,
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<TestComponent>()
@@ -47,9 +46,8 @@ fn blacklist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Blacklist,
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<TestComponent>()
@@ -104,9 +102,8 @@ fn blacklist_with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Blacklist,
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<TestComponent>()
@@ -145,9 +142,8 @@ fn empty_whitelist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist,
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<TestComponent>()
@@ -179,9 +175,8 @@ fn whitelist() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist,
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<TestComponent>()
@@ -239,9 +234,8 @@ fn whitelist_with_despawn() {
             MinimalPlugins,
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
                 visibility_policy: VisibilityPolicy::Whitelist,
-                ..Default::default()
+                ..ServerPlugin::new(PostUpdate)
             }),
         ))
         .replicate::<TestComponent>()
@@ -279,10 +273,7 @@ fn signature() {
         app.add_plugins((
             MinimalPlugins,
             StatesPlugin,
-            RepliconPlugins.set(ServerPlugin {
-                tick_schedule: PostUpdate.intern(),
-                ..Default::default()
-            }),
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .replicate::<TestComponent>()
         .finish();


### PR DESCRIPTION
Requires #574.

To conveniently set the schedule without importing the `ScheduleLabel` trait.