### PR TITLE
Added game reset functionality to tic_tac_toe example

### DIFF
--- a/example_backend/examples/tic_tac_toe.rs
+++ b/example_backend/examples/tic_tac_toe.rs
@@ -333,7 +333,7 @@ fn init_symbol(
         ));
 }
 
-/// Removes symbol's underlying ui elements and adds interaction back for empty cell
+/// Removes symbol's underlying ui elements and adds interaction back to reset to an empty cell.
 fn deinit_symbol(remove: On<Remove, Symbol>, mut commands: Commands) {
     commands
         .entity(remove.entity)
@@ -368,7 +368,7 @@ fn init_client(
 
 /// Listens for click on a reset button and requests [`ResetGame`] event on match.
 ///
-/// Runs on singleplayer, server, client
+/// Runs on singleplayer, server, client.
 fn request_reset_game(
     click: On<Pointer<Click>>,
     reset_button: Single<Entity, With<ResetButton>>,
@@ -383,7 +383,7 @@ fn request_reset_game(
 /// Resets the game on event by deleting all placed symbols from the game
 /// and replicating the deletion back to clients.
 ///
-/// Runs on singleplayer, server
+/// Runs on singleplayer, server.
 fn reset_game(
     reset: On<FromClient<ResetGame>>,
     game_state: Res<State<GameState>>,
@@ -409,9 +409,9 @@ fn reset_game(
     });
 }
 
-/// Sets the state of the game back to [`GameState::InGame`]
+/// Sets the state of the game back to [`GameState::InGame`].
 ///
-/// Runs on singleplayer, server, client
+/// Runs on singleplayer, server, client.
 fn restart_game(_on: On<RestartGame>, mut commands: Commands) {
     info!("restarting game");
     commands.set_state(GameState::InGame);

--- a/example_backend/examples/tic_tac_toe.rs
+++ b/example_backend/examples/tic_tac_toe.rs
@@ -708,8 +708,8 @@ struct PickCell {
 #[derive(Event, Deserialize, Serialize, Clone, Copy)]
 struct ResetGame;
 
-/// A restart game event
+/// Resets the state to [`GameState::InGame`].
 ///
-/// Used to reset game state to [`GameState::InGame`]
+/// Used as a confirmation after a successful [`ResetGame`].
 #[derive(Event, Deserialize, Serialize, Clone, Copy)]
 struct RestartGame;

--- a/example_backend/examples/tic_tac_toe.rs
+++ b/example_backend/examples/tic_tac_toe.rs
@@ -35,17 +35,27 @@ fn main() {
         .init_resource::<TurnSymbol>()
         .replicate::<Symbol>()
         .add_client_event::<PickCell>(Channel::Ordered)
+        .add_client_event::<ResetGame>(Channel::Ordered)
+        .add_server_event::<RestartGame>(Channel::Ordered)
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_observer(disconnect_by_client)
         .add_observer(init_client)
         .add_observer(apply_pick)
         .add_observer(init_symbols)
+        .add_observer(removed_symbols)
         .add_observer(advance_turn)
+        .add_observer(request_reset_game)
+        .add_observer(reset_game)
+        .add_observer(restart_game)
         .add_systems(Startup, (read_cli, setup_ui))
         .add_systems(
             OnEnter(GameState::InGame),
             (show_turn_text, show_turn_symbol),
         )
+        .add_systems(OnEnter(GameState::Winner), show_reset_button)
+        .add_systems(OnEnter(GameState::Tie), show_reset_button)
+        .add_systems(OnExit(GameState::Winner), hide_reset_button)
+        .add_systems(OnExit(GameState::Tie), hide_reset_button)
         .add_systems(OnEnter(GameState::Disconnected), show_disconnected_text)
         .add_systems(OnEnter(GameState::Winner), show_winner_text)
         .add_systems(OnEnter(GameState::Tie), show_tie_text)
@@ -56,11 +66,16 @@ fn main() {
         .add_systems(OnEnter(ServerState::Running), show_waiting_client_text)
         .add_systems(
             Update,
-            (
+            ((
                 update_buttons_background.run_if(local_player_turn),
                 show_turn_symbol.run_if(resource_changed::<TurnSymbol>),
             )
-                .run_if(in_state(GameState::InGame)),
+                .run_if(in_state(GameState::InGame)),),
+        )
+        .add_systems(
+            Update,
+            update_buttons_background
+                .run_if(in_state(GameState::Winner).or(in_state(GameState::Tie))),
         )
         .run();
 }
@@ -204,10 +219,32 @@ fn setup_ui(mut commands: Commands, symbol_font: Res<SymbolFont>) {
                             TextColor(TEXT_COLOR),
                         )]
                     )]
-                )
+                ),
+                (
+                    ResetButton,
+                    Visibility::Hidden,
+                    children![(
+                        Text::new("Reset Game"),
+                        TextFont {
+                            font_size: FONT_SIZE,
+                            ..Default::default()
+                        },
+                        TextColor(TEXT_COLOR),
+                    )]
+                ),
             ]
         )],
     ));
