### PR TITLE
Remove required components on replicated removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AllExcept` filter scope and `VisibilityScope::AllExcept` as a counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden. Useful for replicating a stripped-down entity (e.g. only its transform and light) to clients outside its full visibility range.
 
+### Changed
+
+- Replicated removals now also remove all required components. This may be unexpected if you set `Replicated` as a required component, because removing it also pauses replication. Use `remove_without_requires` with `AppMarkerExt::set_receive_fns` to restore the old behavior.
+
 ## [0.40.3] - 2026-06-02
 
 ### Added

--- a/example_backend/examples/authoritative_rts.rs
+++ b/example_backend/examples/authoritative_rts.rs
@@ -202,6 +202,7 @@ fn apply_unit_spawn(
 
     commands.spawn((
         Unit,
+        Replicated,
         team,
         Transform::from_translation(spawn.position.extend(0.0)),
     ));
@@ -685,7 +686,7 @@ struct MoveUnits {
 
 #[derive(Component, Serialize, Deserialize)]
 #[component(immutable)]
-#[require(Replicated, Command, Mesh2d, MeshMaterial2d<ColorMaterial>)]
+#[require(Command, Mesh2d, MeshMaterial2d<ColorMaterial>)]
 struct Unit;
 
 #[derive(Component)]

--- a/example_backend/examples/deterministic_boids.rs
+++ b/example_backend/examples/deterministic_boids.rs
@@ -115,6 +115,7 @@ fn spawn_boids(commands: &mut Commands) {
 
         commands.spawn((
             Boid { color, group },
+            Replicated,
             Bias(bias),
             Velocity(velocity),
             Transform {
@@ -283,7 +284,7 @@ impl Default for Cli {
 }
 
 #[derive(Component, Serialize, Deserialize)]
-#[require(Replicated, Mesh2d, MeshMaterial2d<ColorMaterial>)]
+#[require(Mesh2d, MeshMaterial2d<ColorMaterial>)]
 #[component(immutable)]
 struct Boid {
     color: Color,

--- a/example_backend/examples/simple_button.rs
+++ b/example_backend/examples/simple_button.rs
@@ -45,7 +45,11 @@ fn setup(mut commands: Commands, cli: Res<Cli>) -> Result<()> {
             let server = ExampleServer::new(port)?;
             commands.insert_resource(server);
 
-            commands.spawn((UiRoot, children![ToggleButton(false)]));
+            commands.spawn((
+                UiRoot,
+                Replicated,
+                children![(ToggleButton(false), Replicated)],
+            ));
             commands.spawn(Text::new("Server"));
         }
         Cli::Client { ip, port } => {
@@ -172,7 +176,6 @@ impl Default for Cli {
 /// this component is spawned) and the client (when the entity with this component is replicated).
 #[derive(Component, Serialize, Deserialize)]
 #[require(
-    Replicated,
     Node {
         width: Val::Percent(100.0),
         height: Val::Percent(100.0),
@@ -192,7 +195,6 @@ struct UiRoot;
 /// See <https://github.com/bevyengine/bevy/issues/19776> for more details.
 #[derive(Component, Serialize, Deserialize, Deref, DerefMut, Clone, Copy)]
 #[require(
-    Replicated,
     Button,
     Node {
         width: Val::Px(150.0),

--- a/example_backend/examples/tic_tac_toe.rs
+++ b/example_backend/examples/tic_tac_toe.rs
@@ -110,7 +110,7 @@ fn read_cli(mut commands: Commands, cli: Res<Cli>) -> Result<()> {
             let server = ExampleServer::new(port)?;
             commands.insert_resource(server);
 
-            commands.spawn((LocalPlayer, symbol));
+            commands.spawn((LocalPlayer, Replicated, symbol));
         }
         Cli::Client { ip, port } => {
             info!("connecting to {ip}:{port}");
@@ -191,7 +191,9 @@ fn setup_ui(mut commands: Commands, symbol_font: Res<SymbolFont>) {
                     },
                     Children::spawn(SpawnWith(|parent: &mut RelatedSpawner<_>| {
                         for index in 0..GRID_SIZE * GRID_SIZE {
-                            parent.spawn(Cell { index }).observe(pick_cell);
+                            parent
+                                .spawn((Cell { index }, Replicated))
+                                .observe(pick_cell);
                         }
                     }))
                 ),
@@ -357,11 +359,9 @@ fn init_client(
     server_symbol: Single<&Symbol, With<LocalPlayer>>,
 ) {
     // Utilize client entity as a player for convenient lookups by `client`.
-    commands.entity(add.entity).insert((
-        ClientPlayer,
-        Signature::of::<ClientPlayer>(),
-        server_symbol.next(),
-    ));
+    commands
+        .entity(add.entity)
+        .insert((ClientPlayer, Replicated, server_symbol.next()));
 
     commands.set_state(GameState::InGame);
 }
@@ -658,13 +658,11 @@ struct ResetButton;
 
 /// Cell location on the grid.
 ///
-/// We want to replicate all cells, so we set [`Replicated`] as a required component.
-/// We also want entities with this component to be automatically mapped between
+/// We want entities with this component to be automatically mapped between
 /// client and server, so we also require the [`Signature`] component.
 #[derive(Component, Hash)]
 #[require(
     Button,
-    Replicated,
     BackgroundColor(BACKGROUND_COLOR),
     Signature::of::<Cell>(),
     Node {
@@ -683,7 +681,6 @@ struct Cell {
 /// Used to determine if player can place a symbol.
 /// See also [`local_player_turn`].
 #[derive(Component)]
-#[require(Replicated)]
 struct LocalPlayer;
 
 /// Player that is also a client.
@@ -692,7 +689,7 @@ struct LocalPlayer;
 /// and automatically map it to the player entity on the server
 /// with the [`Signature`] component.
 #[derive(Component, Hash)]
-#[require(Replicated, Signature::of::<ClientPlayer>())]
+#[require(Signature::of::<ClientPlayer>())]
 struct ClientPlayer;
 
 /// A symbol pick.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,8 +180,7 @@ for functions. For more details, see [`AppRuleExt::replicate_filtered`].
 
 You don't want to replicate all components because not all of them are
 necessary to send over the network. Components that can be calculated on the client can
-be inserted using Bevy's required components feature. You can also mark [`Replicated`]
-as required to automatically replicate all entities with this component.
+be inserted using Bevy's required components feature.
 
 ```
 # use bevy::{prelude::*, state::app::StatesPlugin};
