### PR TITLE
Fix singleplayer in authoritative_rts asking for a team

### DIFF
--- a/example_backend/examples/authoritative_rts.rs
+++ b/example_backend/examples/authoritative_rts.rs
@@ -93,7 +93,6 @@ fn setup(mut commands: Commands, cli: Res<Cli>) -> Result<()> {
     match *cli {
         Cli::Singleplayer { team } => {
             info!("starting singleplayer as `{team:?}`");
-            commands.client_trigger(TeamRequest { team });
             commands.insert_resource(LocalTeam(team));
         }
         Cli::Server { port, team } => {


### PR DESCRIPTION
It seems like singleplayer for authoritative_rts, for whatever the reason is triggering team request, even though by the looks of it it's supposed to be just one team.

Without this change, it fails on `server never requests a team` and crashes when trying singleplayer.