### PR TITLE
Do not resend messages locally after disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replication for rules with multiple components when their insertions were split across multiple ticks.
 - Avoid panicking when `Signature` inserted during replication.
 - Send mappings only for entities with `Replicated`.
+- After disconnecting, clients no longer resend buffered messages locally.
 
 ### Removed
 
 - `VisibilityPolicy`. No longer needed because visibility is now ergonomically controlled by components.
+- `ClientSystems::ResetEvents`. Events now reset during `ClientSystems::Reset` like everything else.
 
 ## [0.36.1] - 2025-10-11
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -57,12 +57,7 @@ impl Plugin for ClientPlugin {
             )
             .configure_sets(
                 OnEnter(ClientState::Connected),
-                (
-                    ClientSystems::ResetEvents,
-                    ClientSystems::Receive,
-                    ClientSystems::Diagnostics,
-                )
-                    .chain(),
+                (ClientSystems::Receive, ClientSystems::Diagnostics).chain(),
             )
             .configure_sets(
                 PostUpdate,
@@ -785,12 +780,6 @@ pub enum ClientSystems {
     ///
     /// Runs in [`PostUpdate`].
     SendPackets,
-    /// Systems that reset queued server events.
-    ///
-    /// This is a separate set from [`ClientSystems::Reset`] to avoid sending events that were sent before the connection.
-    ///
-    /// Runs in [`OnEnter`] for [`ClientState::Connected`].
-    ResetEvents,
     /// Systems that reset the client.
     ///
     /// Runs in [`OnExit`] for [`ClientState::Connected`].

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -142,13 +142,14 @@ impl Plugin for ClientMessagePlugin {
             )
             .add_systems(
                 OnEnter(ClientState::Connected),
-                (
-                    reset_fn.in_set(ClientSystems::ResetEvents),
-                    (enter_receive_fn, enter_trigger_fn)
-                        .chain()
-                        .after(super::receive_replication)
-                        .in_set(ClientSystems::Receive),
-                ),
+                (enter_receive_fn, enter_trigger_fn)
+                    .chain()
+                    .after(super::receive_replication)
+                    .in_set(ClientSystems::Receive),
+            )
+            .add_systems(
+                OnExit(ClientState::Connected),
+                reset_fn.in_set(ClientSystems::Reset),
             )
             .add_systems(
                 PostUpdate,

--- a/src/shared/message/client_message.rs
+++ b/src/shared/message/client_message.rs
@@ -372,7 +372,7 @@ impl ClientMessage {
         let drained_count = messages.drain().count();
         if drained_count > 0 {
             warn!(
-                "discarded {drained_count} messages of type `{}` that were buffered before the connection",
+                "discarded {drained_count} messages of type `{}` due to a disconnect",
                 ShortName::of::<M>()
             );
         }

--- a/src/shared/message/server_message.rs
+++ b/src/shared/message/server_message.rs
@@ -586,8 +586,9 @@ impl ServerMessage {
         let queue: &mut MessageQueue<M> = unsafe { queue.deref_mut() };
         if !queue.is_empty() {
             warn!(
-                "discarding {} queued messages due to a disconnect",
-                queue.len()
+                "discarding {} queued messages of type `{}` due to a disconnect",
+                queue.len(),
+                ShortName::of::<M>()
             );
         }
         queue.clear();


### PR DESCRIPTION
In the RTS example, when the server disconnects a client because it selected an already occupied team, protocol events were being resent locally on the client.

This happened because events are resent locally when the client is not connected, to support single-player and listen-server modes.

To fix this, we need toreset events after disconnect. Previously, events were reset before connection, but doing so after disconnect is more consistent with the rest of our logic.

Added two tests reproducing the issue (messages and events) and verified they now pass.