### PR TITLE
Change StateScoped to DespawnOnExit in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ app.add_systems(OnEnter(ClientState::Connecting), display_connection_message) //
 # fn initialize_match() {}
 ```
 
-You can also use these states with [`DespawnOnExit`] to control the lifetime of entities across states.
+You can also use these states with [`DespawnOnExit`] to control the lifetime of entities.
 
 Read more about system patterns in the [Abstracting over configurations](#abstracting-over-configurations)
 section.


### PR DESCRIPTION
[State Scoped](https://docs.rs/bevy_state/0.17.2/bevy_state/state_scoped/type.StateScoped.html) and AppExtStates::enable_state_scoped_entities have been deprecated as of bevy version 0.17.

Updated docs to be hopefully more correct.