### PR TITLE
Avoid sending despawn for entities that weren't sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `VisibilityPolicy` to `server::client_visibility` module.
 - Include `TrackAppExt::track_mutate_messages` in the replication protocol, since it affects the serialization format.
 
+### Fixed
+
+- Avoid sending despawn for entities that weren't sent.
+
 ## [0.36.1] - 2025-10-11
 
 ### Changed

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -148,8 +148,10 @@ impl ClientTicks {
     }
 
     /// Removes a despawned or hidden entity from tracking by this client.
-    pub(crate) fn remove_entity(&mut self, entity: Entity) {
-        self.mutation_ticks.remove(&entity);
+    ///
+    /// Returns `true` if the entity has a tick.
+    pub(crate) fn remove_entity(&mut self, entity: Entity) -> bool {
+        self.mutation_ticks.remove(&entity).is_some()
     }
 
     /// Removes all mutate messages older then `min_timestamp`.

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -461,27 +461,15 @@ fn hidden() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
+    server_app.world_mut().spawn((Replicated, A)).remove::<A>();
 
     server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
 
-    server_app
-        .world_mut()
-        .entity_mut(server_entity)
-        .remove::<A>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    let mut replicated = client_app.world_mut().query::<&Replicated>();
+    let mut messages = server_app.world_mut().resource_mut::<ServerMessages>();
     assert_eq!(
-        replicated.iter(client_app.world()).len(),
+        messages.drain_sent().count(),
         0,
-        "client shouldn't know about hidden entity"
+        "client shouldn't receive anything for a hidden entity"
     );
 }
 

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -19,15 +19,10 @@ fn client_stats() {
 
     server_app.connect_client(&mut client_app);
 
-    client_app
-        .world_mut()
-        .spawn((TestComponent, Signature::from(0)));
     let server_entity = server_app
         .world_mut()
         .spawn((Replicated, TestComponent, Signature::from(0)))
         .id();
-
-    server_app.world_mut().spawn(Replicated).despawn();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -43,14 +38,21 @@ fn client_stats() {
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    server_app.world_mut().despawn(server_entity);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
 
     let stats = client_app.world().resource::<ClientReplicationStats>();
     assert_eq!(stats.entities_changed, 2);
     assert_eq!(stats.components_changed, 2);
     assert_eq!(stats.mappings, 1);
     assert_eq!(stats.despawns, 1);
-    assert_eq!(stats.messages, 2);
-    assert_eq!(stats.bytes, 24);
+    assert_eq!(stats.messages, 3);
+    assert_eq!(stats.bytes, 25);
 }
 
 #[derive(Component, Deserialize, Serialize)]


### PR DESCRIPTION
Discovered a small bug while working on the new visibility API.
I updated the check in `after_spawn` to cause fail without the fix.
I also updated other tests to use the same strong check just in case.