+}
+
+fn show_reset_button(mut reset_button_visibility: Single<&mut Visibility, With<ResetButton>>) {
+    debug!("showing reset button");
+    **reset_button_visibility = Visibility::Inherited;
+}
+
+fn hide_reset_button(mut reset_button_visibility: Single<&mut Visibility, With<ResetButton>>) {
+    debug!("hiding reset button");
+    **reset_button_visibility = Visibility::Hidden;
 }
 
 /// Converts point clicks into cell picking events.
@@ -296,6 +333,14 @@ fn init_symbols(
         ));
 }
 
+/// Removes symbol's underlying ui elements
+fn removed_symbols(remove: On<Remove, Symbol>, mut commands: Commands) {
+    commands
+        .entity(remove.entity)
+        .insert(Interaction::None)
+        .despawn_children();
+}
+
 /// Starts the game after connection.
 ///
 /// Used only for a client.
@@ -318,6 +363,59 @@ fn init_client(
         server_symbol.next(),
     ));
 
+    commands.set_state(GameState::InGame);
+}
+
+/// Listens for user input and requests game reset when anyone presses R.
+///
+/// Runs on singleplayer, server, client
+fn request_reset_game(
+    click: On<Pointer<Click>>,
+    reset_button: Single<Entity, With<ResetButton>>,
+    mut commands: Commands,
+) {
+    if click.entity == *reset_button {
+        debug!("requesting reset");
+        commands.client_trigger(ResetGame);
+    }
+}
+
+/// Resets the game based on event by deleting all symbols from the game
+/// and replicating the deletion back to clients.
+///
+/// Does additional check to prevent players from resetting game in wrong game state
+///
+/// Runs on singleplayer, server
+fn reset_game(
+    on: On<FromClient<ResetGame>>,
+    game_state: Res<State<GameState>>,
+    cells_entities: Query<Entity, (With<Symbol>, With<Button>)>,
+    mut commands: Commands,
+) {
+    if *game_state != GameState::Winner && *game_state != GameState::Tie {
+        error!(
+            "client {} requested game reset in wrong game state",
+            on.client_id
+        );
+        return;
+    }
+
+    info!("resetting the game");
+    for entity in cells_entities {
+        commands.entity(entity).remove::<Symbol>();
+    }
+
+    commands.server_trigger(ToClients {
+        targets: SendTargets::All,
+        message: RestartGame,
+    });
+}
+
+/// Sets the state of the game back to [`GameState::InGame`]
+///
+/// Runs on singleplayer, server, client
+fn restart_game(_on: On<RestartGame>, mut commands: Commands) {
+    info!("restarting game");
     commands.set_state(GameState::InGame);
 }
 
@@ -547,6 +645,19 @@ impl fmt::Display for Symbol {
 #[derive(Component)]
 struct BottomText;
 
+/// Reset button UI node.
+#[derive(Component)]
+#[require(
+    Button,
+    BackgroundColor(BACKGROUND_COLOR),
+    Node {
+        margin: UiRect::all(Val::Px(BUTTON_MARGIN)),
+        justify_content: JustifyContent::Center,
+        ..Default::default()
+    }
+)]
+struct ResetButton;
+
 /// Cell location on the grid.
 ///
 /// We want to replicate all cells, so we set [`Replicated`] as a required component.
@@ -594,3 +705,15 @@ struct ClientPlayer;
 struct PickCell {
     index: usize,
 }
+
+/// A reset game event
+///
+/// Used to send reset event to the authority and clear up the board
+#[derive(Event, Deserialize, Serialize, Clone, Copy)]
+struct ResetGame;
+
+/// A restart game event
+///
+/// Used to reset game state to [`GameState::InGame`]
+#[derive(Event, Deserialize, Serialize, Clone, Copy)]
+struct RestartGame;