@@ -204,7 +203,7 @@ fn init_player_mesh(
 }
 
 #[derive(Component, Deserialize, Serialize)]
-#[require(Replicated, Mesh2d)]
+#[require(Mesh2d)]
 struct Player;
 ```
 
@@ -241,6 +240,12 @@ will resend the data (because it might have been lost). Since the tick for this 
 client will write the component again, even if it is the same. If your game logic relies on this behavior, you can set
 [`write_if_neq`](shared::replication::registry::receive_fns::write_if_neq) as your writing function for
 the desired components. See [receive markers](#receive-markers) for more details.
+
+### Removals
+
+In Bevy, a component can be removed either alone or together with its required components. However, there is no way to
+distinguish between these two cases, so we always remove its required components as well. While this is a sensible default,
+you can override it using [receive markers](#receive-markers).
 
 #### Component relations
 

--- a/src/shared/replication/deferred_entity.rs
+++ b/src/shared/replication/deferred_entity.rs
@@ -50,6 +50,23 @@ impl<'w> DeferredEntity<'w> {
         self
     }
 
+    /// Like [`EntityWorldMut::remove_with_requires`], but accepts only a single component and buffers it.
+    ///
+    /// Calling this function multiple times for different components is equivalent to removing a bundle with them.
+    pub fn remove_with_requires<C: Component>(&mut self) -> &mut Self {
+        let component_id = self.register_component::<C>();
+        self.changes.removals.push(component_id);
+
+        let components = self.entity.world().components();
+        // SAFETY: the ID was registered above.
+        let info = unsafe { components.get_info_unchecked(component_id) };
+        for required_id in info.required_components().iter_ids() {
+            self.changes.removals.push(required_id);
+        }
+
+        self
+    }
+
     /// Gets mutable access to the component of type `C` for the current entity.
     ///
     /// Returns `None` if the entity does not have a component of type `C`.
@@ -163,6 +180,7 @@ mod tests {
 
         entity
             .insert(Unit)
+            .insert(WithRequired)
             .insert(Trivial(1))
             .insert(WithVec(vec![2, 3]))
             .insert(WithBox(Box::new(Trivial(4))))
@@ -171,6 +189,8 @@ mod tests {
         entity.flush();
 
         assert!(entity.get::<Unit>().is_some());
+        assert!(entity.get::<WithRequired>().is_some());
+        assert!(entity.get::<Required>().is_some());
         assert_eq!(**entity.get::<Trivial>().unwrap(), 1);
         assert_eq!(**entity.get::<WithVec>().unwrap(), [2, 3]);
 
@@ -190,6 +210,7 @@ mod tests {
 
         entity
             .remove::<Unit>()
+            .remove_with_requires::<WithRequired>()
             .remove::<Trivial>()
             .remove::<WithVec>()
             .remove::<WithBox>()
@@ -198,6 +219,8 @@ mod tests {
         entity.flush();
 
         assert!(!entity.contains::<Unit>());
+        assert!(!entity.contains::<WithRequired>());
+        assert!(!entity.contains::<Required>());
         assert!(!entity.contains::<Trivial>());
         assert!(!entity.contains::<WithVec>());
         assert!(!entity.contains::<WithBox>());
@@ -211,6 +234,13 @@ mod tests {
 
     #[derive(Component)]
     struct Unit;
+
+    #[derive(Component)]
+    #[require(Required)]
+    struct WithRequired;
+
+    #[derive(Component, Default)]
+    struct Required;
 
     #[derive(Component, Deref)]
     struct Trivial(usize);

--- a/src/shared/replication/receive_markers.rs
+++ b/src/shared/replication/receive_markers.rs
@@ -148,6 +148,26 @@ pub trait AppMarkerExt {
     #[derive(Component, Serialize, Deserialize, PartialEq)]
     struct Health(u32);
     ```
