### PR TITLE
Compare changes using `RepliconTick`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -249,7 +249,6 @@ fn cleanup_acks(
 }
 
 fn receive_acks(
-    change_tick: SystemChangeTick,
     mut messages: ResMut<ServerMessages>,
     mut pools: ResMut<ClientPools>,
     mut clients: Query<&mut ClientTicks>,
@@ -263,9 +262,7 @@ fn receive_acks(
                             "messages from client `{client}` should have been removed on disconnect"
                         )
                     });
-                    if let Some(mut entities) =
-                        ticks.ack_mutate_message(client, change_tick.this_run(), mutate_index)
-                    {
+                    if let Some(mut entities) = ticks.ack_mutate_message(client, mutate_index) {
                         entities.clear();
                         pools.entities.push(entities);
                     }

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -99,7 +99,6 @@ impl ClientTicks {
     pub(crate) fn ack_mutate_message(
         &mut self,
         client: Entity,
-        this_run: Tick,
         mutate_index: MutateIndex,
     ) -> Option<Vec<Entity>> {
         let Some(mutate_info) = self.mutations.remove(&mutate_index) else {
@@ -115,7 +114,7 @@ impl ClientTicks {
 
             // Received tick could be outdated because we bump it
             // if we detect any insertion on the entity in `collect_changes`.
-            if !system_tick.is_newer_than(mutate_info.system_tick, this_run) {
+            if *server_tick < mutate_info.server_tick {
                 *system_tick = mutate_info.system_tick;
                 *server_tick = mutate_info.server_tick;
             }


### PR DESCRIPTION
Requires #601.

After #553, we now store a `RepliconTick` per entity. This allows us to simplify acknowledgment by comparing against it instead of comparing by `Tick`.