### PR TITLE
Add `iter_sent` and `iter_received` to backend message resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `iter_received` and `iter_sent` methods on `ClientMessages` and `ServerMessages` to inspect inbound and outbound messages on a channel without consuming them.
+
 ### Changed
 
 - `VisibilityFilter` trait and related types moved to the `shared::replication::visibility` module and no longer feature gated by the `server` feature.

--- a/src/shared/backend/client_messages.rs
+++ b/src/shared/backend/client_messages.rs
@@ -40,6 +40,22 @@ impl ClientMessages {
         channel_messages.len()
     }
 
+    /// Returns an iterator over received messages from the server on a channel without consuming them.
+    ///
+    /// Unlike [`Self::receive`], the messages stay in the resource. Intended for tools
+    /// that need to observe inbound traffic (e.g. debug overlays or client-side replay
+    /// recording) alongside Replicon's normal consumption.
+    pub fn iter_received<I: Into<usize>>(
+        &self,
+        channel_id: I,
+    ) -> impl ExactSizeIterator<Item = &Bytes> + '_ {
+        let channel_id = channel_id.into();
+        self.received_messages
+            .get(channel_id)
+            .unwrap_or_else(|| panic!("client should have a receive channel with id {channel_id}"))
+            .iter()
+    }
+
     /// Receives all available messages from the server over a channel.
     ///
     /// All messages will be drained.
@@ -88,6 +104,17 @@ impl ClientMessages {
             channel_messages.clear();
         }
         self.sent_messages.clear();
+    }
+
+    /// Returns an iterator over sent messages without consuming them.
+    ///
+    /// Unlike [`Self::drain_sent`], the messages stay in the resource. Intended for
+    /// tools that need to observe outbound traffic before the messaging backend drains
+    /// them.
+    pub fn iter_sent(&self) -> impl ExactSizeIterator<Item = (usize, &Bytes)> + '_ {
+        self.sent_messages
+            .iter()
+            .map(|(channel_id, bytes)| (*channel_id, bytes))
     }
 
     /// Removes all sent messages, returning them as an iterator with channel.

