### PR TITLE
Add allow-list visibility filter scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Only` filter scope and `VisibilityScope::OnlyComponents` as an allow-list counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden. Useful for replicating a stripped-down entity (e.g. only its transform and light) to clients outside its full visibility range.
+
 ## [0.40.2] - 2026-05-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Only` filter scope and `VisibilityScope::OnlyComponents` as an allow-list counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden. Useful for replicating a stripped-down entity (e.g. only its transform and light) to clients outside its full visibility range.
+- `AllExcept` filter scope and `VisibilityScope::AllExcept` as a counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden. Useful for replicating a stripped-down entity (e.g. only its transform and light) to clients outside its full visibility range.
 - `ServerMutateTicks::last_confirmed_tick` to check the most recently reported fully received mutation tick.
 
 ## [0.40.2] - 2026-05-23

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,7 +749,7 @@ pub mod prelude {
                 registry::rule_fns::RuleFns,
                 rules::{AppRuleExt, component::ReplicationMode},
                 signature::Signature,
-                visibility::{ComponentScope, FilterScope, SingleComponent, VisibilityFilter},
+                visibility::{ComponentScope, FilterScope, Only, SingleComponent, VisibilityFilter},
             },
             replicon_tick::RepliconTick,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,7 +749,9 @@ pub mod prelude {
                 registry::rule_fns::RuleFns,
                 rules::{AppRuleExt, component::ReplicationMode},
                 signature::Signature,
-                visibility::{ComponentScope, FilterScope, Only, SingleComponent, VisibilityFilter},
+                visibility::{
+                    ComponentScope, FilterScope, Only, SingleComponent, VisibilityFilter,
+                },
             },
             replicon_tick::RepliconTick,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -750,7 +750,8 @@ pub mod prelude {
                 rules::{AppRuleExt, component::ReplicationMode},
                 signature::Signature,
                 visibility::{
-                    ComponentScope, FilterScope, Only, SingleComponent, VisibilityFilter,
+                    AllExcept, ComponentScope, ComponentsScope, FilterScope, SingleComponent,
+                    VisibilityFilter,
                 },
             },
             replicon_tick::RepliconTick,