+
+    Don't remove the required components on removal:
+
+    ```
+    # use bevy::state::app::StatesPlugin;
+    use bevy::prelude::*;
+    use bevy_replicon::{prelude::*, shared::replication::registry::receive_fns};
+    use serde::{Deserialize, Serialize};
+
+    # let mut app = App::new();
+    # app.add_plugins((StatesPlugin, RepliconPlugins));
+    app.replicate::<Player>().set_receive_fns::<Player>(
+        receive_fns::default_write,
+        receive_fns::remove_without_requires::<Player>,
+    );
+
+    #[derive(Component, Serialize, Deserialize)]
+    #[require(Replicated)] // `Replicated` would otherwise be removed on `Player` removal.
+    struct Player;
+    ```
     */
     fn set_receive_fns<C: Component<Mutability: MutWrite<C>>>(
         &mut self,

--- a/src/shared/replication/registry/receive_fns.rs
+++ b/src/shared/replication/registry/receive_fns.rs
@@ -153,6 +153,15 @@ pub fn default_insert_write<C: Component>(
 }
 
 /// Default component removal function.
+///
+/// Removes `C` and its required components. See also [`remove_without_requires`].
 pub fn default_remove<C: Component>(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
+    entity.remove_with_requires::<C>();
+}
+
+/// Removes only `C`, leaving required components untouched.
+///
+/// You can use it to override [`default_remove`] with [`AppMarkerExt::set_receive_fns`].
+pub fn remove_without_requires<C: Component>(_ctx: &mut RemoveCtx, entity: &mut DeferredEntity) {
     entity.remove::<C>();
 }

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -3,13 +3,9 @@ use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
     server::server_tick::ServerTick,
-    shared::replication::{
-        deferred_entity::DeferredEntity,
-        registry::{ctx::WriteCtx, receive_fns},
-    },
+    shared::replication::registry::receive_fns,
     test_app::{ServerTestAppExt, TestClientEntity},
 };
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use test_log::test;
 