--- a/example_backend/examples/tic_tac_toe.rs
+++ b/example_backend/examples/tic_tac_toe.rs
@@ -41,8 +41,8 @@ fn main() {
         .add_observer(disconnect_by_client)
         .add_observer(init_client)
         .add_observer(apply_pick)
-        .add_observer(init_symbols)
-        .add_observer(removed_symbols)
+        .add_observer(init_symbol)
+        .add_observer(deinit_symbol)
         .add_observer(advance_turn)
         .add_observer(request_reset_game)
         .add_observer(reset_game)
@@ -308,7 +308,7 @@ fn apply_pick(
 }
 
 /// Initializes spawned symbol on client after replication and on server / single-player right after the spawn.
-fn init_symbols(
+fn init_symbol(
     add: On<Add, Symbol>,
     mut commands: Commands,
     symbol_font: Res<SymbolFont>,
@@ -333,8 +333,8 @@ fn init_symbols(
         ));
 }
 
-/// Removes symbol's underlying ui elements
-fn removed_symbols(remove: On<Remove, Symbol>, mut commands: Commands) {
+/// Removes symbol's underlying ui elements and adds interaction back for empty cell
+fn deinit_symbol(remove: On<Remove, Symbol>, mut commands: Commands) {
     commands
         .entity(remove.entity)
         .insert(Interaction::None)
@@ -366,7 +366,7 @@ fn init_client(
     commands.set_state(GameState::InGame);
 }
 
-/// Listens for user input and requests game reset when anyone presses R.
+/// Listens for click on a reset button and requests [`ResetGame`] event on match.
 ///
 /// Runs on singleplayer, server, client
 fn request_reset_game(
@@ -380,14 +380,12 @@ fn request_reset_game(
     }
 }
 
-/// Resets the game based on event by deleting all symbols from the game
+/// Resets the game on event by deleting all placed symbols from the game
 /// and replicating the deletion back to clients.
-///
-/// Does additional check to prevent players from resetting game in wrong game state
 ///
 /// Runs on singleplayer, server
 fn reset_game(
-    on: On<FromClient<ResetGame>>,
+    reset: On<FromClient<ResetGame>>,
     game_state: Res<State<GameState>>,
     cells_entities: Query<Entity, (With<Symbol>, With<Button>)>,
     mut commands: Commands,
@@ -395,7 +393,7 @@ fn reset_game(
     if *game_state != GameState::Winner && *game_state != GameState::Tie {
         error!(
             "client {} requested game reset in wrong game state",
-            on.client_id
+            reset.client_id
         );
         return;
     }
@@ -706,9 +704,7 @@ struct PickCell {
     index: usize,
 }
 
-/// A reset game event
-///
-/// Used to send reset event to the authority and clear up the board
+/// A request to reset the game and clear up the board.
 #[derive(Event, Deserialize, Serialize, Clone, Copy)]
 struct ResetGame;
 

--- a/example_backend/examples/tic_tac_toe.rs
+++ b/example_backend/examples/tic_tac_toe.rs
@@ -66,11 +66,11 @@ fn main() {
         .add_systems(OnEnter(ServerState::Running), show_waiting_client_text)
         .add_systems(
             Update,
-            ((
+            (
                 update_buttons_background.run_if(local_player_turn),
                 show_turn_symbol.run_if(resource_changed::<TurnSymbol>),
             )
-                .run_if(in_state(GameState::InGame)),),
+                .run_if(in_state(GameState::InGame)),
         )
         .add_systems(
             Update,


### PR DESCRIPTION
Hello!

This is my first contribution to bevy (_replicon) ecosystem, and i'm still learning, so if there is anything out of ordinary and if you see it can be improved - please do so! Eager to learn more about all of this.

Overall, i thought it's odd that you cannot reset the tic-tac-toe after it was finished, and decided to try to implement such functionality.

Used few more events (including server event) and decided to re-use buttons highlight from the grid. 
Should be useful for newcomers to see clearly distinction between client and server calls that work in singleplayer too.

Most time was actually spent on not realising that `Symbol` was also present on `LocalPlayer` (thus, i cleared it too when clearing the entity out of `Symbol`) and forgetting to add back `Interaction` to `Symbol` elements so you can actually interact with them after they have been cleared.

Also another question - would all other backends have to basically merge those changes back to their backend examples?
It's a question for another day probably, but it felt odd that almost all backends implementations barely have any difference compared to base replicon examples, only startup/init changes. Perhaps it's best to make example as a separate repository and include it as submodule, that can link with examples?... (just a thought, probably overcomplicating stuff a lot)

<img width="492" height="623" alt="image" src="https://github.com/user-attachments/assets/3b07161e-6350-4943-a3c7-9e7f8dd2735a" />