--- a/src/server.rs
+++ b/src/server.rs
@@ -620,14 +620,13 @@ fn collect_removals(
                     // Allow-list: the hidden set is the complement, so scan the
                     // client's components. Buffered to release the borrow before removing.
                     VisibilityScope::AllExcept(mask) => {
-                        lost_buffer.clear();
                         lost_buffer.extend(
                             entity_ticks
                                 .components
                                 .iter()
                                 .filter(|&component_index| !mask.contains(component_index)),
                         );
-                        for &component_index in &*lost_buffer {
+                        for component_index in lost_buffer.drain(..) {
                             write_lost(component_index, entity_ticks)?;
                         }
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -609,7 +609,6 @@ fn collect_removals(
                     VisibilityScope::Entity => {
                         unreachable!("entity filters are processed during despawn collection")
                     }
-                    // Hide-list: iterate the filter's small mask directly.
                     VisibilityScope::Components(mask) => {
                         for component_index in mask.iter() {
                             if entity_ticks.components.contains(component_index) {
@@ -617,9 +616,8 @@ fn collect_removals(
                             }
                         }
                     }
-                    // Allow-list: the hidden set is the complement, so scan the
-                    // client's components. Buffered to release the borrow before removing.
                     VisibilityScope::AllExcept(mask) => {
+                        // Buffered to release the borrow before removing.
                         lost_buffer.extend(
                             entity_ticks
                                 .components

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,7 @@ use crate::{
         message::server_message::message_buffer::MessageBuffer,
         replication::{
             client_ticks::{ClientTicks, EntityTicks},
-            registry::{ReplicationRegistry, component_mask::ComponentMask},
+            registry::{ComponentIndex, ReplicationRegistry, component_mask::ComponentMask},
             rules::ReplicationRules,
             track_mutate_messages::TrackMutateMessages,
         },
@@ -510,6 +510,7 @@ fn collect_removals(
     mut replicated_archetypes: ResMut<ReplicatedArchetypes>,
     mut serialized: ResMut<SerializedData>,
     mut pools: ResMut<ClientPools>,
+    mut lost_buffer: Local<Vec<ComponentIndex>>,
     mut clients: Query<(
         Entity,
         &mut Updates,
@@ -578,35 +579,31 @@ fn collect_removals(
             let mut entity_range = None;
             message.start_entity_removals();
 
-            for components in filter_mask.hidden_components(&filter_registry) {
-                for component_index in components.iter() {
-                    if !entity_ticks.components.contains(component_index) {
-                        // The client didn't see this component.
-                        continue;
-                    }
+            // Iterate the client's components instead of a filter's hide-mask so
+            // allow-list (`OnlyComponents`) scopes, whose hidden set is the complement, work too.
+            lost_buffer.clear();
+            lost_buffer.extend(entity_ticks.components.iter().filter(|&component_index| {
+                filter_mask.is_component_hidden(&filter_registry, component_index)
+            }));
+            for &component_index in &*lost_buffer {
+                let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
+                    panic!("`{component_index:?}` should've been registered to be marked as lost")
+                });
+                let rule = archetype.find_rule(id).unwrap_or_else(|| {
+                    panic!("`{id:?}` should match a rule since the client knows about it")
+                });
 
-                    let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
-                        panic!(
-                            "`{component_index:?}` should've been registered to be marked as lost"
-                        )
-                    });
-                    let rule = archetype.find_rule(id).unwrap_or_else(|| {
-                        panic!("`{id:?}` should match a rule since the client knows about it")
-                    });
-
-                    trace!(
-                        "writing `{:?}` lost for `{entity}` for client `{client}`",
-                        rule.fns_id
-                    );
-                    if !message.removals_entity_added() {
-                        let entity_range =
-                            entity.write_cached(&mut serialized, &mut entity_range)?;
-                        message.add_removals_entity(&mut pools, entity_range);
-                    }
-                    let fns_id_range = rule.fns_id.write(&mut serialized)?;
-                    message.add_removal(fns_id_range);
-                    entity_ticks.components.remove(component_index);
+                trace!(
+                    "writing `{:?}` lost for `{entity}` for client `{client}`",
+                    rule.fns_id
+                );
+                if !message.removals_entity_added() {
+                    let entity_range = entity.write_cached(&mut serialized, &mut entity_range)?;
+                    message.add_removals_entity(&mut pools, entity_range);
                 }
+                let fns_id_range = rule.fns_id.write(&mut serialized)?;
+                message.add_removal(fns_id_range);
+                entity_ticks.components.remove(component_index);
             }
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ mod replication_query;
 pub mod server_tick;
 pub mod visibility;
 
-use core::{mem, time::Duration};
+use core::{mem, ops::Range, time::Duration};
 
 use bevy::{
     ecs::{
@@ -30,7 +30,7 @@ use crate::{
     postcard_utils,
     prelude::*,
     server::{
-        replicated_archetypes::ReplicatedArchetypes,
+        replicated_archetypes::{ReplicatedArchetype, ReplicatedArchetypes},
         replication_messages::{
             mutations::MutationsSplit,
             serialized_data::{EntityMapping, MessageWrite, WritableComponent},
@@ -45,6 +45,7 @@ use crate::{
             registry::{ComponentIndex, ReplicationRegistry, component_mask::ComponentMask},
             rules::ReplicationRules,
             track_mutate_messages::TrackMutateMessages,
+            visibility::VisibilityScope,
         },
     },
 };
@@ -579,34 +580,98 @@ fn collect_removals(
             let mut entity_range = None;
             message.start_entity_removals();
 
-            // Iterate the client's components instead of a filter's hide-mask so
-            // allow-list (`OnlyComponents`) scopes, whose hidden set is the complement, work too.
-            lost_buffer.clear();
-            lost_buffer.extend(entity_ticks.components.iter().filter(|&component_index| {
-                filter_mask.is_component_hidden(&filter_registry, component_index)
-            }));
-            for &component_index in &*lost_buffer {
-                let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
-                    panic!("`{component_index:?}` should've been registered to be marked as lost")
-                });
-                let rule = archetype.find_rule(id).unwrap_or_else(|| {
-                    panic!("`{id:?}` should match a rule since the client knows about it")
-                });
-
-                trace!(
-                    "writing `{:?}` lost for `{entity}` for client `{client}`",
-                    rule.fns_id
-                );
-                if !message.removals_entity_added() {
-                    let entity_range = entity.write_cached(&mut serialized, &mut entity_range)?;
-                    message.add_removals_entity(&mut pools, entity_range);
+            for scope in filter_mask.scopes(&filter_registry) {
+                match scope {
+                    VisibilityScope::Entity => {
+                        unreachable!("entity filters are processed during despawn collection")
+                    }
+                    // Hide-list: iterate the filter's small mask directly.
+                    VisibilityScope::Components(mask) => {
+                        for component_index in mask.iter() {
+                            if entity_ticks.components.contains(component_index) {
+                                write_lost_component(
+                                    component_index,
+                                    entity,
+                                    client,
+                                    &registry,
+                                    archetype,
+                                    entity_ticks,
+                                    &mut serialized,
+                                    &mut pools,
+                                    &mut message,
+                                    &mut entity_range,
+                                )?;
+                            }
+                        }
+                    }
+                    // Allow-list: the hidden set is the complement, so scan the
+                    // client's components. Buffered to release the borrow before removing.
+                    VisibilityScope::AllExcept(mask) => {
+                        lost_buffer.clear();
+                        lost_buffer.extend(
+                            entity_ticks
+                                .components
+                                .iter()
+                                .filter(|&component_index| !mask.contains(component_index)),
+                        );
+                        for &component_index in &*lost_buffer {
+                            write_lost_component(
+                                component_index,
+                                entity,
+                                client,
+                                &registry,
+                                archetype,
+                                entity_ticks,
+                                &mut serialized,
+                                &mut pools,
+                                &mut message,
+                                &mut entity_range,
+                            )?;
+                        }
+                    }
                 }
-                let fns_id_range = rule.fns_id.write(&mut serialized)?;
-                message.add_removal(fns_id_range);
-                entity_ticks.components.remove(component_index);
             }
         }
     }
+
+    Ok(())
+}
+
+/// Writes a removal for a component the client can no longer see and drops it from its ticks.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "follows the replication send path"
+)]
+fn write_lost_component(
+    component_index: ComponentIndex,
+    entity: Entity,
+    client: Entity,
+    registry: &ReplicationRegistry,
+    archetype: &ReplicatedArchetype,
+    entity_ticks: &mut EntityTicks,
+    serialized: &mut SerializedData,
+    pools: &mut ClientPools,
+    message: &mut Updates,
+    entity_range: &mut Option<Range<usize>>,
+) -> Result<()> {
+    let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
+        panic!("`{component_index:?}` should've been registered to be marked as lost")
+    });
+    let rule = archetype
+        .find_rule(id)
+        .unwrap_or_else(|| panic!("`{id:?}` should match a rule since the client knows about it"));
+
+    trace!(
+        "writing `{:?}` lost for `{entity}` for client `{client}`",
+        rule.fns_id
+    );
+    if !message.removals_entity_added() {
+        let entity_range = entity.write_cached(serialized, entity_range)?;
+        message.add_removals_entity(pools, entity_range);
+    }
+    let fns_id_range = rule.fns_id.write(serialized)?;
+    message.add_removal(fns_id_range);
+    entity_ticks.components.remove(component_index);
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ mod replication_query;
 pub mod server_tick;
 pub mod visibility;
 
-use core::{mem, ops::Range, time::Duration};
+use core::{mem, time::Duration};
 
 use bevy::{
     ecs::{
@@ -30,7 +30,7 @@ use crate::{
     postcard_utils,
     prelude::*,
     server::{
-        replicated_archetypes::{ReplicatedArchetype, ReplicatedArchetypes},
+        replicated_archetypes::ReplicatedArchetypes,
         replication_messages::{
             mutations::MutationsSplit,
             serialized_data::{EntityMapping, MessageWrite, WritableComponent},
@@ -580,6 +580,32 @@ fn collect_removals(
             let mut entity_range = None;
             message.start_entity_removals();
 
+            // Writes a removal for a lost component and drops it from the client's ticks.
+            let mut write_lost = |component_index: ComponentIndex,
+                                  entity_ticks: &mut EntityTicks|
+             -> Result<()> {
+                let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
+                    panic!("`{component_index:?}` should've been registered to be marked as lost")
+                });
+                let rule = archetype.find_rule(id).unwrap_or_else(|| {
+                    panic!("`{id:?}` should match a rule since the client knows about it")
+                });
+
+                trace!(
+                    "writing `{:?}` lost for `{entity}` for client `{client}`",
+                    rule.fns_id
+                );
+                if !message.removals_entity_added() {
+                    let entity_range = entity.write_cached(&mut serialized, &mut entity_range)?;
+                    message.add_removals_entity(&mut pools, entity_range);
+                }
+                let fns_id_range = rule.fns_id.write(&mut serialized)?;
+                message.add_removal(fns_id_range);
+                entity_ticks.components.remove(component_index);
+
+                Ok(())
+            };
+
             for scope in filter_mask.scopes(&filter_registry) {
                 match scope {
                     VisibilityScope::Entity => {
@@ -589,18 +615,7 @@ fn collect_removals(
                     VisibilityScope::Components(mask) => {
                         for component_index in mask.iter() {
                             if entity_ticks.components.contains(component_index) {
-                                write_lost_component(
-                                    component_index,
-                                    entity,
-                                    client,
-                                    &registry,
-                                    archetype,
-                                    entity_ticks,
-                                    &mut serialized,
-                                    &mut pools,
-                                    &mut message,
-                                    &mut entity_range,
-                                )?;
+                                write_lost(component_index, entity_ticks)?;
                             }
                         }
                     }
@@ -615,63 +630,13 @@ fn collect_removals(
                                 .filter(|&component_index| !mask.contains(component_index)),
                         );
                         for &component_index in &*lost_buffer {
-                            write_lost_component(
-                                component_index,
-                                entity,
-                                client,
-                                &registry,
-                                archetype,
-                                entity_ticks,
-                                &mut serialized,
-                                &mut pools,
-                                &mut message,
-                                &mut entity_range,
-                            )?;
+                            write_lost(component_index, entity_ticks)?;
                         }
                     }
                 }
             }
         }
     }
-
-    Ok(())
-}
-
-/// Writes a removal for a component the client can no longer see and drops it from its ticks.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "follows the replication send path"
-)]
-fn write_lost_component(
-    component_index: ComponentIndex,
-    entity: Entity,
-    client: Entity,
-    registry: &ReplicationRegistry,
-    archetype: &ReplicatedArchetype,
-    entity_ticks: &mut EntityTicks,
-    serialized: &mut SerializedData,
-    pools: &mut ClientPools,
-    message: &mut Updates,
-    entity_range: &mut Option<Range<usize>>,
-) -> Result<()> {
-    let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
-        panic!("`{component_index:?}` should've been registered to be marked as lost")
-    });
-    let rule = archetype
-        .find_rule(id)
-        .unwrap_or_else(|| panic!("`{id:?}` should match a rule since the client knows about it"));
-
-    trace!(
-        "writing `{:?}` lost for `{entity}` for client `{client}`",
-        rule.fns_id
-    );
-    if !message.removals_entity_added() {
-        let entity_range = entity.write_cached(serialized, entity_range)?;
-        message.add_removals_entity(pools, entity_range);
-    }
-    let fns_id_range = rule.fns_id.write(serialized)?;
-    message.add_removal(fns_id_range);
-    entity_ticks.components.remove(component_index);
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -581,9 +581,7 @@ fn collect_removals(
             message.start_entity_removals();
 
             // Writes a removal for a lost component and drops it from the client's ticks.
-            let mut write_lost = |component_index: ComponentIndex,
-                                  entity_ticks: &mut EntityTicks|
-             -> Result<()> {
+            let mut write_lost = |component_index, entity_ticks: &mut EntityTicks| -> Result<()> {
                 let &(id, _) = registry.get_by_index(component_index).unwrap_or_else(|| {
                     panic!("`{component_index:?}` should've been registered to be marked as lost")
                 });

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -48,6 +48,14 @@ impl FiltersMask {
             .any(|bit| matches!(registry.scope(bit), VisibilityScope::Entity))
     }
 
+    /// Returns an iterator over the scope of each set filter.
+    pub(crate) fn scopes(
+        self,
+        registry: &FilterRegistry,
+    ) -> impl Iterator<Item = &VisibilityScope> {
+        self.iter().map(|bit| registry.scope(bit))
+    }
+
     /// Returns `true` if the given component is hidden by any of the filters.
     ///
     /// Entity filters are treated as hiding all components.
@@ -59,7 +67,7 @@ impl FiltersMask {
         self.iter().any(|bit| match registry.scope(bit) {
             VisibilityScope::Entity => true,
             VisibilityScope::Components(component_mask) => component_mask.contains(index),
-            VisibilityScope::OnlyComponents(component_mask) => !component_mask.contains(index),
+            VisibilityScope::AllExcept(component_mask) => !component_mask.contains(index),
         })
     }
 }

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -3,10 +3,7 @@ use core::iter;
 use bevy::prelude::*;
 
 use super::registry::FilterRegistry;
-use crate::shared::replication::{
-    registry::{ComponentIndex, component_mask::ComponentMask},
-    visibility::VisibilityScope,
-};
+use crate::shared::replication::{registry::ComponentIndex, visibility::VisibilityScope};
 
 /// Bitset of visibility filters for an entity for a client.
 ///
@@ -62,19 +59,7 @@ impl FiltersMask {
         self.iter().any(|bit| match registry.scope(bit) {
             VisibilityScope::Entity => true,
             VisibilityScope::Components(component_mask) => component_mask.contains(index),
-        })
-    }
-
-    /// Returns an iterator over hidden components for an entity.
-    pub(crate) fn hidden_components(
-        self,
-        registry: &FilterRegistry,
-    ) -> impl Iterator<Item = &ComponentMask> {
-        self.iter().map(|bit| match registry.scope(bit) {
-            VisibilityScope::Entity => {
-                panic!("if the entity is hidden, iteration over hidden components shouldn't happen")
-            }
-            VisibilityScope::Components(component_mask) => component_mask,
+            VisibilityScope::OnlyComponents(component_mask) => !component_mask.contains(index),
         })
     }
 }

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -163,12 +163,6 @@ mod tests {
         mask.insert(bit);
 
         assert!(!mask.is_hidden(&filter_registry));
-        assert_eq!(
-            mask.hidden_components(&filter_registry)
-                .flat_map(|m| m.iter())
-                .count(),
-            1
-        );
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(mask.is_component_hidden(&filter_registry, a_index));
@@ -189,12 +183,6 @@ mod tests {
         mask.insert(bit);
 
         assert!(!mask.is_hidden(&filter_registry));
-        assert_eq!(
-            mask.hidden_components(&filter_registry)
-                .flat_map(|m| m.iter())
-                .count(),
-            2
-        );
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(mask.is_component_hidden(&filter_registry, a_index));
@@ -204,6 +192,26 @@ mod tests {
 
         let (c_index, _) = registry.init_component_fns::<C>(&mut world);
         assert!(!mask.is_component_hidden(&filter_registry, c_index));
+    }
+
+    #[test]
+    fn only_component_visibility() {
+        let mut world = World::new();
+        let mut registry = ReplicationRegistry::default();
+        let mut filter_registry = FilterRegistry::default();
+        filter_registry.register_filter::<OnlyComponentVisibility>(&mut world, &mut registry);
+
+        let bit = filter_registry.bit::<OnlyComponentVisibility>();
+        let mut mask = FiltersMask::default();
+        mask.insert(bit);
+
+        assert!(!mask.is_hidden(&filter_registry));
+
+        let (a_index, _) = registry.init_component_fns::<A>(&mut world);
+        assert!(!mask.is_component_hidden(&filter_registry, a_index));
+
+        let (b_index, _) = registry.init_component_fns::<B>(&mut world);
+        assert!(mask.is_component_hidden(&filter_registry, b_index));
     }
 
     #[derive(Component)]
@@ -239,6 +247,19 @@ mod tests {
     impl VisibilityFilter for MultiComponentVisibility {
         type ClientComponent = Self;
         type Scope = (A, B);
+
+        fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+            component.is_some()
+        }
+    }
+
+    #[derive(Component)]
+    #[component(immutable)]
+    struct OnlyComponentVisibility;
+
+    impl VisibilityFilter for OnlyComponentVisibility {
+        type ClientComponent = Self;
+        type Scope = Only<SingleComponent<A>>;
 
         fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
             component.is_some()

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -195,13 +195,13 @@ mod tests {
     }
 
     #[test]
-    fn only_component_visibility() {
+    fn all_except_visibility() {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry::default();
-        filter_registry.register_filter::<OnlyComponentVisibility>(&mut world, &mut registry);
+        filter_registry.register_filter::<AllExceptVisibility>(&mut world, &mut registry);
 
-        let bit = filter_registry.bit::<OnlyComponentVisibility>();
+        let bit = filter_registry.bit::<AllExceptVisibility>();
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
@@ -255,11 +255,11 @@ mod tests {
 
     #[derive(Component)]
     #[component(immutable)]
-    struct OnlyComponentVisibility;
+    struct AllExceptVisibility;
 
-    impl VisibilityFilter for OnlyComponentVisibility {
+    impl VisibilityFilter for AllExceptVisibility {
         type ClientComponent = Self;
-        type Scope = Only<SingleComponent<A>>;
+        type Scope = AllExcept<SingleComponent<A>>;
 
         fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
             component.is_some()

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -277,10 +277,11 @@ pub trait FilterScope {
     fn visibility_scope(world: &mut World, registry: &mut ReplicationRegistry) -> VisibilityScope;
 }
 
-/// A [`FilterScope`] that resolves to specific components rather than the whole entity.
+/// A [`FilterScope`] with components.
 ///
-/// Implemented for [`SingleComponent`] and tuples of [`Component`]s. Bounds
-/// [`AllExcept`] so it can't wrap [`Entity`].
+/// Implemented for [`SingleComponent`] and tuples of [`Component`]s.
+///
+/// Used for [`AllExcept`] in order to limit it to components.
 pub trait ComponentsScope: FilterScope {}
 
 #[deprecated(since = "0.39.0", note = "Renamed into `SingleComponent`")]

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -265,14 +265,10 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
 pub enum VisibilityScope {
     /// Whole entity.
     Entity,
-    /// Specific components on the entity (hide-list): when the filter denies
-    /// visibility, these components are hidden.
+    /// Specific components on the entity.
     Components(ComponentMask),
-    /// Specific components on the entity (allow-list): when the filter denies
-    /// visibility, every component *except* these hidden. Useful for sending
-    /// a stripped-down "proxy" of an entity (e.g. only its position + light) to
-    /// clients outside its full visibility range.
-    OnlyComponents(ComponentMask),
+    /// All components on the entity, except these.
+    AllExcept(ComponentMask),
 }
 
 /// Associates the type with a visibility scope.
@@ -280,6 +276,12 @@ pub trait FilterScope {
     /// Returns data that should be hidden when [`VisibilityFilter::is_visible`] returns `false`.
     fn visibility_scope(world: &mut World, registry: &mut ReplicationRegistry) -> VisibilityScope;
 }
+
+/// A [`FilterScope`] that resolves to specific components rather than the whole entity.
+///
+/// Implemented for [`SingleComponent`] and tuples of [`Component`]s. Bounds
+/// [`AllExcept`] so it can't wrap [`Entity`].
+pub trait ComponentsScope: FilterScope {}
 
 #[deprecated(since = "0.39.0", note = "Renamed into `SingleComponent`")]
 pub type ComponentScope<A> = SingleComponent<A>;
@@ -301,6 +303,8 @@ impl<C: Component<Mutability: MutWrite<C>>> FilterScope for SingleComponent<C> {
     }
 }
 
+impl<C: Component<Mutability: MutWrite<C>>> ComponentsScope for SingleComponent<C> {}
+
 impl FilterScope for Entity {
     fn visibility_scope(
         _world: &mut World,
@@ -310,13 +314,11 @@ impl FilterScope for Entity {
     }
 }
 
-/// Inverts a component [`FilterScope`] into an allow-list.
+/// Hides every component on the entity except those in `S` when the filter denies visibility.
 ///
-/// When the filter denies visibility, only the components in the wrapped scope
-/// `S` are replicated; every other component on the entity is hidden. `S` must
-/// be a component scope ([`SingleComponent`] or a tuple of [`Component`]s), which
-/// produces [`VisibilityScope::OnlyComponents`]. Wrapping [`Entity`] is
-/// meaningless and passes through unchanged.
+/// `S` must be a [`ComponentsScope`]: [`SingleComponent`] or a tuple of [`Component`]s.
+/// Useful for keeping a stripped-down view of an entity replicated past its full
+/// visibility range, e.g. only its transform and light.
 ///
 /// # Examples
 ///
@@ -329,8 +331,8 @@ impl FilterScope for Entity {
 ///
 /// impl VisibilityFilter for InRange {
 ///     type ClientComponent = Self;
-///     // Out-of-range clients receive only `Transform` + `PointLight`, not the rest.
-///     type Scope = Only<(Transform, PointLight)>;
+///     // Out-of-range clients keep only `Transform` and `PointLight`.
+///     type Scope = AllExcept<(Transform, PointLight)>;
 ///
 ///     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
 ///         component.is_some_and(|c| c.0)
@@ -338,15 +340,14 @@ impl FilterScope for Entity {
 /// }
 /// # #[derive(Component)] struct PointLight;
 /// ```
-pub struct Only<S>(PhantomData<S>);
+pub struct AllExcept<S>(PhantomData<S>);
 
-impl<S: FilterScope> FilterScope for Only<S> {
+impl<S: ComponentsScope> FilterScope for AllExcept<S> {
     fn visibility_scope(world: &mut World, registry: &mut ReplicationRegistry) -> VisibilityScope {
-        match S::visibility_scope(world, registry) {
-            VisibilityScope::Components(mask) => VisibilityScope::OnlyComponents(mask),
-            // `Only<Entity>` is meaningless; pass other scopes through unchanged.
-            other => other,
-        }
+        let VisibilityScope::Components(mask) = S::visibility_scope(world, registry) else {
+            unreachable!("`ComponentsScope` always yields `VisibilityScope::Components`");
+        };
+        VisibilityScope::AllExcept(mask)
     }
 }
 
@@ -362,6 +363,8 @@ macro_rules! impl_filter_scope {
                 VisibilityScope::Components(mask)
             }
         }
+
+        impl<$($C: Component<Mutability: MutWrite<$C>>),*> ComponentsScope for ($($C,)*) {}
     };
 }
 

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -265,8 +265,14 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
 pub enum VisibilityScope {
     /// Whole entity.
     Entity,
-    /// Specific components on the entity.
+    /// Specific components on the entity (hide-list): when the filter denies
+    /// visibility, these components are hidden.
     Components(ComponentMask),
+    /// Specific components on the entity (allow-list): when the filter denies
+    /// visibility, every component *except* these hidden. Useful for sending
+    /// a stripped-down "proxy" of an entity (e.g. only its position + light) to
+    /// clients outside its full visibility range.
+    OnlyComponents(ComponentMask),
 }
 
 /// Associates the type with a visibility scope.
@@ -301,6 +307,46 @@ impl FilterScope for Entity {
         _registry: &mut ReplicationRegistry,
     ) -> VisibilityScope {
         VisibilityScope::Entity
+    }
+}
+
+/// Inverts a component [`FilterScope`] into an allow-list.
+///
+/// When the filter denies visibility, only the components in the wrapped scope
+/// `S` are replicated; every other component on the entity is hidden. `S` must
+/// be a component scope ([`SingleComponent`] or a tuple of [`Component`]s), which
+/// produces [`VisibilityScope::OnlyComponents`]. Wrapping [`Entity`] is
+/// meaningless and passes through unchanged.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_replicon::prelude::*;
+/// #[derive(Component, PartialEq)]
+/// #[component(immutable)]
+/// struct InRange(bool);
+///
+/// impl VisibilityFilter for InRange {
+///     type ClientComponent = Self;
+///     // Out-of-range clients receive only `Transform` + `PointLight`, not the rest.
+///     type Scope = Only<(Transform, PointLight)>;
+///
+///     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+///         component.is_some_and(|c| c.0)
+///     }
+/// }
+/// # #[derive(Component)] struct PointLight;
+/// ```
+pub struct Only<S>(PhantomData<S>);
+
+impl<S: FilterScope> FilterScope for Only<S> {
+    fn visibility_scope(world: &mut World, registry: &mut ReplicationRegistry) -> VisibilityScope {
+        match S::visibility_scope(world, registry) {
+            VisibilityScope::Components(mask) => VisibilityScope::OnlyComponents(mask),
+            // `Only<Entity>` is meaningless; pass other scopes through unchanged.
+            other => other,
+        }
     }
 }
 

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -723,6 +723,40 @@ fn hidden_component() {
 }
 
 #[test]
+fn hidden_all_except() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .add_visibility_filter::<AllExceptVisibility>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    // The client lacks `AllExceptVisibility`, so the filter applies and only `A` reaches it.
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, B, AllExceptVisibility));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(a.iter(client_app.world()).len(), 1, "allowed by all except");
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(b.iter(client_app.world()).len(), 0, "hidden by all except");
+}
+
+#[test]
 fn visibility_gain() {
     let mut server_app = App::new();
     let mut client_app = App::new();
@@ -764,259 +798,6 @@ fn visibility_gain() {
     assert_eq!(components.iter(client_app.world()).len(), 1);
 }
 
-#[test]
-fn allow_list_component() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<A>()
-        .replicate::<B>()
-        .add_visibility_filter::<AllExceptVisibility>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    // The client lacks `AllExceptVisibility`, so the allow-list applies and only `A` reaches it.
-    server_app
-        .world_mut()
-        .spawn((Replicated, A, B, AllExceptVisibility));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut a = client_app.world_mut().query::<&A>();
-    assert_eq!(
-        a.iter(client_app.world()).len(),
-        1,
-        "allow-listed component should replicate"
-    );
-    let mut b = client_app.world_mut().query::<&B>();
-    assert_eq!(
-        b.iter(client_app.world()).len(),
-        0,
-        "non-allow-listed component should be hidden"
-    );
-}
-
-#[test]
-fn allow_list_loss() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<A>()
-        .replicate::<B>()
-        .add_visibility_filter::<AllExceptVisibility>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    // Client has the filter component, so the whole entity is visible.
-    let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert(AllExceptVisibility);
-    server_app
-        .world_mut()
-        .spawn((Replicated, A, B, AllExceptVisibility));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut b = client_app.world_mut().query::<&B>();
-    assert_eq!(
-        b.iter(client_app.world()).len(),
-        1,
-        "non-allow-listed component should replicate while visible"
-    );
-
-    // Drop the filter component, so the allow-list applies and `B` is removed on the client.
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .remove::<AllExceptVisibility>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    let mut a = client_app.world_mut().query::<&A>();
-    assert_eq!(
-        a.iter(client_app.world()).len(),
-        1,
-        "allow-listed component should stay"
-    );
-    let mut b = client_app.world_mut().query::<&B>();
-    assert_eq!(
-        b.iter(client_app.world()).len(),
-        0,
-        "non-allow-listed component should be removed on visibility loss"
-    );
-}
-
-/// Two `AllExcept` filters on the same entity, `C` is hidden by both.
-#[test]
-fn multiple_allow_lists_loss() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<A>()
-        .replicate::<B>()
-        .replicate::<C>()
-        .add_visibility_filter::<AllExceptVisibility>()
-        .add_visibility_filter::<AllExceptVisibilityB>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert((AllExceptVisibility, AllExceptVisibilityB));
-    server_app.world_mut().spawn((
-        Replicated,
-        A,
-        B,
-        C,
-        AllExceptVisibility,
-        AllExceptVisibilityB,
-    ));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut c = client_app.world_mut().query::<&C>();
-    assert_eq!(
-        c.iter(client_app.world()).len(),
-        1,
-        "fully visible at first"
-    );
-
-    // Both filters deny: one allows only `A`, the other only `B`. Their allow-lists
-    // intersect, so everything is hidden and `C` is hidden by both.
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .remove::<(AllExceptVisibility, AllExceptVisibilityB)>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    let mut a = client_app.world_mut().query::<&A>();
-    assert_eq!(
-        a.iter(client_app.world()).len(),
-        0,
-        "hidden by the `B` filter"
-    );
-    let mut b = client_app.world_mut().query::<&B>();
-    assert_eq!(
-        b.iter(client_app.world()).len(),
-        0,
-        "hidden by the `A` filter"
-    );
-    let mut c = client_app.world_mut().query::<&C>();
-    assert_eq!(
-        c.iter(client_app.world()).len(),
-        0,
-        "hidden by both filters"
-    );
-}
-
-/// `Components` and `AllExcept` filters on the same entity, `A` is hidden by both.
-#[test]
-fn hide_list_and_allow_list_loss() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<A>()
-        .replicate::<B>()
-        .replicate::<C>()
-        .add_visibility_filter::<ComponentVisibility>()
-        .add_visibility_filter::<AllExceptVisibilityB>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert((ComponentVisibility, AllExceptVisibilityB));
-    server_app.world_mut().spawn((
-        Replicated,
-        A,
-        B,
-        C,
-        ComponentVisibility,
-        AllExceptVisibilityB,
-    ));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut a = client_app.world_mut().query::<&A>();
-    assert_eq!(
-        a.iter(client_app.world()).len(),
-        1,
-        "fully visible at first"
-    );
-
-    // Hide-list hides `A`; allow-list keeps only `B`, so it also hides `A` and `C`.
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .remove::<(ComponentVisibility, AllExceptVisibilityB)>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    let mut a = client_app.world_mut().query::<&A>();
-    assert_eq!(
-        a.iter(client_app.world()).len(),
-        0,
-        "hidden by both filters"
-    );
-    let mut b = client_app.world_mut().query::<&B>();
-    assert_eq!(b.iter(client_app.world()).len(), 1, "allowed by allow-list");
-    let mut c = client_app.world_mut().query::<&C>();
-    assert_eq!(c.iter(client_app.world()).len(), 0, "hidden by allow-list");
-}
-
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "Table")]
 struct Table;
@@ -1037,9 +818,6 @@ struct A;
 
 #[derive(Component, Deserialize, Serialize)]
 struct B;
-
-#[derive(Component, Deserialize, Serialize)]
-struct C;
 
 #[derive(Component)]
 struct ReplaceMarker;
@@ -1083,19 +861,6 @@ struct AllExceptVisibility;
 impl VisibilityFilter for AllExceptVisibility {
     type ClientComponent = Self;
     type Scope = AllExcept<SingleComponent<A>>;
-
-    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
-        component.is_some()
-    }
-}
-
-#[derive(Component)]
-#[component(immutable)]
-struct AllExceptVisibilityB;
-
-impl VisibilityFilter for AllExceptVisibilityB {
-    type ClientComponent = Self;
-    type Scope = AllExcept<SingleComponent<B>>;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -776,16 +776,16 @@ fn allow_list_component() {
         ))
         .replicate::<A>()
         .replicate::<B>()
-        .add_visibility_filter::<OnlyComponentVisibility>()
+        .add_visibility_filter::<AllExceptVisibility>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    // The client lacks `OnlyComponentVisibility`, so the allow-list applies and only `A` reaches it.
+    // The client lacks `AllExceptVisibility`, so the allow-list applies and only `A` reaches it.
     server_app
         .world_mut()
-        .spawn((Replicated, A, B, OnlyComponentVisibility));
+        .spawn((Replicated, A, B, AllExceptVisibility));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -818,7 +818,7 @@ fn allow_list_loss() {
         ))
         .replicate::<A>()
         .replicate::<B>()
-        .add_visibility_filter::<OnlyComponentVisibility>()
+        .add_visibility_filter::<AllExceptVisibility>()
         .finish();
     }
 
@@ -829,10 +829,10 @@ fn allow_list_loss() {
     server_app
         .world_mut()
         .entity_mut(client)
-        .insert(OnlyComponentVisibility);
+        .insert(AllExceptVisibility);
     server_app
         .world_mut()
-        .spawn((Replicated, A, B, OnlyComponentVisibility));
+        .spawn((Replicated, A, B, AllExceptVisibility));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -850,7 +850,7 @@ fn allow_list_loss() {
     server_app
         .world_mut()
         .entity_mut(client)
-        .remove::<OnlyComponentVisibility>();
+        .remove::<AllExceptVisibility>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -928,11 +928,11 @@ impl VisibilityFilter for ComponentVisibility {
 
 #[derive(Component)]
 #[component(immutable)]
-struct OnlyComponentVisibility;
+struct AllExceptVisibility;
 
-impl VisibilityFilter for OnlyComponentVisibility {
+impl VisibilityFilter for AllExceptVisibility {
     type ClientComponent = Self;
-    type Scope = Only<SingleComponent<A>>;
+    type Scope = AllExcept<SingleComponent<A>>;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -870,6 +870,153 @@ fn allow_list_loss() {
     );
 }
 
+/// Two `AllExcept` filters on the same entity, `C` is hidden by both.
+#[test]
+fn multiple_allow_lists_loss() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .replicate::<C>()
+        .add_visibility_filter::<AllExceptVisibility>()
+        .add_visibility_filter::<AllExceptVisibilityB>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert((AllExceptVisibility, AllExceptVisibilityB));
+    server_app.world_mut().spawn((
+        Replicated,
+        A,
+        B,
+        C,
+        AllExceptVisibility,
+        AllExceptVisibilityB,
+    ));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut c = client_app.world_mut().query::<&C>();
+    assert_eq!(
+        c.iter(client_app.world()).len(),
+        1,
+        "fully visible at first"
+    );
+
+    // Both filters deny: one allows only `A`, the other only `B`. Their allow-lists
+    // intersect, so everything is hidden and `C` is hidden by both.
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .remove::<(AllExceptVisibility, AllExceptVisibilityB)>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        0,
+        "hidden by the `B` filter"
+    );
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(
+        b.iter(client_app.world()).len(),
+        0,
+        "hidden by the `A` filter"
+    );
+    let mut c = client_app.world_mut().query::<&C>();
+    assert_eq!(
+        c.iter(client_app.world()).len(),
+        0,
+        "hidden by both filters"
+    );
+}
+
+/// `Components` and `AllExcept` filters on the same entity, `A` is hidden by both.
+#[test]
+fn hide_list_and_allow_list_loss() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .replicate::<C>()
+        .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<AllExceptVisibilityB>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert((ComponentVisibility, AllExceptVisibilityB));
+    server_app.world_mut().spawn((
+        Replicated,
+        A,
+        B,
+        C,
+        ComponentVisibility,
+        AllExceptVisibilityB,
+    ));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        1,
+        "fully visible at first"
+    );
+
+    // Hide-list hides `A`; allow-list keeps only `B`, so it also hides `A` and `C`.
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .remove::<(ComponentVisibility, AllExceptVisibilityB)>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        0,
+        "hidden by both filters"
+    );
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(b.iter(client_app.world()).len(), 1, "allowed by allow-list");
+    let mut c = client_app.world_mut().query::<&C>();
+    assert_eq!(c.iter(client_app.world()).len(), 0, "hidden by allow-list");
+}
+
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "Table")]
 struct Table;
