### PR TITLE
Add broadcast messages and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `iter_received` and `iter_sent` methods on `ClientMessages` and `ServerMessages` to inspect inbound and outbound messages on a channel without consuming them.
 
+### Added
+
+- Broadcast messages and events via `BroadcastMessageAppExt` and `BroadcastEventAppExt`. Emitted as `Broadcast<M>` on both the sender and the receiver to allow shared logic for client-side prediction.
+
 ### Changed
 
 - `ServerMessages::retain_sent` is now public, allowing users to filter outbound messages before the backend drains them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `iter_received` and `iter_sent` methods on `ClientMessages` and `ServerMessages` to inspect inbound and outbound messages on a channel without consuming them.
-
-### Added
-
 - Broadcast messages and events via `BroadcastMessageAppExt` and `BroadcastEventAppExt`. Emitted as `Broadcast<M>` on both the sender and the receiver to allow shared logic for client-side prediction.
+- `iter_received` and `iter_sent` methods on `ClientMessages` and `ServerMessages` to inspect inbound and outbound messages on a channel without consuming them.
 
 ### Changed
 

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -51,6 +51,37 @@ impl Plugin for ClientMessagePlugin {
             .build_state(app.world_mut())
             .build_system(send);
 
+        let broadcast_send_fn = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for message in registry.iter_all_broadcast() {
+                    builder.add_write_by_id(message.messages_id());
+                }
+            }),
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for message in registry.iter_all_broadcast() {
+                    builder.add_write_by_id(message.broadcast_id());
+                }
+            }),
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(broadcast_send);
+
+        let broadcast_trigger_fn = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for event in registry.iter_broadcast_events() {
+                    builder.add_write_by_id(event.message().broadcast_id());
+                }
+            }),
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(broadcast_trigger);
+
         let receive_builder = (
             FilteredResourcesMutParamBuilder::new(|builder| {
                 for message in registry.iter_all_server() {
@@ -113,6 +144,22 @@ impl Plugin for ClientMessagePlugin {
             .build_state(app.world_mut())
             .build_system(send_locally);
 
+        let broadcast_send_locally_fn = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for message in registry.iter_all_broadcast() {
+                    builder.add_write_by_id(message.broadcast_id());
+                }
+            }),
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for message in registry.iter_all_broadcast() {
+                    builder.add_write_by_id(message.messages_id());
+                }
+            }),
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(broadcast_send_locally);
+
         let reset_fn = (
             FilteredResourcesMutParamBuilder::new(|builder| {
                 for message in registry.iter_all_client() {
@@ -122,6 +169,11 @@ impl Plugin for ClientMessagePlugin {
             FilteredResourcesMutParamBuilder::new(|builder| {
                 for message in registry.iter_all_server() {
                     builder.add_write_by_id(message.queue_id());
+                }
+            }),
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for message in registry.iter_all_broadcast() {
+                    builder.add_write_by_id(message.messages_id());
                 }
             }),
             ParamBuilder,
@@ -155,7 +207,10 @@ impl Plugin for ClientMessagePlugin {
                 PostUpdate,
                 (
                     send_fn.run_if(in_state(ClientState::Connected)),
+                    broadcast_send_fn.run_if(in_state(ClientState::Connected)),
                     send_locally_fn.run_if(in_state(ClientState::Disconnected)),
+                    broadcast_send_locally_fn.run_if(in_state(ClientState::Disconnected)),
+                    broadcast_trigger_fn,
                 )
                     .chain()
                     .in_set(ClientSystems::Send),
@@ -191,6 +246,40 @@ fn send(
                 &mut ctx,
                 &messages,
                 reader.into_inner(),
+                &mut client_messages,
+            );
+        }
+    }
+}
+
+fn broadcast_send(
+    mut messages: FilteredResourcesMut,
+    mut broadcasts: FilteredResourcesMut,
+    mut client_messages: ResMut<ClientMessages>,
+    type_registry: Res<AppTypeRegistry>,
+    entity_map: Res<ServerEntityMap>,
+    registry: Res<RemoteMessageRegistry>,
+) {
+    let mut ctx = ClientSendCtx {
+        entity_map: &entity_map,
+        type_registry: &type_registry,
+        invalid_entities: Vec::new(),
+    };
+
+    for message in registry.iter_all_broadcast() {
+        let messages = messages
+            .get_mut_by_id(message.messages_id())
+            .expect("messages resource should be accessible");
+        let broadcasts = broadcasts
+            .get_mut_by_id(message.broadcast_id())
+            .expect("broadcast messages resource should be accessible");
+
+        // SAFETY: passed pointers were obtained using this message data.
+        unsafe {
+            message.send(
+                &mut ctx,
+                messages.into_inner(),
+                broadcasts.into_inner(),
                 &mut client_messages,
             );
         }
@@ -246,6 +335,20 @@ fn trigger(
     }
 }
 
+fn broadcast_trigger(
+    mut broadcasts: FilteredResourcesMut,
+    mut commands: Commands,
+    registry: Res<RemoteMessageRegistry>,
+) {
+    for event in registry.iter_broadcast_events() {
+        let broadcasts = broadcasts
+            .get_mut_by_id(event.message().broadcast_id())
+            .expect("broadcast messages resource should be accessible");
+        // SAFETY: passed pointer was obtained using this event data.
+        unsafe { event.trigger(&mut commands, broadcasts.into_inner()) };
+    }
+}
+
 fn send_locally(
     mut from_messages: FilteredResourcesMut,
     mut messages: FilteredResourcesMut,
@@ -264,9 +367,28 @@ fn send_locally(
     }
 }
 
+fn broadcast_send_locally(
+    mut broadcasts: FilteredResourcesMut,
+    mut messages: FilteredResourcesMut,
+    registry: Res<RemoteMessageRegistry>,
+) {
+    for message in registry.iter_all_broadcast() {
+        let broadcasts = broadcasts
+            .get_mut_by_id(message.broadcast_id())
+            .expect("broadcast messages resource should be accessible");
+        let messages = messages
+            .get_mut_by_id(message.messages_id())
+            .expect("messages resource should be accessible");
+
+        // SAFETY: passed pointers were obtained using this message data.
+        unsafe { message.send_locally(broadcasts.into_inner(), messages.into_inner()) };
+    }
+}
+
 fn reset(
     mut messages: FilteredResourcesMut,
     mut queues: FilteredResourcesMut,
+    mut broadcast_messages: FilteredResourcesMut,
     registry: Res<RemoteMessageRegistry>,
 ) {
     for message in registry.iter_all_client() {
@@ -285,5 +407,14 @@ fn reset(
 
         // SAFETY: passed pointer was obtained using this message data.
         unsafe { messages.reset(queue.into_inner()) };
+    }
+
+    for message in registry.iter_all_broadcast() {
+        let messages = broadcast_messages
+            .get_mut_by_id(message.messages_id())
+            .expect("broadcast messages resource should be accessible");
+
+        // SAFETY: passed pointer was obtained using this message data.
+        unsafe { message.reset(messages.into_inner()) };
     }
 }

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -206,10 +206,9 @@ impl Plugin for ClientMessagePlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    send_fn.run_if(in_state(ClientState::Connected)),
-                    broadcast_send_fn.run_if(in_state(ClientState::Connected)),
-                    send_locally_fn.run_if(in_state(ClientState::Disconnected)),
-                    broadcast_send_locally_fn.run_if(in_state(ClientState::Disconnected)),
+                    (send_fn, broadcast_send_fn).run_if(in_state(ClientState::Connected)),
+                    (send_locally_fn, broadcast_send_locally_fn)
+                        .run_if(in_state(ClientState::Disconnected)),
                     broadcast_trigger_fn,
                 )
                     .chain()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,8 +375,8 @@ fn on_attack(on: On<Broadcast<Attack>>) {
 struct Attack;
 ```
 
-For events with entities inside use [`BroadcastEventAppExt::add_mapped_broadcast_event`].
-Serialization can also be customized with [`BroadcastEventAppExt::add_broadcast_event_with`].
+Similar to regular client messages, we also provide [`BroadcastEventAppExt::add_mapped_broadcast_event`].
+and [`BroadcastEventAppExt::add_broadcast_event_with`].
 
 ### From server to client
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,32 @@ fn receive(ping: On<FromClient<Ping>>) {
 For events with entities inside use [`ClientEventAppExt::add_mapped_client_event`].
 Similar to messages, serialization can also be customized with [`ClientEventAppExt::add_client_event_with`].
 
+If you need to react to the same message on both the client and the server (for example,
+to share logic between client-side prediction and authoritative server processing), use
+[`BroadcastMessageAppExt::add_broadcast_message`] or
+[`BroadcastEventAppExt::add_broadcast_event`]. The message is emitted as [`Broadcast<M>`]
+on both sides, with the [`Broadcaster`] field indicating its origin.
+
+```
+# use bevy::{prelude::*, state::app::StatesPlugin};
+# use bevy_replicon::prelude::*;
+# use serde::{Deserialize, Serialize};
+# let mut app = App::new();
+# app.add_plugins((StatesPlugin, RepliconPlugins));
+app.add_broadcast_event::<Attack>(Channel::Ordered)
+    .add_observer(on_attack);
+
+fn on_attack(on: On<Broadcast<Attack>>) {
+    info!("attack from `{:?}`", on.broadcaster);
+}
+
+#[derive(Event, Deserialize, Serialize)]
+struct Attack;
+```
+
+For events with entities inside use [`BroadcastEventAppExt::add_mapped_broadcast_event`].
+Serialization can also be customized with [`BroadcastEventAppExt::add_broadcast_event_with`].
+
 ### From server to client
 
 A similar technique is used to send messages from server to clients. To do this,
@@ -705,6 +731,8 @@ pub mod prelude {
             },
             client_id::ClientId,
             message::{
+                broadcast_event::{BroadcastEventAppExt, BroadcastTriggerExt},
+                broadcast_message::{Broadcast, BroadcastMessageAppExt, Broadcaster},
                 client_event::{ClientEventAppExt, ClientTriggerExt},
                 client_message::{ClientMessageAppExt, FromClient},
                 server_event::{ServerEventAppExt, ServerTriggerExt},

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -119,7 +119,10 @@ impl Plugin for ServerMessagePlugin {
                 PreUpdate,
                 (
                     (receive_fn, broadcast_receive_fn).run_if(in_state(ServerState::Running)),
-                    (trigger_fn, broadcast_trigger_fn).run_if(in_state(ClientState::Disconnected)),
+                    (
+                        trigger_fn.run_if(in_state(ClientState::Disconnected)),
+                        broadcast_trigger_fn,
+                    ),
                 )
                     .chain()
                     .in_set(ServerSystems::Receive),

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -119,8 +119,7 @@ impl Plugin for ServerMessagePlugin {
                 PreUpdate,
                 (
                     (receive_fn, broadcast_receive_fn).run_if(in_state(ServerState::Running)),
-                    trigger_fn.run_if(in_state(ClientState::Disconnected)),
-                    broadcast_trigger_fn,
+                    (trigger_fn, broadcast_trigger_fn).run_if(in_state(ClientState::Disconnected)),
                 )
                     .chain()
                     .in_set(ServerSystems::Receive),

--- a/src/server/message.rs
+++ b/src/server/message.rs
@@ -61,6 +61,19 @@ impl Plugin for ServerMessagePlugin {
             .build_state(app.world_mut())
             .build_system(receive);
 
+        let broadcast_receive_fn = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for message in registry.iter_all_broadcast() {
+                    builder.add_write_by_id(message.broadcast_id());
+                }
+            }),
+            ParamBuilder,
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(broadcast_receive);
+
         let trigger_fn = (
             FilteredResourcesMutParamBuilder::new(|builder| {
                 for event in registry.iter_client_events() {
@@ -72,6 +85,18 @@ impl Plugin for ServerMessagePlugin {
         )
             .build_state(app.world_mut())
             .build_system(trigger);
+
+        let broadcast_trigger_fn = (
+            FilteredResourcesMutParamBuilder::new(|builder| {
+                for event in registry.iter_broadcast_events() {
+                    builder.add_write_by_id(event.message().broadcast_id());
+                }
+            }),
+            ParamBuilder,
+            ParamBuilder,
+        )
+            .build_state(app.world_mut())
+            .build_system(broadcast_trigger);
 
         let send_locally_fn = (
             FilteredResourcesMutParamBuilder::new(|builder| {
@@ -93,8 +118,9 @@ impl Plugin for ServerMessagePlugin {
             .add_systems(
                 PreUpdate,
                 (
-                    receive_fn.run_if(in_state(ServerState::Running)),
+                    (receive_fn, broadcast_receive_fn).run_if(in_state(ServerState::Running)),
                     trigger_fn.run_if(in_state(ClientState::Disconnected)),
+                    broadcast_trigger_fn,
                 )
                     .chain()
                     .in_set(ServerSystems::Receive),
@@ -176,6 +202,26 @@ fn receive(
     }
 }
 
+fn broadcast_receive(
+    mut broadcasts: FilteredResourcesMut,
+    mut server_messages: ResMut<ServerMessages>,
+    type_registry: Res<AppTypeRegistry>,
+    message_registry: Res<RemoteMessageRegistry>,
+) {
+    let mut ctx = ServerReceiveCtx {
+        type_registry: &type_registry,
+    };
+
+    for message in message_registry.iter_all_broadcast() {
+        let broadcasts = broadcasts
+            .get_mut_by_id(message.broadcast_id())
+            .expect("broadcast messages resource should be accessible");
+
+        // SAFETY: passed pointer was obtained using this message data.
+        unsafe { message.receive(&mut ctx, broadcasts.into_inner(), &mut server_messages) };
+    }
+}
+
 fn trigger(
     mut from_messages: FilteredResourcesMut,
     mut commands: Commands,
@@ -187,6 +233,20 @@ fn trigger(
             .expect("client messages resource should be accessible");
         // SAFETY: passed pointer was obtained using this message data.
         unsafe { event.trigger(&mut commands, from_messages.into_inner()) };
+    }
+}
+
+fn broadcast_trigger(
+    mut broadcasts: FilteredResourcesMut,
+    mut commands: Commands,
+    registry: Res<RemoteMessageRegistry>,
+) {
+    for event in registry.iter_broadcast_events() {
+        let broadcasts = broadcasts
+            .get_mut_by_id(event.message().broadcast_id())
+            .expect("broadcast messages resource should be accessible");
+        // SAFETY: passed pointer was obtained using this event data.
+        unsafe { event.trigger(&mut commands, broadcasts.into_inner()) };
     }
 }
 

--- a/src/shared/message.rs
+++ b/src/shared/message.rs
@@ -1,3 +1,5 @@
+pub mod broadcast_event;
+pub mod broadcast_message;
 pub mod client_event;
 pub mod client_message;
 pub mod ctx;

--- a/src/shared/message/broadcast_event.rs
+++ b/src/shared/message/broadcast_event.rs
@@ -1,0 +1,191 @@
+use core::any::TypeId;
+
+use bevy::{ecs::entity::MapEntities, prelude::*, ptr::PtrMut};
+use log::debug;
+use serde::{Serialize, de::DeserializeOwned};
+
+use super::{
+    broadcast_message::BroadcastMessage,
+    client_message,
+    ctx::{ClientSendCtx, ServerReceiveCtx},
+    message_fns::{DeserializeFn, MessageFns, SerializeFn},
+    registry::RemoteMessageRegistry,
+};
+use crate::prelude::*;
+
+/// An extension trait for [`App`] for creating broadcast events.
+///
+/// See also [`BroadcastMessageAppExt`] for messages, [`ClientEventAppExt`] for regular client events
+/// and [`ServerEventAppExt`] for server events.
+pub trait BroadcastEventAppExt {
+    /// Registers a remote event that can be triggered using [`BroadcastTriggerExt::broadcast_trigger`].
+    ///
+    /// After triggering `E` event on the client, [`Broadcast<E>`] event will be triggered locally
+    /// with [`Broadcaster::Local`] and on the server with [`Broadcaster::Remote`].
+    ///
+    /// On a listen server, the event will be triggered locally with [`Broadcaster::Local`].
+    fn add_broadcast_event<E: Event + Serialize + DeserializeOwned>(
+        &mut self,
+        channel: Channel,
+    ) -> &mut Self {
+        self.add_broadcast_event_with(
+            channel,
+            client_message::default_serialize::<E>,
+            client_message::default_deserialize::<E>,
+        )
+    }
+
+    /// Same as [`Self::add_broadcast_event`], but additionally maps client entities to server inside the event before sending.
+    ///
+    /// Always use it for events that contain entities. Entities must be annotated with `#[entities]`.
+    /// For details, see [`Component::map_entities`].
+    fn add_mapped_broadcast_event<E: Event + Serialize + DeserializeOwned + MapEntities + Clone>(
+        &mut self,
+        channel: Channel,
+    ) -> &mut Self {
+        self.add_broadcast_event_with(
+            channel,
+            client_message::default_serialize_mapped::<E>,
+            client_message::default_deserialize::<E>,
+        )
+    }
+
+    /// Same as [`Self::add_broadcast_event`], but uses the specified functions for serialization and deserialization.
+    ///
+    /// See also [`BroadcastMessageAppExt::add_broadcast_message_with`].
+    fn add_broadcast_event_with<E: Event>(
+        &mut self,
+        channel: Channel,
+        serialize: SerializeFn<ClientSendCtx, E>,
+        deserialize: DeserializeFn<ServerReceiveCtx, E>,
+    ) -> &mut Self;
+}
+
+impl BroadcastEventAppExt for App {
+    fn add_broadcast_event_with<E: Event>(
+        &mut self,
+        channel: Channel,
+        serialize: SerializeFn<ClientSendCtx, E>,
+        deserialize: DeserializeFn<ServerReceiveCtx, E>,
+    ) -> &mut Self {
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .add_broadcast_event::<E>();
+
+        let fns =
+            MessageFns::new(serialize, deserialize).with_convert::<BroadcastEventMessage<E>>();
+        let event = BroadcastEvent::new(self, channel, fns);
+        let mut registry = self.world_mut().resource_mut::<RemoteMessageRegistry>();
+        registry.register_broadcast_event(event);
+
+        self
+    }
+}
+
+/// Small abstraction on top of [`BroadcastMessage`] that stores a function to trigger them.
+pub(crate) struct BroadcastEvent {
+    type_id: TypeId,
+    message: BroadcastMessage,
+    trigger: TriggerFn,
+}
+
+impl BroadcastEvent {
+    fn new<E: Event>(
+        app: &mut App,
+        channel: Channel,
+        fns: MessageFns<ClientSendCtx, ServerReceiveCtx, BroadcastEventMessage<E>, E>,
+    ) -> Self {
+        Self {
+            type_id: TypeId::of::<E>(),
+            message: BroadcastMessage::new(app, channel, fns),
+            trigger: Self::trigger_typed::<E>,
+        }
+    }
+
+    /// Drains received [`Broadcast<BroadcastEventMessage<E>>`] messages and triggers them as [`Broadcast<E>`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `broadcasts` is [`Messages<Broadcast<BroadcastEventMessage<E>>>`]
+    /// and this instance was created for `E`.
+    pub(crate) unsafe fn trigger(&self, commands: &mut Commands, broadcasts: PtrMut) {
+        unsafe { (self.trigger)(commands, broadcasts) }
+    }
+
+    /// Typed version of [`Self::trigger`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `broadcasts` is [`Messages<Broadcast<BroadcastEventMessage<E>>>`].
+    unsafe fn trigger_typed<E: Event>(commands: &mut Commands, broadcasts: PtrMut) {
+        let broadcasts: &mut Messages<Broadcast<BroadcastEventMessage<E>>> =
+            unsafe { broadcasts.deref_mut() };
+        for Broadcast {
+            broadcaster,
+            message,
+        } in broadcasts.drain()
+        {
+            debug!(
+                "triggering `{}` from `{broadcaster:?}`",
+                ShortName::of::<Broadcast<E>>()
+            );
+            commands.trigger(Broadcast {
+                broadcaster,
+                message: message.event,
+            });
+        }
+    }
+
+    pub(super) fn type_id(&self) -> TypeId {
+        self.type_id
+    }
+
+    pub(crate) fn message(&self) -> &BroadcastMessage {
+        &self.message
+    }
+}
+
+/// Signature of broadcast trigger functions.
+type TriggerFn = unsafe fn(&mut Commands, PtrMut);
+
+/// Extension trait for triggering broadcast events.
+///
+/// See also [`BroadcastEventAppExt`].
+pub trait BroadcastTriggerExt {
+    /// Like [`Commands::trigger`], but triggers [`Broadcast<E>`] locally and on the server.
+    fn broadcast_trigger(&mut self, event: impl Event);
+}
+
+impl BroadcastTriggerExt for Commands<'_, '_> {
+    fn broadcast_trigger(&mut self, event: impl Event) {
+        self.write_message(BroadcastEventMessage { event });
+    }
+}
+
+impl BroadcastTriggerExt for World {
+    fn broadcast_trigger(&mut self, event: impl Event) {
+        self.write_message(BroadcastEventMessage { event });
+    }
+}
+
+/// A message that used under the hood for broadcast events.
+///
+/// Events are implemented through messages in order to reuse their logic.
+/// So we send this message instead and, after receiving it, drain it to trigger regular events.
+/// This also allows us to avoid requiring [`Clone`] because events can't be drained.
+#[derive(Message)]
+struct BroadcastEventMessage<E> {
+    event: E,
+}
+
+impl<E> From<E> for BroadcastEventMessage<E> {
+    fn from(event: E) -> Self {
+        Self { event }
+    }
+}
+
+impl<E> AsRef<E> for BroadcastEventMessage<E> {
+    fn as_ref(&self) -> &E {
+        &self.event
+    }
+}

--- a/src/shared/message/broadcast_message.rs
+++ b/src/shared/message/broadcast_message.rs
@@ -1,0 +1,406 @@
+use core::any::TypeId;
+
+use bevy::{
+    ecs::{component::ComponentId, entity::MapEntities},
+    prelude::*,
+    ptr::PtrMut,
+};
+use bytes::Bytes;
+use log::{debug, error, warn};
+use serde::{Serialize, de::DeserializeOwned};
+
+use super::{
+    client_message,
+    ctx::{ClientSendCtx, ServerReceiveCtx},
+    message_fns::{DeserializeFn, MessageFns, SerializeFn, UntypedMessageFns},
+    registry::RemoteMessageRegistry,
+};
+use crate::prelude::*;
+
+/// An extension trait for [`App`] for creating broadcast messages.
+///
+/// See also [`BroadcastEventAppExt`] for events, [`ClientMessageAppExt`] for regular client messages
+/// and [`ServerMessageAppExt`] for server messages.
+pub trait BroadcastMessageAppExt {
+    /// Registers a remote broadcast message.
+    ///
+    /// Similar to [`ClientMessageAppExt::add_client_message`], but the message is emitted as
+    /// [`Broadcast<M>`] both on the sender (with [`Broadcaster::Local`]) and on the receiver
+    /// (with [`Broadcaster::Remote`]). Useful for sharing logic between client-side prediction
+    /// and authoritative server processing.
+    ///
+    /// On a listen server, locally written messages are emitted as [`Broadcast<M>`] with
+    /// [`Broadcaster::Local`].
+    ///
+    /// Calling [`App::add_message`] is not necessary. Can be used for regular messages that were
+    /// previously registered. But be careful, since all messages `M` are drained,
+    /// which could break Bevy or third-party plugin systems that read `M`.
+    fn add_broadcast_message<M: Message + Serialize + DeserializeOwned>(
+        &mut self,
+        channel: Channel,
+    ) -> &mut Self {
+        self.add_broadcast_message_with(
+            channel,
+            client_message::default_serialize::<M>,
+            client_message::default_deserialize::<M>,
+        )
+    }
+
+    /// Same as [`Self::add_broadcast_message`], but additionally maps client entities to server inside the message before sending.
+    ///
+    /// Always use it for messages that contain entities. Entities must be annotated with `#[entities]`.
+    /// For details, see [`Component::map_entities`].
+    fn add_mapped_broadcast_message<M>(&mut self, channel: Channel) -> &mut Self
+    where
+        M: Message + Serialize + DeserializeOwned + MapEntities + Clone,
+    {
+        self.add_broadcast_message_with(
+            channel,
+            client_message::default_serialize_mapped::<M>,
+            client_message::default_deserialize::<M>,
+        )
+    }
+
+    /// Same as [`Self::add_broadcast_message`], but uses the specified functions for serialization and deserialization.
+    ///
+    /// See also [`ClientMessageAppExt::add_client_message_with`].
+    fn add_broadcast_message_with<M: Message>(
+        &mut self,
+        channel: Channel,
+        serialize: SerializeFn<ClientSendCtx, M>,
+        deserialize: DeserializeFn<ServerReceiveCtx, M>,
+    ) -> &mut Self;
+}
+
+impl BroadcastMessageAppExt for App {
+    fn add_broadcast_message_with<M: Message>(
+        &mut self,
+        channel: Channel,
+        serialize: SerializeFn<ClientSendCtx, M>,
+        deserialize: DeserializeFn<ServerReceiveCtx, M>,
+    ) -> &mut Self {
+        self.world_mut()
+            .resource_mut::<ProtocolHasher>()
+            .add_broadcast_message::<M>();
+
+        let fns = MessageFns::new(serialize, deserialize);
+        let message = BroadcastMessage::new(self, channel, fns);
+        let mut registry = self.world_mut().resource_mut::<RemoteMessageRegistry>();
+        registry.register_broadcast_message(message);
+
+        self
+    }
+}
+
+/// Type-erased functions and metadata for a registered broadcast message.
+///
+/// Needed to erase message types to process them in a single system.
+pub(crate) struct BroadcastMessage {
+    /// ID of [`Messages<M>`] resource.
+    messages_id: ComponentId,
+
+    /// ID of [`Messages<Broadcast<M>>`] resource.
+    broadcast_id: ComponentId,
+
+    /// Used channel.
+    channel_id: usize,
+
+    /// ID of `M`.
+    type_id: TypeId,
+
+    send: SendFn,
+    receive: ReceiveFn,
+    send_locally: SendLocallyFn,
+    reset: ResetFn,
+    fns: UntypedMessageFns,
+}
+
+impl BroadcastMessage {
+    pub(super) fn new<M: Message, I: 'static>(
+        app: &mut App,
+        channel: Channel,
+        fns: MessageFns<ClientSendCtx, ServerReceiveCtx, M, I>,
+    ) -> Self {
+        let channel_id = app
+            .world_mut()
+            .resource_mut::<RepliconChannels>()
+            .create_client_channel(channel);
+
+        app.add_message::<M>().add_message::<Broadcast<M>>();
+
+        let messages_id = app.world().resource_id::<Messages<M>>().unwrap();
+        let broadcast_id = app.world().resource_id::<Messages<Broadcast<M>>>().unwrap();
+
+        Self {
+            messages_id,
+            broadcast_id,
+            channel_id,
+            type_id: TypeId::of::<M>(),
+            send: Self::send_typed::<M, I>,
+            receive: Self::receive_typed::<M, I>,
+            send_locally: Self::send_locally_typed::<M>,
+            reset: Self::reset_typed::<M>,
+            fns: fns.into(),
+        }
+    }
+
+    pub(crate) fn messages_id(&self) -> ComponentId {
+        self.messages_id
+    }
+
+    pub(crate) fn broadcast_id(&self) -> ComponentId {
+        self.broadcast_id
+    }
+
+    pub(super) fn channel_id(&self) -> usize {
+        self.channel_id
+    }
+
+    pub(super) fn type_id(&self) -> TypeId {
+        self.type_id
+    }
+
+    /// Sends a broadcast message to the server and writes it locally as [`Broadcast<M>`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `messages` is [`Messages<M>`], `broadcasts` is [`Messages<Broadcast<M>>`]
+    /// and this instance was created for `M`.
+    pub(crate) unsafe fn send(
+        &self,
+        ctx: &mut ClientSendCtx,
+        messages: PtrMut,
+        broadcasts: PtrMut,
+        client_messages: &mut ClientMessages,
+    ) {
+        unsafe { (self.send)(self, ctx, messages, broadcasts, client_messages) };
+    }
+
+    /// Typed version of [`Self::send`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `messages` is [`Messages<M>`], `broadcasts` is [`Messages<Broadcast<M>>`],
+    /// and this instance was created for `M` and `I`.
+    unsafe fn send_typed<M: Message, I: 'static>(
+        &self,
+        ctx: &mut ClientSendCtx,
+        messages: PtrMut,
+        broadcasts: PtrMut,
+        client_messages: &mut ClientMessages,
+    ) {
+        let messages: &mut Messages<M> = unsafe { messages.deref_mut() };
+        let broadcasts: &mut Messages<Broadcast<M>> = unsafe { broadcasts.deref_mut() };
+        for message in messages.drain() {
+            let mut message_bytes = Vec::new();
+            if let Err(e) = unsafe { self.serialize::<M, I>(ctx, &message, &mut message_bytes) } {
+                error!(
+                    "ignoring message `{}` that failed to serialize: {e}",
+                    ShortName::of::<M>()
+                );
+                continue;
+            }
+
+            debug!("sending broadcast message `{}`", ShortName::of::<M>());
+            client_messages.send(self.channel_id, message_bytes);
+            broadcasts.write(Broadcast {
+                broadcaster: Broadcaster::Local,
+                message,
+            });
+        }
+    }
+
+    /// Receives broadcast messages from clients.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `broadcasts` is [`Messages<Broadcast<M>>`]
+    /// and this instance was created for `M`.
+    pub(crate) unsafe fn receive(
+        &self,
+        ctx: &mut ServerReceiveCtx,
+        broadcasts: PtrMut,
+        server_messages: &mut ServerMessages,
+    ) {
+        unsafe { (self.receive)(self, ctx, broadcasts, server_messages) }
+    }
+
+    /// Typed version of [`Self::receive`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `broadcasts` is [`Messages<Broadcast<M>>`]
+    /// and this instance was created for `M` and `I`.
+    unsafe fn receive_typed<M: Message, I: 'static>(
+        &self,
+        ctx: &mut ServerReceiveCtx,
+        broadcasts: PtrMut,
+        server_messages: &mut ServerMessages,
+    ) {
+        let broadcasts: &mut Messages<Broadcast<M>> = unsafe { broadcasts.deref_mut() };
+        for (client, mut message) in server_messages.receive(self.channel_id) {
+            match unsafe { self.deserialize::<M, I>(ctx, &mut message) } {
+                Ok(message) => {
+                    debug!(
+                        "writing broadcast message `{}` from client `{client}`",
+                        ShortName::of::<M>()
+                    );
+                    broadcasts.write(Broadcast {
+                        broadcaster: Broadcaster::Remote(client.into()),
+                        message,
+                    });
+                }
+                Err(e) => debug!(
+                    "ignoring message `{}` from client `{client}` that failed to deserialize: {e}",
+                    ShortName::of::<M>()
+                ),
+            }
+        }
+    }
+
+    /// Drains messages `M` and writes them as [`Broadcast<M>`] with [`Broadcaster::Local`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `messages` is [`Messages<M>`], `broadcasts` is [`Messages<Broadcast<M>>`]
+    /// and this instance was created for `M`.
+    pub(crate) unsafe fn send_locally(&self, broadcasts: PtrMut, messages: PtrMut) {
+        unsafe { (self.send_locally)(broadcasts, messages) }
+    }
+
+    /// Typed version of [`Self::send_locally`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `messages` is [`Messages<M>`] and `broadcasts` is [`Messages<Broadcast<M>>`].
+    unsafe fn send_locally_typed<M: Message>(broadcasts: PtrMut, messages: PtrMut) {
+        let broadcasts: &mut Messages<Broadcast<M>> = unsafe { broadcasts.deref_mut() };
+        let messages: &mut Messages<M> = unsafe { messages.deref_mut() };
+        if !messages.is_empty() {
+            debug!(
+                "writing {} broadcast message(s) `{}` locally",
+                messages.len(),
+                ShortName::of::<M>()
+            );
+            broadcasts.write_batch(messages.drain().map(|message| Broadcast {
+                broadcaster: Broadcaster::Local,
+                message,
+            }));
+        }
+    }
+
+    /// Drains all messages.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `messages` is [`Messages<M>`]
+    /// and this instance was created for `M`.
+    pub(crate) unsafe fn reset(&self, messages: PtrMut) {
+        unsafe { (self.reset)(messages) }
+    }
+
+    /// Typed version of [`Self::reset`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `messages` is [`Messages<M>`].
+    unsafe fn reset_typed<M: Message>(messages: PtrMut) {
+        let messages: &mut Messages<M> = unsafe { messages.deref_mut() };
+        let drained_count = messages.drain().count();
+        if drained_count > 0 {
+            warn!(
+                "discarded {drained_count} broadcast messages of type `{}` due to a disconnect",
+                ShortName::of::<M>()
+            );
+        }
+    }
+
+    /// Serializes a message.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that this instance was created for `M` and `I`.
+    unsafe fn serialize<M: 'static, I: 'static>(
+        &self,
+        ctx: &mut ClientSendCtx,
+        message: &M,
+        message_bytes: &mut Vec<u8>,
+    ) -> Result<()> {
+        unsafe {
+            self.fns
+                .typed::<ClientSendCtx, ServerReceiveCtx, M, I>()
+                .serialize(ctx, message, message_bytes)?;
+        }
+
+        if ctx.invalid_entities.is_empty() {
+            Ok(())
+        } else {
+            let error_text = format!(
+                "unable to map entities `{:?}` for the server, \
+                make sure that the message references entities visible to the server",
+                ctx.invalid_entities,
+            );
+            ctx.invalid_entities.clear();
+            Err(error_text.into())
+        }
+    }
+
+    /// Deserializes a message.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that this instance was created for `M` and `I`.
+    unsafe fn deserialize<M: 'static, I: 'static>(
+        &self,
+        ctx: &mut ServerReceiveCtx,
+        message: &mut Bytes,
+    ) -> Result<M> {
+        unsafe {
+            self.fns
+                .typed::<ClientSendCtx, ServerReceiveCtx, M, I>()
+                .deserialize(ctx, message)
+        }
+    }
+}
+
+/// Signature of broadcast message sending functions.
+type SendFn = unsafe fn(&BroadcastMessage, &mut ClientSendCtx, PtrMut, PtrMut, &mut ClientMessages);
+
+/// Signature of broadcast message receiving functions.
+type ReceiveFn = unsafe fn(&BroadcastMessage, &mut ServerReceiveCtx, PtrMut, &mut ServerMessages);
+
+/// Signature of broadcast message local-sending functions.
+type SendLocallyFn = unsafe fn(PtrMut, PtrMut);
+
+/// Signature of broadcast message reset functions.
+type ResetFn = unsafe fn(PtrMut);
+
+/// A remote message that originates from a client.
+///
+/// Emitted both on the sender (with [`Broadcaster::Local`]) and on the receiver
+/// (with [`Broadcaster::Remote`]).
+#[derive(Message, Event, Deref, DerefMut, Debug, Clone, Copy)]
+pub struct Broadcast<T> {
+    /// Origin of the message.
+    pub broadcaster: Broadcaster,
+
+    /// Transmitted message.
+    #[deref]
+    pub message: T,
+}
+
+impl<E: EntityEvent> EntityEvent for Broadcast<E> {
+    fn event_target(&self) -> Entity {
+        self.message.event_target()
+    }
+}
+
+/// Origin of a [`Broadcast`] message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Broadcaster {
+    /// Written locally by this app.
+    Local,
+
+    /// Received over the network from a remote client.
+    Remote(ClientId),
+}

