### PR TITLE
Send mappings only for entities with `Replicated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid sending despawn for entities that weren't sent.
 - Replication for rules with multiple components when their insertions were split across multiple ticks.
 - Avoid panicking when `Signature` inserted during replication.
+- Send mappings only for entities with `Replicated`.
 
 ### Removed
 


### PR DESCRIPTION
Requires #609.

Added `Replicated` to the query filter. Also realized we don't need the addition check. Verifying that the client received the entity is enough.