@@ -890,6 +1037,9 @@ struct A;
 
 #[derive(Component, Deserialize, Serialize)]
 struct B;
+
+#[derive(Component, Deserialize, Serialize)]
+struct C;
 
 #[derive(Component)]
 struct ReplaceMarker;
@@ -933,6 +1083,19 @@ struct AllExceptVisibility;
 impl VisibilityFilter for AllExceptVisibility {
     type ClientComponent = Self;
     type Scope = AllExcept<SingleComponent<A>>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct AllExceptVisibilityB;
+
+impl VisibilityFilter for AllExceptVisibilityB {
+    type ClientComponent = Self;
+    type Scope = AllExcept<SingleComponent<B>>;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -783,7 +783,9 @@ fn allow_list_component() {
     server_app.connect_client(&mut client_app);
 
     // The client lacks `OnlyComponentVisibility`, so the allow-list applies and only `A` reaches it.
-    server_app.world_mut().spawn((Replicated, A, B, OnlyComponentVisibility));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, B, OnlyComponentVisibility));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -828,7 +830,9 @@ fn allow_list_loss() {
         .world_mut()
         .entity_mut(client)
         .insert(OnlyComponentVisibility);
-    server_app.world_mut().spawn((Replicated, A, B, OnlyComponentVisibility));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, B, OnlyComponentVisibility));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -764,6 +764,108 @@ fn visibility_gain() {
     assert_eq!(components.iter(client_app.world()).len(), 1);
 }
 
