### PR TITLE
Include `TrackAppExt::track_mutate_messages` in the replication protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move `VisibilityPolicy` to `server::client_visibility` module.
+- Include `TrackAppExt::track_mutate_messages` in the replication protocol, since it affects the serialization format.
 
 ## [0.36.1] - 2025-10-11
 

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -98,6 +98,11 @@ impl ProtocolHasher {
         self.hash::<E>(ProtocolPart::IndependentEvent);
     }
 
+    pub(crate) fn track_mutate_messages(&mut self) {
+        debug!("enabling mutate message tracking");
+        ProtocolPart::TrackMutateMessages.hash(&mut self.0);
+    }
+
     fn hash<T>(&mut self, part: ProtocolPart) {
         part.hash(&mut self.0);
         any::type_name::<T>().hash(&mut self.0);
@@ -127,6 +132,7 @@ enum ProtocolPart {
     ServerEvent,
     IndependentMessage,
     IndependentEvent,
+    TrackMutateMessages,
 }
 
 /// Hash of all registered events and replication rules.
@@ -225,10 +231,11 @@ mod tests {
             hasher.add_server_event::<StructC>();
             hasher.add_client_message::<StructB>();
             hasher.add_client_event::<StructC>();
+            hasher.track_mutate_messages();
             hasher.add_custom(0usize);
         }
 
-        const EXPECTED: ProtocolHash = ProtocolHash(10617357519866006183);
+        const EXPECTED: ProtocolHash = ProtocolHash(7833509759262497991);
         assert_eq!(hasher1.finish(), EXPECTED);
         assert_eq!(hasher2.finish(), EXPECTED);
     }

--- a/src/shared/replication/track_mutate_messages.rs
+++ b/src/shared/replication/track_mutate_messages.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
-use log::debug;
+
+use crate::prelude::*;
 
 pub trait TrackAppExt {
     /// Enables mutate messages tracking.
@@ -19,7 +20,10 @@ pub trait TrackAppExt {
 
 impl TrackAppExt for App {
     fn track_mutate_messages(&mut self) -> &mut Self {
-        debug!("enabling mutate message tracking");
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .track_mutate_messages();
+
         self.world_mut().resource_mut::<TrackMutateMessages>().0 = true;
         self
     }


### PR DESCRIPTION
This feature affects the serialization format.