--- a/src/shared/backend/client_messages.rs
+++ b/src/shared/backend/client_messages.rs
@@ -42,9 +42,9 @@ impl ClientMessages {
 
     /// Returns an iterator over received messages from the server on a channel without consuming them.
     ///
-    /// Unlike [`Self::receive`], the messages stay in the resource. Intended for tools
-    /// that need to observe inbound traffic (such as client-side replay
-    /// recording) before Replicon consumes them.
+    /// The messages stay in the resource. Intended for tools that need to
+    /// observe inbound traffic (such as client-side replay recording) before
+    /// Replicon consumes them.
     pub fn iter_received<I: Into<usize>>(
         &self,
         channel_id: I,

--- a/src/shared/backend/client_messages.rs
+++ b/src/shared/backend/client_messages.rs
@@ -43,8 +43,8 @@ impl ClientMessages {
     /// Returns an iterator over received messages from the server on a channel without consuming them.
     ///
     /// Unlike [`Self::receive`], the messages stay in the resource. Intended for tools
-    /// that need to observe inbound traffic (e.g. debug overlays or client-side replay
-    /// recording) alongside Replicon's normal consumption.
+    /// that need to observe inbound traffic (such as client-side replay
+    /// recording) before Replicon consumes them.
     pub fn iter_received<I: Into<usize>>(
         &self,
         channel_id: I,

--- a/src/shared/backend/server_messages.rs
+++ b/src/shared/backend/server_messages.rs
@@ -37,6 +37,23 @@ impl ServerMessages {
         self.sent_messages.retain(|&(entity, ..)| entity != client);
     }
 
+    /// Returns an iterator over received messages from clients on a channel without consuming them.
+    ///
+    /// Unlike [`Self::receive`], the messages stay in the resource. Intended for tools
+    /// that need to observe inbound traffic (e.g. debug overlays or replay recording)
+    /// alongside Replicon's normal consumption.
+    pub fn iter_received<I: Into<usize>>(
+        &self,
+        channel_id: I,
+    ) -> impl ExactSizeIterator<Item = (Entity, &Bytes)> + '_ {
+        let channel_id = channel_id.into();
+        self.received_messages
+            .get(channel_id)
+            .unwrap_or_else(|| panic!("server should have a receive channel with id {channel_id}"))
+            .iter()
+            .map(|(entity, bytes)| (*entity, bytes))
+    }
+
     /// Receives all available messages from clients over a channel.
     ///
     /// All messages will be drained.
@@ -93,6 +110,17 @@ impl ServerMessages {
         F: FnMut(&(Entity, usize, Bytes)) -> bool,
     {
         self.sent_messages.retain(f)
+    }
+
+    /// Returns an iterator over sent messages without consuming them.
+    ///
+    /// Unlike [`Self::drain_sent`], the messages stay in the resource. Intended for
+    /// tools that need to observe outbound traffic (e.g. server-side replay recording)
+    /// before the messaging backend drains them.
+    pub fn iter_sent(&self) -> impl ExactSizeIterator<Item = (Entity, usize, &Bytes)> + '_ {
+        self.sent_messages
+            .iter()
+            .map(|(entity, channel_id, bytes)| (*entity, *channel_id, bytes))
     }
 
     /// Removes all sent messages, returning them as an iterator with client entity and channel.

--- a/src/shared/backend/server_messages.rs
+++ b/src/shared/backend/server_messages.rs
@@ -40,8 +40,8 @@ impl ServerMessages {
     /// Returns an iterator over received messages from clients on a channel without consuming them.
     ///
     /// Unlike [`Self::receive`], the messages stay in the resource. Intended for tools
-    /// that need to observe inbound traffic (e.g. debug overlays or replay recording)
-    /// alongside Replicon's normal consumption.
+    /// that need to observe inbound traffic (such as replay recording)
+    /// before Replicon consumes them.
     pub fn iter_received<I: Into<usize>>(
         &self,
         channel_id: I,

--- a/src/shared/backend/server_messages.rs
+++ b/src/shared/backend/server_messages.rs
@@ -39,9 +39,9 @@ impl ServerMessages {
 
     /// Returns an iterator over received messages from clients on a channel without consuming them.
     ///
-    /// Unlike [`Self::receive`], the messages stay in the resource. Intended for tools
-    /// that need to observe inbound traffic (such as replay recording)
-    /// before Replicon consumes them.
+    /// The messages stay in the resource. Intended for tools that need to
+    /// observe inbound traffic (such as replay recording) before Replicon
+    /// consumes them.
     pub fn iter_received<I: Into<usize>>(
         &self,
         channel_id: I,


### PR DESCRIPTION
## Summary

Adds four non-consuming inspection methods on the backend message resources:

  - `ServerMessages::iter_sent` -> `(Entity, usize, &Bytes)`
  - `ServerMessages::iter_received` -> `(Entity, &Bytes)`
  - `ClientMessages::iter_sent` -> `(usize, &Bytes)`
  - `ClientMessages::iter_received` -> `&Bytes`

All four borrow the underlying buffer (no allocation, no clone of `Bytes`) and return `ExactSizeIterator`.

## Motivation

The current API only exposes `drain_*` / `receive` for reading the message buffers, which consumes them. That works for a backend that *is* the only reader, but blocks tooling that wants to observe traffic without disturbing Replicon's normal consumption - e.g. debug overlays, traffic recorders, or replay capture systems that want to tee the encoded byte stream to disk before the backend forwards it.

Without an inspection API the workaround is to drain everything and then re-`send` / `insert_received` to put it back, which works for the server's outbound buffer (since `send` is `pub`) but is impossible for `ClientMessages` inbound buffer (`receive` is `pub(crate)`) without forking or wrapping the network backend.