+#[test]
+fn allow_list_component() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .add_visibility_filter::<OnlyComponentVisibility>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    // The client lacks `OnlyComponentVisibility`, so the allow-list applies and only `A` reaches it.
+    server_app.world_mut().spawn((Replicated, A, B, OnlyComponentVisibility));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        1,
+        "allow-listed component should replicate"
+    );
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(
+        b.iter(client_app.world()).len(),
+        0,
+        "non-allow-listed component should be hidden"
+    );
+}
+
+#[test]
+fn allow_list_loss() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .add_visibility_filter::<OnlyComponentVisibility>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    // Client has the filter component, so the whole entity is visible.
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert(OnlyComponentVisibility);
+    server_app.world_mut().spawn((Replicated, A, B, OnlyComponentVisibility));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(
+        b.iter(client_app.world()).len(),
+        1,
+        "non-allow-listed component should replicate while visible"
+    );
+
+    // Drop the filter component, so the allow-list applies and `B` is removed on the client.
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .remove::<OnlyComponentVisibility>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        1,
+        "allow-listed component should stay"
+    );
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(
+        b.iter(client_app.world()).len(),
+        0,
+        "non-allow-listed component should be removed on visibility loss"
+    );
+}
+
 #[derive(Component, Deserialize, Serialize)]
 #[component(storage = "Table")]
 struct Table;
