### PR TITLE
Make ServerMessages::retain_sent public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `ServerMessages::retain_sent` is now public, allowing users to filter outbound messages before the backend drains them.
 - `VisibilityFilter` trait and related types moved to the `shared::replication::visibility` module and no longer feature gated by the `server` feature.
 - `Replicated` is no longer automatically inserted on clients, only `Remote`. `scene::replicate_into` will serialize all entities that have either `Remote` or `Replicated`.
 

--- a/src/shared/backend/server_messages.rs
+++ b/src/shared/backend/server_messages.rs
@@ -86,9 +86,7 @@ impl ServerMessages {
     }
 
     /// Retains only the messages specified by the predicate.
-    ///
-    /// Used for testing.
-    pub(crate) fn retain_sent<F>(&mut self, f: F)
+    pub fn retain_sent<F>(&mut self, f: F)
     where
         F: FnMut(&(Entity, usize, Bytes)) -> bool,
     {


### PR DESCRIPTION
Promotes `ServerMessages::retain_sent` from `pub(crate)` to `pub` so users can filter outbound server messages in-place (e.g. dropping messages to specific clients or channels before the backend drains them).