--- a/src/shared/message/broadcast_message.rs
+++ b/src/shared/message/broadcast_message.rs
@@ -404,3 +404,15 @@ pub enum Broadcaster {
     /// Received over the network from a remote client.
     Remote(ClientId),
 }
+
+impl Broadcaster {
+    /// Returns `true` if the message was written locally.
+    pub fn is_local(self) -> bool {
+        matches!(self, Self::Local)
+    }
+
+    /// Returns `true` if the message was received from a remote client.
+    pub fn is_remote(self) -> bool {
+        matches!(self, Self::Remote(_))
+    }
+}

--- a/src/shared/message/broadcast_message.rs
+++ b/src/shared/message/broadcast_message.rs
@@ -406,11 +406,6 @@ pub enum Broadcaster {
 }
 
 impl Broadcaster {
-    /// Returns `true` if the message was written locally.
-    pub fn is_local(self) -> bool {
-        matches!(self, Self::Local)
-    }
-
     /// Returns `true` if the message was received from a remote client.
     pub fn is_remote(self) -> bool {
         matches!(self, Self::Remote(_))

--- a/src/shared/message/registry.rs
+++ b/src/shared/message/registry.rs
@@ -3,6 +3,7 @@ use core::any::TypeId;
 use bevy::prelude::*;
 
 use super::{
+    broadcast_event::BroadcastEvent, broadcast_message::BroadcastMessage,
     client_event::ClientEvent, client_message::ClientMessage, server_event::ServerEvent,
     server_message::ServerMessage,
 };
@@ -14,8 +15,10 @@ pub struct RemoteMessageRegistry {
     // but they are messages under the hood.
     server_messages: Vec<ServerMessage>,
     client_messages: Vec<ClientMessage>,
+    broadcast_messages: Vec<BroadcastMessage>,
     server_events: Vec<ServerEvent>,
     client_events: Vec<ClientEvent>,
+    broadcast_events: Vec<BroadcastEvent>,
 }
 
 impl RemoteMessageRegistry {
@@ -27,12 +30,20 @@ impl RemoteMessageRegistry {
         self.client_messages.push(message);
     }
 
+    pub(super) fn register_broadcast_message(&mut self, message: BroadcastMessage) {
+        self.broadcast_messages.push(message);
+    }
+
     pub(super) fn register_server_event(&mut self, event: ServerEvent) {
         self.server_events.push(event);
     }
 
     pub(super) fn register_client_event(&mut self, event: ClientEvent) {
         self.client_events.push(event);
+    }
+
+    pub(super) fn register_broadcast_event(&mut self, event: BroadcastEvent) {
+        self.broadcast_events.push(event);
     }
 
     pub(super) fn iter_server_messages_mut(&mut self) -> impl Iterator<Item = &mut ServerMessage> {
@@ -55,12 +66,22 @@ impl RemoteMessageRegistry {
             .chain(self.client_events.iter().map(|e| e.message()))
     }
 
+    pub(crate) fn iter_all_broadcast(&self) -> impl Iterator<Item = &BroadcastMessage> {
+        self.broadcast_messages
+            .iter()
+            .chain(self.broadcast_events.iter().map(|e| e.message()))
+    }
+
     pub(crate) fn iter_server_events(&self) -> impl Iterator<Item = &ServerEvent> {
         self.server_events.iter()
     }
 
     pub(crate) fn iter_client_events(&self) -> impl Iterator<Item = &ClientEvent> {
         self.client_events.iter()
+    }
+
+    pub(crate) fn iter_broadcast_events(&self) -> impl Iterator<Item = &BroadcastEvent> {
+        self.broadcast_events.iter()
     }
 
     /// Returns registered channel ID for server message `M`.
@@ -98,6 +119,26 @@ impl RemoteMessageRegistry {
     /// See also [`ClientEventAppExt::add_client_event`](super::client_event::ClientEventAppExt::add_client_event).
     pub fn client_event_channel<E: Event>(&self) -> Option<usize> {
         self.client_events
+            .iter()
+            .find(|e| e.type_id() == TypeId::of::<E>())
+            .map(|e| e.message().channel_id())
+    }
+
+    /// Returns registered channel ID for broadcast message `M`.
+    ///
+    /// See also [`BroadcastMessageAppExt::add_broadcast_message`](super::broadcast_message::BroadcastMessageAppExt::add_broadcast_message).
+    pub fn broadcast_message_channel<M: Message>(&self) -> Option<usize> {
+        self.broadcast_messages
+            .iter()
+            .find(|m| m.type_id() == TypeId::of::<M>())
+            .map(|m| m.channel_id())
+    }
+
+    /// Returns registered channel ID for broadcast event `E`.
+    ///
+    /// See also [`BroadcastEventAppExt::add_broadcast_event`](super::broadcast_event::BroadcastEventAppExt::add_broadcast_event).
+    pub fn broadcast_event_channel<E: Event>(&self) -> Option<usize> {
+        self.broadcast_events
             .iter()
             .find(|e| e.type_id() == TypeId::of::<E>())
             .map(|e| e.message().channel_id())

--- a/src/shared/protocol.rs
+++ b/src/shared/protocol.rs
@@ -78,6 +78,16 @@ impl ProtocolHasher {
         self.hash::<E>(ProtocolPart::ClientEvent);
     }
 
+    pub(crate) fn add_broadcast_message<E>(&mut self) {
+        debug!("adding broadcast message `{}`", ShortName::of::<E>());
+        self.hash::<E>(ProtocolPart::BroadcastMessage);
+    }
+
+    pub(crate) fn add_broadcast_event<E>(&mut self) {
+        debug!("adding broadcast event `{}`", ShortName::of::<E>());
+        self.hash::<E>(ProtocolPart::BroadcastEvent);
+    }
+
     pub(crate) fn add_server_message<E>(&mut self) {
         debug!("adding server message `{}`", ShortName::of::<E>());
         self.hash::<E>(ProtocolPart::ServerMessage);
@@ -133,6 +143,8 @@ enum ProtocolPart {
     IndependentMessage,
     IndependentEvent,
     TrackMutateMessages,
+    BroadcastMessage,
+    BroadcastEvent,
 }
 
 /// Hash of all registered events and replication rules.

--- a/tests/broadcast_event.rs
+++ b/tests/broadcast_event.rs
@@ -26,19 +26,19 @@ fn regular() {
 
     client_app.update();
 
-    let local_events = &client_app.world().resource::<EventReader<Test>>().events;
-    assert_eq!(local_events.len(), 1);
-    assert!(matches!(local_events[0].broadcaster, Broadcaster::Local));
+    let local_reader = client_app.world().resource::<EventReader<Test>>();
+    assert_eq!(local_reader.events.len(), 1);
+    assert_eq!(local_reader.events[0].broadcaster, Broadcaster::Local);
 
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let remote_events = &server_app.world().resource::<EventReader<Test>>().events;
-    assert_eq!(remote_events.len(), 1);
-    assert!(matches!(
-        remote_events[0].broadcaster,
-        Broadcaster::Remote(ClientId::Client(entity)) if entity == client_entity
-    ));
+    let remote_reader = server_app.world().resource::<EventReader<Test>>();
+    assert_eq!(remote_reader.events.len(), 1);
+    assert_eq!(
+        remote_reader.events[0].broadcaster,
+        Broadcaster::Remote(ClientId::Client(client_entity))
+    );
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn local_sending() {
 
     let reader = app.world().resource::<EventReader<Test>>();
     assert_eq!(reader.events.len(), 1);
-    assert!(matches!(reader.events[0].broadcaster, Broadcaster::Local));
+    assert_eq!(reader.events[0].broadcaster, Broadcaster::Local);
 }
 
 #[test]

--- a/tests/broadcast_event.rs
+++ b/tests/broadcast_event.rs
@@ -1,0 +1,189 @@
+use bevy::{ecs::entity::MapEntities, prelude::*, state::app::StatesPlugin, time::TimePlugin};
+use bevy_replicon::{
+    prelude::*,
+    shared::server_entity_map::ServerEntityMap,
+    test_app::{ServerTestAppExt, TestClientEntity},
+};
+use serde::{Deserialize, Serialize};
+use test_log::test;
+
+#[test]
+fn regular() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, StatesPlugin, RepliconPlugins))
+            .add_broadcast_event::<Test>(Channel::Ordered)
+            .finish();
+    }
+    client_app.init_resource::<EventReader<Test>>();
+    server_app.init_resource::<EventReader<Test>>();
+
+    server_app.connect_client(&mut client_app);
+    let client_entity = **client_app.world().resource::<TestClientEntity>();
+
+    client_app.world_mut().broadcast_trigger(Test);
+
+    client_app.update();
+
+    let local_events = &client_app.world().resource::<EventReader<Test>>().events;
+    assert_eq!(local_events.len(), 1);
+    assert!(matches!(local_events[0].broadcaster, Broadcaster::Local));
+
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let remote_events = &server_app.world().resource::<EventReader<Test>>().events;
+    assert_eq!(remote_events.len(), 1);
+    assert!(matches!(
+        remote_events[0].broadcaster,
+        Broadcaster::Remote(ClientId::Client(entity)) if entity == client_entity
+    ));
+}
+
+#[test]
+fn mapped() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .add_mapped_broadcast_event::<WithEntity>(Channel::Ordered)
+        .finish();
+    }
+    server_app.init_resource::<EventReader<WithEntity>>();
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let client_entity = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .unwrap();
+
+    client_app
+        .world_mut()
+        .broadcast_trigger(WithEntity(client_entity));
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let reader = server_app.world().resource::<EventReader<WithEntity>>();
+    let mapped_entities: Vec<_> = reader.events.iter().map(|event| event.0).collect();
+    assert_eq!(mapped_entities, [server_entity]);
+}
+
+#[test]
+fn without_plugins() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    server_app
+        .add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins
+                .build()
+                .disable::<ClientPlugin>()
+                .disable::<ClientMessagePlugin>(),
+        ))
+        .add_broadcast_event::<Test>(Channel::Ordered)
+        .finish();
+    client_app
+        .add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins
+                .build()
+                .disable::<ServerPlugin>()
+                .disable::<ServerMessagePlugin>(),
+        ))
+        .add_broadcast_event::<Test>(Channel::Ordered)
+        .finish();
+    server_app.init_resource::<EventReader<Test>>();
+
+    server_app.connect_client(&mut client_app);
+
+    client_app.world_mut().broadcast_trigger(Test);
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let reader = server_app.world().resource::<EventReader<Test>>();
+    assert_eq!(reader.events.len(), 1);
+}
+
+#[test]
+fn local_sending() {
+    let mut app = App::new();
+    app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins))
+        .add_broadcast_event::<Test>(Channel::Ordered)
+        .finish();
+    app.init_resource::<EventReader<Test>>();
+
+    app.world_mut().broadcast_trigger(Test);
+
+    app.update();
+
+    let reader = app.world().resource::<EventReader<Test>>();
+    assert_eq!(reader.events.len(), 1);
+    assert!(matches!(reader.events[0].broadcaster, Broadcaster::Local));
+}
+
+#[test]
+fn with_disconnect() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, StatesPlugin, RepliconPlugins))
+            .add_broadcast_event::<Test>(Channel::Ordered)
+            .finish();
+    }
+    client_app.init_resource::<EventReader<Test>>();
+
+    server_app.connect_client(&mut client_app);
+
+    client_app.world_mut().broadcast_trigger(Test);
+
+    server_app.disconnect_client(&mut client_app);
+
+    let reader = client_app.world().resource::<EventReader<Test>>();
+    assert!(
+        reader.events.is_empty(),
+        "client shouldn't resend events locally after disconnect"
+    );
+}
+
+#[derive(Deserialize, Event, Serialize, Clone)]
+struct Test;
+
+#[derive(Deserialize, Event, Serialize, Clone, MapEntities)]
+struct WithEntity(#[entities] Entity);
+
+#[derive(Resource)]
+struct EventReader<E: Event> {
+    events: Vec<Broadcast<E>>,
+}
+
+impl<E: Event + Clone> FromWorld for EventReader<E> {
+    fn from_world(world: &mut World) -> Self {
+        world.add_observer(|on: On<Broadcast<E>>, mut reader: ResMut<Self>| {
+            reader.events.push(on.event().clone());
+        });
+
+        Self {
+            events: Default::default(),
+        }
+    }
+}

--- a/tests/broadcast_message.rs
+++ b/tests/broadcast_message.rs
@@ -1,0 +1,195 @@
+use bevy::{ecs::entity::MapEntities, prelude::*, state::app::StatesPlugin, time::TimePlugin};
+use bevy_replicon::{
+    prelude::*,
+    shared::server_entity_map::ServerEntityMap,
+    test_app::{ServerTestAppExt, TestClientEntity},
+};
+use serde::{Deserialize, Serialize};
+use test_log::test;
+
+#[test]
+fn regular() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, StatesPlugin, RepliconPlugins))
+            .add_broadcast_message::<Test>(Channel::Ordered)
+            .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+    let client_entity = **client_app.world().resource::<TestClientEntity>();
+
+    client_app.world_mut().write_message(Test);
+
+    client_app.update();
+
+    let local = client_app.world().resource::<Messages<Broadcast<Test>>>();
+    let mut cursor = local.get_cursor();
+    let broadcasts: Vec<_> = cursor.read(local).collect();
+    assert_eq!(broadcasts.len(), 1);
+    assert!(matches!(broadcasts[0].broadcaster, Broadcaster::Local));
+
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let received = server_app.world().resource::<Messages<Broadcast<Test>>>();
+    let mut cursor = received.get_cursor();
+    let broadcasts: Vec<_> = cursor.read(received).collect();
+    assert_eq!(broadcasts.len(), 1);
+    assert!(matches!(
+        broadcasts[0].broadcaster,
+        Broadcaster::Remote(ClientId::Client(entity)) if entity == client_entity
+    ));
+}
+
+#[test]
+fn mapped() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .add_mapped_broadcast_message::<WithEntity>(Channel::Ordered)
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app.world_mut().spawn(Replicated).id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let client_entity = *client_app
+        .world()
+        .resource::<ServerEntityMap>()
+        .to_client()
+        .get(&server_entity)
+        .unwrap();
+
+    client_app
+        .world_mut()
+        .write_message(WithEntity(client_entity));
+
+    client_app.update();
+
+    let local = client_app
+        .world()
+        .resource::<Messages<Broadcast<WithEntity>>>();
+    let mut cursor = local.get_cursor();
+    let local_entities: Vec<_> = cursor.read(local).map(|m| m.0).collect();
+    assert_eq!(local_entities, [client_entity]);
+
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let received = server_app
+        .world()
+        .resource::<Messages<Broadcast<WithEntity>>>();
+    let mut cursor = received.get_cursor();
+    let received_entities: Vec<_> = cursor.read(received).map(|m| m.0).collect();
+    assert_eq!(received_entities, [server_entity]);
+}
+
+#[test]
+fn without_plugins() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    server_app
+        .add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins
+                .build()
+                .disable::<ClientPlugin>()
+                .disable::<ClientMessagePlugin>(),
+        ))
+        .add_broadcast_message::<Test>(Channel::Ordered)
+        .finish();
+    client_app
+        .add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins
+                .build()
+                .disable::<ServerPlugin>()
+                .disable::<ServerMessagePlugin>(),
+        ))
+        .add_broadcast_message::<Test>(Channel::Ordered)
+        .finish();
+
+    server_app.connect_client(&mut client_app);
+
+    client_app.world_mut().write_message(Test);
+
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    server_app.update();
+
+    let received = server_app.world().resource::<Messages<Broadcast<Test>>>();
+    let mut cursor = received.get_cursor();
+    let broadcasts: Vec<_> = cursor.read(received).collect();
+    assert_eq!(broadcasts.len(), 1);
+    assert!(matches!(
+        broadcasts[0].broadcaster,
+        Broadcaster::Remote(ClientId::Client(_))
+    ));
+}
+
+#[test]
+fn local_sending() {
+    let mut app = App::new();
+    app.add_plugins((TimePlugin, StatesPlugin, RepliconPlugins))
+        .add_broadcast_message::<Test>(Channel::Ordered)
+        .finish();
+
+    app.world_mut().write_message(Test);
+
+    app.update();
+
+    let messages = app.world().resource::<Messages<Test>>();
+    assert!(messages.is_empty());
+
+    let broadcasts = app.world().resource::<Messages<Broadcast<Test>>>();
+    let mut cursor = broadcasts.get_cursor();
+    let collected: Vec<_> = cursor.read(broadcasts).collect();
+    assert_eq!(collected.len(), 1);
+    assert!(matches!(collected[0].broadcaster, Broadcaster::Local));
+}
+
+#[test]
+fn with_disconnect() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((MinimalPlugins, StatesPlugin, RepliconPlugins))
+            .add_broadcast_message::<Test>(Channel::Ordered)
+            .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    client_app.world_mut().write_message(Test);
+
+    server_app.disconnect_client(&mut client_app);
+
+    let messages = client_app.world().resource::<Messages<Test>>();
+    assert!(messages.is_empty());
+
+    let broadcasts = client_app.world().resource::<Messages<Broadcast<Test>>>();
+    assert!(
+        broadcasts.is_empty(),
+        "client shouldn't resend broadcasts locally after disconnect"
+    );
+}
+
+#[derive(Deserialize, Message, Serialize)]
+struct Test;
+
+#[derive(Deserialize, Message, Serialize, Clone, MapEntities)]
+struct WithEntity(#[entities] Entity);

--- a/tests/broadcast_message.rs
+++ b/tests/broadcast_message.rs
@@ -24,23 +24,27 @@ fn regular() {
 
     client_app.update();
 
-    let local = client_app.world().resource::<Messages<Broadcast<Test>>>();
-    let mut cursor = local.get_cursor();
-    let broadcasts: Vec<_> = cursor.read(local).collect();
-    assert_eq!(broadcasts.len(), 1);
-    assert!(matches!(broadcasts[0].broadcaster, Broadcaster::Local));
+    let local_broadcasts: Vec<_> = client_app
+        .world_mut()
+        .resource_mut::<Messages<Broadcast<Test>>>()
+        .drain()
+        .collect();
+    assert_eq!(local_broadcasts.len(), 1);
+    assert_eq!(local_broadcasts[0].broadcaster, Broadcaster::Local);
 
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let received = server_app.world().resource::<Messages<Broadcast<Test>>>();
-    let mut cursor = received.get_cursor();
-    let broadcasts: Vec<_> = cursor.read(received).collect();
-    assert_eq!(broadcasts.len(), 1);
-    assert!(matches!(
-        broadcasts[0].broadcaster,
-        Broadcaster::Remote(ClientId::Client(entity)) if entity == client_entity
-    ));
+    let remote_broadcasts: Vec<_> = server_app
+        .world_mut()
+        .resource_mut::<Messages<Broadcast<Test>>>()
+        .drain()
+        .collect();
+    assert_eq!(remote_broadcasts.len(), 1);
+    assert_eq!(
+        remote_broadcasts[0].broadcaster,
+        Broadcaster::Remote(ClientId::Client(client_entity))
+    );
 }
 
 #[test]
@@ -78,22 +82,24 @@ fn mapped() {
 
     client_app.update();
 
-    let local = client_app
-        .world()
-        .resource::<Messages<Broadcast<WithEntity>>>();
-    let mut cursor = local.get_cursor();
-    let local_entities: Vec<_> = cursor.read(local).map(|m| m.0).collect();
+    let local_entities: Vec<_> = client_app
+        .world_mut()
+        .resource_mut::<Messages<Broadcast<WithEntity>>>()
+        .drain()
+        .map(|m| m.0)
+        .collect();
     assert_eq!(local_entities, [client_entity]);
 
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let received = server_app
-        .world()
-        .resource::<Messages<Broadcast<WithEntity>>>();
-    let mut cursor = received.get_cursor();
-    let received_entities: Vec<_> = cursor.read(received).map(|m| m.0).collect();
-    assert_eq!(received_entities, [server_entity]);
+    let mapped_entities: Vec<_> = server_app
+        .world_mut()
+        .resource_mut::<Messages<Broadcast<WithEntity>>>()
+        .drain()
+        .map(|m| m.0)
+        .collect();
+    assert_eq!(mapped_entities, [server_entity]);
 }
 
 #[test]
@@ -131,14 +137,13 @@ fn without_plugins() {
     server_app.exchange_with_client(&mut client_app);
     server_app.update();
 
-    let received = server_app.world().resource::<Messages<Broadcast<Test>>>();
-    let mut cursor = received.get_cursor();
-    let broadcasts: Vec<_> = cursor.read(received).collect();
+    let broadcasts: Vec<_> = server_app
+        .world_mut()
+        .resource_mut::<Messages<Broadcast<Test>>>()
+        .drain()
+        .collect();
     assert_eq!(broadcasts.len(), 1);
-    assert!(matches!(
-        broadcasts[0].broadcaster,
-        Broadcaster::Remote(ClientId::Client(_))
-    ));
+    assert!(broadcasts[0].broadcaster.is_remote());
 }
 
 #[test]
@@ -155,11 +160,13 @@ fn local_sending() {
     let messages = app.world().resource::<Messages<Test>>();
     assert!(messages.is_empty());
 
-    let broadcasts = app.world().resource::<Messages<Broadcast<Test>>>();
-    let mut cursor = broadcasts.get_cursor();
-    let collected: Vec<_> = cursor.read(broadcasts).collect();
-    assert_eq!(collected.len(), 1);
-    assert!(matches!(collected[0].broadcaster, Broadcaster::Local));
+    let broadcasts: Vec<_> = app
+        .world_mut()
+        .resource_mut::<Messages<Broadcast<Test>>>()
+        .drain()
+        .collect();
+    assert_eq!(broadcasts.len(), 1);
+    assert_eq!(broadcasts[0].broadcaster, Broadcaster::Local);
 }
 
 #[test]

--- a/tests/broadcast_message.rs
+++ b/tests/broadcast_message.rs
@@ -143,7 +143,7 @@ fn without_plugins() {
         .drain()
         .collect();
     assert_eq!(broadcasts.len(), 1);
-    assert!(broadcasts[0].broadcaster.is_remote());
+    assert!(matches!(broadcasts[0].broadcaster, Broadcaster::Remote(_)));
 }
 
 #[test]

--- a/tests/broadcast_message.rs
+++ b/tests/broadcast_message.rs
@@ -143,7 +143,7 @@ fn without_plugins() {
         .drain()
         .collect();
     assert_eq!(broadcasts.len(), 1);
-    assert!(matches!(broadcasts[0].broadcaster, Broadcaster::Remote(_)));
+    assert!(broadcasts[0].broadcaster.is_remote());
 }
 
 #[test]


### PR DESCRIPTION
# Add broadcast messages and events

Closes #673 
Adds `Broadcast<M>` and matching app extensions so the same observer/system can drive both client-side prediction and authoritative server logic from a single code path.

Unlike `FromClient<M>` (server-only), `Broadcast<M>` is emitted on both the sender and the receiver, with the `Broadcaster` field indicating the origin (`Local` or `Remote(ClientId)`). On a listen server, the local player's writes become `Local` rather than `Remote(Server)`, as discussed in the issue.

## API

- `app.add_broadcast_message::<M>(channel)` (+ `_mapped` / `_with` variants)
- `app.add_broadcast_event::<E>(channel)` (+ `_mapped` / `_with` variants)
- `commands.broadcast_trigger(event)`

```rust
app.add_broadcast_event::<Attack>(Channel::Ordered)
    .add_observer(on_attack);

fn on_attack(on: On<Broadcast<Attack>>) {
    // Runs on both client (Local) and server (Remote).
}
```

Mapped variants map entities only on the wire; the local copy keeps the original client entity ids so shared client logic can use them.