@@ -814,6 +916,19 @@ struct ComponentVisibility;
 impl VisibilityFilter for ComponentVisibility {
     type ClientComponent = Self;
     type Scope = SingleComponent<A>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct OnlyComponentVisibility;
+
+impl VisibilityFilter for OnlyComponentVisibility {
+    type ClientComponent = Self;
+    type Scope = Only<SingleComponent<A>>;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -568,6 +568,209 @@ fn hidden_component() {
 }
 
 #[test]
+fn hidden_all_except() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .add_visibility_filter::<AllExceptVisibilityA>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    // Client has the filter component, so the whole entity is visible.
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert(AllExceptVisibilityA);
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, B, AllExceptVisibilityA));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(
+        b.iter(client_app.world()).len(),
+        1,
+        "allowed by all except should replicate while visible"
+    );
+
+    // Drop the filter component, so the allow-list applies and `B` is removed on the client.
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .remove::<AllExceptVisibilityA>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(a.iter(client_app.world()).len(), 1, "allowed by all except");
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(b.iter(client_app.world()).len(), 0, "hidden by all except");
+}
+
+// Two `AllExcept` filters on the same entity, `C` is hidden by both.
+#[test]
+fn multiple_hidden_all_except() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .replicate::<C>()
+        .add_visibility_filter::<AllExceptVisibilityA>()
+        .add_visibility_filter::<AllExceptVisibilityB>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert((AllExceptVisibilityA, AllExceptVisibilityB));
+    server_app.world_mut().spawn((
+        Replicated,
+        A,
+        B,
+        C,
+        AllExceptVisibilityA,
+        AllExceptVisibilityB,
+    ));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut c = client_app.world_mut().query::<&C>();
+    assert_eq!(
+        c.iter(client_app.world()).len(),
+        1,
+        "fully visible at first"
+    );
+
+    // Both filters deny: one allows only `A`, the other only `B`. Their allow-lists
+    // intersect, so everything is hidden and `C` is hidden by both.
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .remove::<(AllExceptVisibilityA, AllExceptVisibilityB)>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        0,
+        "hidden by the all except B filter"
+    );
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(
+        b.iter(client_app.world()).len(),
+        0,
+        "hidden by the all except A filter"
+    );
+    let mut c = client_app.world_mut().query::<&C>();
+    assert_eq!(
+        c.iter(client_app.world()).len(),
+        0,
+        "hidden by both filters"
+    );
+}
+
+// `Components` and `AllExcept` filters on the same entity, `A` is hidden by both.
+#[test]
+fn hidden_component_and_all_expect() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .replicate::<B>()
+        .replicate::<C>()
+        .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<AllExceptVisibilityB>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert((ComponentVisibility, AllExceptVisibilityB));
+    server_app.world_mut().spawn((
+        Replicated,
+        A,
+        B,
+        C,
+        ComponentVisibility,
+        AllExceptVisibilityB,
+    ));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        1,
+        "fully visible at first"
+    );
+
+    // Hide-list hides `A`; allow-list keeps only `B`, so it also hides `A` and `C`.
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .remove::<(ComponentVisibility, AllExceptVisibilityB)>();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    let mut a = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        a.iter(client_app.world()).len(),
+        0,
+        "hidden by both filters"
+    );
+    let mut b = client_app.world_mut().query::<&B>();
+    assert_eq!(b.iter(client_app.world()).len(), 1, "allowed by all except");
+    let mut c = client_app.world_mut().query::<&C>();
+    assert_eq!(c.iter(client_app.world()).len(), 0, "hidden by all except");
+}
+
+#[test]
 fn visibility_lose() {
     let mut server_app = App::new();
     let mut client_app = App::new();
@@ -621,6 +824,9 @@ struct A;
 struct B;
 
 #[derive(Component, Deserialize, Serialize)]
+struct C;
+
+#[derive(Component, Deserialize, Serialize)]
 struct NotReplicated;
 
 #[derive(Component)]
@@ -652,6 +858,32 @@ struct ComponentVisibility;
 impl VisibilityFilter for ComponentVisibility {
     type ClientComponent = Self;
     type Scope = SingleComponent<A>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct AllExceptVisibilityA;
+
+impl VisibilityFilter for AllExceptVisibilityA {
+    type ClientComponent = Self;
+    type Scope = AllExcept<SingleComponent<A>>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct AllExceptVisibilityB;
+
+impl VisibilityFilter for AllExceptVisibilityB {
+    type ClientComponent = Self;
+    type Scope = AllExcept<SingleComponent<B>>;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()


### PR DESCRIPTION
Adds `AllExcept<S>` filter scope and `VisibilityScope::AllExcept`, a counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden, so you can replicate a stripped-down entity (e.g. only transform and light) to clients outside its full visibility range.

This is useful when an entity should stay partially visible past its full visibility range. A lamp post far from a player can keep replicating just its point light, so the light still renders even when the player is outside its PVS, while the rest of its gameplay components stay hidden until the player gets close. The same applies to anything with a long-range visual: a campfire, a beacon, a muzzle flash, or a distant explosion.

Usage:
```rust
#[derive(Component, PartialEq)]
#[component(immutable)]
struct InRange(bool);

#[derive(Component)]
struct PointLight;

impl VisibilityFilter for InRange {
    type ClientComponent = Self;
    // Out-of-range clients keep only `Transform` and `PointLight`.
    type Scope = AllExcept<(Transform, PointLight)>;

    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
        component.is_some_and(|c| c.0)
    }
}
```