@@ -39,6 +35,9 @@ fn single() {
     let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
 
+    let mut required = client_app.world_mut().query::<&Required>();
+    assert_eq!(required.iter(client_app.world()).len(), 1);
+
     server_app
         .world_mut()
         .entity_mut(server_entity)
@@ -49,6 +48,7 @@ fn single() {
     client_app.update();
 
     assert_eq!(components.iter(client_app.world()).len(), 0);
+    assert_eq!(required.iter(client_app.world()).len(), 0);
 }
 
 #[test]
@@ -107,33 +107,40 @@ fn receive_fns() {
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
-        .replicate::<Original>()
-        .set_receive_fns(replace, receive_fns::default_remove::<Replaced>)
+        .replicate::<A>()
+        .set_receive_fns::<A>(
+            receive_fns::default_write,
+            receive_fns::remove_without_requires::<A>,
+        )
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app.world_mut().spawn((Replicated, Original)).id();
+    let server_entity = server_app.world_mut().spawn((Replicated, A)).id();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    let mut components = client_app.world_mut().query::<&Replaced>();
+    let mut components = client_app.world_mut().query::<&A>();
     assert_eq!(components.iter(client_app.world()).len(), 1);
+
+    let mut required = client_app.world_mut().query::<&Required>();
+    assert_eq!(required.iter(client_app.world()).len(), 1);
 
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<Original>();
+        .remove::<A>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     assert_eq!(components.iter(client_app.world()).len(), 0);
+    assert_eq!(required.iter(client_app.world()).len(), 1);
 }
 
 #[test]
@@ -147,8 +154,11 @@ fn marker() {
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .register_marker::<ReplaceMarker>()
-        .replicate::<Original>()
-        .set_marker_fns::<ReplaceMarker, _>(replace, receive_fns::default_remove::<Replaced>)
+        .replicate::<A>()
+        .set_marker_fns::<ReplaceMarker, A>(
+            receive_fns::default_write,
+            receive_fns::remove_without_requires::<A>,
+        )
         .finish();
     }
 
@@ -156,7 +166,7 @@ fn marker() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, Original, Signature::from(0)))
+        .spawn((Replicated, A, Signature::from(0)))
         .id();
 
     let client_entity = client_app
@@ -172,14 +182,15 @@ fn marker() {
     server_app
         .world_mut()
         .entity_mut(server_entity)
-        .remove::<Original>();
+        .remove::<A>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
     let client_entity = client_app.world().entity(client_entity);
-    assert!(!client_entity.contains::<Replaced>());
+    assert!(!client_entity.contains::<A>());
+    assert!(client_entity.contains::<Required>());
 }
 
 #[test]
@@ -818,6 +829,7 @@ fn visibility_lose() {
 }
 
 #[derive(Component, Deserialize, Serialize)]
+#[require(Required)]
 struct A;
 
 #[derive(Component, Deserialize, Serialize)]
@@ -832,11 +844,8 @@ struct NotReplicated;
 #[derive(Component)]
 struct ReplaceMarker;
 
-#[derive(Component, Deserialize, Serialize)]
-struct Original;
-
-#[derive(Component, Deserialize, Serialize)]
-struct Replaced;
+#[derive(Component, Default)]
+struct Required;
 
 #[derive(Component)]
 #[component(immutable)]
@@ -888,17 +897,4 @@ impl VisibilityFilter for AllExceptVisibilityB {
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()
     }
-}
-
-/// Deserializes [`OriginalComponent`], but ignores it and inserts [`ReplacedComponent`].
-fn replace(
-    ctx: &mut WriteCtx,
-    rule_fns: &RuleFns<Original>,
-    entity: &mut DeferredEntity,
-    message: &mut Bytes,
-) -> Result<()> {
-    rule_fns.deserialize(ctx, message)?;
-    entity.insert(Replaced);
-
-    Ok(())
 }


### PR DESCRIPTION
This behavior is quite convenient when you use required components.

This may be unexpected if you set `Replicated` as a required component, because removing it also pauses replication. But I'm not sure whether this is a desirable pattern, especially with the upcoming BSN in 0.19. Required components are usually meant to be things that are necessary for a component to function.