### PR TITLE
Free disk space

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
         run: cargo install cargo-tarpaulin
 
       - name: Test
-        run: cargo tarpaulin --workspace --all-features --all-targets --engine llvm --out lcov --exclude-files benches/*
+        run: cargo tarpaulin --workspace --all-features --all-targets --engine llvm --out lcov --exclude-files benches/* example_backend/examples/* example_backend/tests/*
 
       - name: Upload code coverage results
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
We're running into a space limit, which causes `ld` to terminate with a bus error.