### PR TITLE
Add a built-in link conditioner for latency, jitter, and packet loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DeferredEntity::get_components_mut` and `DeferredEntity::get_components_mut_unchecked` to get multiple components mutably.
 - `AllExcept` filter scope and `VisibilityScope::AllExcept` as a counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden. Useful for replicating a stripped-down entity (e.g. only its transform and light) to clients outside its full visibility range.
-- `LinkConditioner` resource and `LinkConditionerPlugin` behind the `link_conditioner` feature to apply artificial latency, jitter, packet loss and duplication to the message exchange. It operates on `ClientMessages` and `ServerMessages`, so it works with any backend (including the in-memory one used in tests). Reliability-aware: only unreliable channels are dropped or duplicated, and ordered channels are never reordered.
+- `LinkConditionerPlugin` behind the `link_conditioner` feature to emulate latency, jitter, packet loss and duplication on received messages. Configure it per-client with a `ConditionerConfig` component or globally with a `GlobalConditionerConfig` resource (with presets like `ConditionerConfig::POOR`). It operates on `ClientMessages` and `ServerMessages`, so it works with any backend. Reliability-aware: only unreliable channels are dropped or duplicated, and ordered channels are never reordered.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DeferredEntity::get_components_mut` and `DeferredEntity::get_components_mut_unchecked` to get multiple components mutably.
 - `AllExcept` filter scope and `VisibilityScope::AllExcept` as a counterpart to `Components`. When a `VisibilityFilter` denies visibility, every component except the listed ones is hidden. Useful for replicating a stripped-down entity (e.g. only its transform and light) to clients outside its full visibility range.
+- `LinkConditioner` resource and `LinkConditionerPlugin` behind the `link_conditioner` feature to apply artificial latency, jitter, packet loss and duplication to the message exchange. It operates on `ClientMessages` and `ServerMessages`, so it works with any backend (including the in-memory one used in tests). Reliability-aware: only unreliable channels are dropped or duplicated, and ordered channels are never reordered.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ client_diagnostics = ["client"]
 # Replication into a scene.
 scene = ["bevy/bevy_scene"]
 
+# Artificial network conditions (latency, jitter, loss, duplication) for testing and debugging.
+link_conditioner = []
+
 [[bench]]
 name = "replication"
 harness = false
@@ -143,6 +146,10 @@ required-features = ["client", "server"]
 [[test]]
 name = "stats"
 required-features = ["client_diagnostics", "client", "server"]
+
+[[test]]
+name = "link_conditioner"
+required-features = ["link_conditioner", "client", "server"]
 
 [lints.clippy]
 type_complexity = "allow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,6 +776,9 @@ pub mod prelude {
 
     #[cfg(feature = "client_diagnostics")]
     pub use super::client::diagnostics::ClientDiagnosticsPlugin;
+
+    #[cfg(feature = "link_conditioner")]
+    pub use super::shared::link_conditioner::{LinkConditioner, LinkConditionerPlugin};
 }
 
 pub use bytes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,7 +778,9 @@ pub mod prelude {
     pub use super::client::diagnostics::ClientDiagnosticsPlugin;
 
     #[cfg(feature = "link_conditioner")]
-    pub use super::shared::link_conditioner::{LinkConditioner, LinkConditionerPlugin};
+    pub use super::shared::link_conditioner::{
+        ConditionerConfig, GlobalConditionerConfig, LinkConditionerPlugin,
+    };
 }
 
 pub use bytes;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,5 +1,7 @@
 pub mod backend;
 pub mod client_id;
+#[cfg(feature = "link_conditioner")]
+pub mod link_conditioner;
 pub mod message;
 pub mod protocol;
 pub mod replication;

--- a/src/shared/link_conditioner.rs
+++ b/src/shared/link_conditioner.rs
@@ -1,20 +1,22 @@
 //! Artificial network conditions for testing and debugging.
 //!
-//! [`LinkConditionerPlugin`] adds latency, jitter, packet loss and duplication to Replicon's
-//! message exchange. It operates on [`ClientMessages`] and [`ServerMessages`] rather than on a
-//! socket.
+//! [`LinkConditionerPlugin`] delays, drops and duplicates received messages to emulate latency,
+//! jitter and packet loss. It operates on [`ClientMessages`] and [`ServerMessages`] rather than on
+//! a socket, so it applies to any messaging backend (including the in-process exchange used in
+//! tests, where it produces deterministic results).
 //!
-//! The conditioning is reliability-aware so Replicon only ever sees conditions within its design:
+//! Configure it by inserting [`GlobalConditionerConfig`] to affect every connection, or a
+//! [`ConditionerConfig`] component on a connected client entity to affect just that client (the
+//! component takes priority). Without either, the plugin does nothing.
+//!
+//! The conditioning is reliability-aware so Replicon only sees conditions within its design:
 //! latency and jitter delay every channel, but loss and duplication apply only to
 //! [`Channel::Unreliable`], and [`Channel::Ordered`] delivery is never reordered. This mirrors what
 //! a real transport exposes to the application - reliable channels retransmit (so the application
 //! observes added delay, never loss), while unreliable ones can drop or arrive doubled.
-//!
-//! The plugin is opt-in and not part of [`RepliconPlugins`](crate::prelude::RepliconPlugins). Add it
-//! on the client, the server, or both; on a peer it conditions traffic in both directions.
 
-use alloc::{collections::BTreeMap, vec::Vec};
-use core::time::Duration;
+use alloc::collections::{BTreeMap, BinaryHeap};
+use core::{cmp::Ordering, time::Duration};
 
 use bevy::prelude::*;
 #[cfg(any(feature = "client", feature = "server"))]
@@ -28,62 +30,48 @@ use crate::{client::ClientSystems, shared::backend::client_messages::ClientMessa
 #[cfg(feature = "server")]
 use crate::{server::ServerSystems, shared::backend::server_messages::ServerMessages};
 
-/// Adds artificial network conditions to Replicon's message exchange.
+/// Applies artificial network conditions to received messages.
 ///
-/// Inserts the [`LinkConditioner`] resource (default conditions are a no-op) and the systems that
-/// hold and release messages around the backend's receive and send. See the [module
-/// documentation](self) for the behavior and guarantees.
+/// Holds and releases messages between the backend's receive and Replicon's reading. Inactive
+/// until a [`GlobalConditionerConfig`] resource or a [`ConditionerConfig`] component is present.
+/// See the [module documentation](self) for behavior and guarantees.
 pub struct LinkConditionerPlugin;
 
 impl Plugin for LinkConditionerPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<LinkConditioner>();
-
         #[cfg(feature = "client")]
-        app.init_resource::<ClientConditionerState>()
-            .add_systems(
-                PreUpdate,
-                condition_client_inbound
-                    .after(ClientSystems::ReceivePackets)
-                    .before(ClientSystems::Receive),
-            )
-            .add_systems(
-                PostUpdate,
-                condition_client_outbound
-                    .after(ClientSystems::Send)
-                    .before(ClientSystems::SendPackets),
-            );
+        app.init_resource::<ClientConditioner>().add_systems(
+            PreUpdate,
+            condition_client_inbound
+                .after(ClientSystems::ReceivePackets)
+                .before(ClientSystems::Receive),
+        );
 
         #[cfg(feature = "server")]
-        app.init_resource::<ServerConditionerState>()
-            .add_systems(
-                PreUpdate,
-                condition_server_inbound
-                    .after(ServerSystems::ReceivePackets)
-                    .before(ServerSystems::Receive),
-            )
-            .add_systems(
-                PostUpdate,
-                condition_server_outbound
-                    .after(ServerSystems::Send)
-                    .before(ServerSystems::SendPackets),
-            );
+        app.init_resource::<ServerConditioner>().add_systems(
+            PreUpdate,
+            condition_server_inbound
+                .after(ServerSystems::ReceivePackets)
+                .before(ServerSystems::Receive),
+        );
+
+        #[cfg(not(any(feature = "client", feature = "server")))]
+        let _ = app;
     }
 }
 
-/// Artificial network conditions applied by [`LinkConditionerPlugin`].
+/// Network conditions for a single connection's received messages.
 ///
-/// All fields default to zero, which is a transparent pass-through. Values apply per message and
-/// per direction, so setting them on one peer for a round trip roughly doubles the perceived
-/// latency.
-#[derive(Resource, Reflect, Clone, Debug, Default)]
-pub struct LinkConditioner {
-    /// Base delay added to every message.
-    pub latency: Duration,
+/// Insert as a component on a connected client entity to condition that client on the server, or
+/// wrap in [`GlobalConditionerConfig`] to condition every connection. A per-client component takes
+/// priority over the resource.
+#[derive(Component, Reflect, Debug, Clone, Copy)]
+pub struct ConditionerConfig {
+    /// Base delay added to every message, in milliseconds.
+    pub latency: u16,
 
-    /// Upper bound of an extra uniform-random delay added on top of [`Self::latency`], sampled per
-    /// message. Models jitter.
-    pub jitter: Duration,
+    /// Maximum random latency added to **or** subtracted from [`Self::latency`], in milliseconds.
+    pub jitter: u16,
 
     /// Probability in `0.0..=1.0` to drop a message.
     ///
@@ -96,247 +84,195 @@ pub struct LinkConditioner {
     pub duplication: f32,
 }
 
-impl LinkConditioner {
-    /// Returns `false` when all conditions are zero, letting the systems skip idle work.
-    fn enabled(&self) -> bool {
-        !self.latency.is_zero()
-            || !self.jitter.is_zero()
-            || self.loss > 0.0
-            || self.duplication > 0.0
-    }
+impl ConditionerConfig {
+    /// A near-perfect connection.
+    pub const VERY_GOOD: Self = Self {
+        latency: 12,
+        jitter: 3,
+        loss: 0.001,
+        duplication: 0.0,
+    };
 
-    /// Samples the delay for a single message.
-    fn delay(&self, rng: &mut Rng) -> Duration {
-        if self.jitter.is_zero() {
-            self.latency
-        } else {
-            self.latency + self.jitter.mul_f32(rng.next_f32())
-        }
-    }
+    /// A good connection.
+    pub const GOOD: Self = Self {
+        latency: 40,
+        jitter: 10,
+        loss: 0.002,
+        duplication: 0.0,
+    };
+
+    /// An average connection.
+    pub const AVERAGE: Self = Self {
+        latency: 100,
+        jitter: 25,
+        loss: 0.02,
+        duplication: 0.0,
+    };
+
+    /// A poor connection.
+    pub const POOR: Self = Self {
+        latency: 200,
+        jitter: 50,
+        loss: 0.04,
+        duplication: 0.0,
+    };
+
+    /// A very poor connection.
+    pub const VERY_POOR: Self = Self {
+        latency: 300,
+        jitter: 75,
+        loss: 0.06,
+        duplication: 0.0,
+    };
 }
+
+/// Network conditions applied to every connection.
+///
+/// A per-client [`ConditionerConfig`] component takes priority over this resource.
+#[derive(Resource, Deref, DerefMut, Reflect, Debug, Clone, Copy)]
+pub struct GlobalConditionerConfig(pub ConditionerConfig);
 
 #[cfg(feature = "client")]
 fn condition_client_inbound(
     time: Res<Time<Real>>,
-    conditioner: Res<LinkConditioner>,
+    global: Option<Res<GlobalConditionerConfig>>,
     channels: Res<RepliconChannels>,
-    mut state: ResMut<ClientConditionerState>,
+    mut conditioner: ResMut<ClientConditioner>,
     mut messages: ResMut<ClientMessages>,
 ) {
-    let now = time.elapsed();
-    let ClientConditionerState { inbound, rng, .. } = &mut *state;
-    if !conditioner.enabled() && inbound.is_empty() {
+    let config = global.map(|global| global.0);
+    if config.is_none() && conditioner.buffer.is_empty() {
         return;
     }
 
+    let now = time.elapsed();
+    let ClientConditioner { buffer, rng } = &mut *conditioner;
     for channel_id in 0..channels.server_channels().len() {
         let channel = channels.server_channels()[channel_id];
         for message in messages.receive(channel_id) {
-            inbound.push(
+            buffer.accept(
                 now,
                 channel_id,
                 channel_id,
                 channel,
                 message,
-                &conditioner,
+                config.as_ref(),
                 rng,
             );
         }
     }
-    inbound.release_due(now, |channel_id, message| {
+    buffer.release(now, |channel_id, message| {
         messages.insert_received(channel_id, message);
-    });
-}
-
-#[cfg(feature = "client")]
-fn condition_client_outbound(
-    time: Res<Time<Real>>,
-    conditioner: Res<LinkConditioner>,
-    channels: Res<RepliconChannels>,
-    mut state: ResMut<ClientConditionerState>,
-    mut messages: ResMut<ClientMessages>,
-) {
-    let now = time.elapsed();
-    let ClientConditionerState { outbound, rng, .. } = &mut *state;
-    if !conditioner.enabled() && outbound.is_empty() {
-        return;
-    }
-
-    for (channel_id, message) in messages.drain_sent() {
-        let channel = channels.client_channels()[channel_id];
-        outbound.push(
-            now,
-            channel_id,
-            channel_id,
-            channel,
-            message,
-            &conditioner,
-            rng,
-        );
-    }
-    outbound.release_due(now, |channel_id, message| {
-        messages.send(channel_id, message);
     });
 }
 
 #[cfg(feature = "server")]
 fn condition_server_inbound(
     time: Res<Time<Real>>,
-    conditioner: Res<LinkConditioner>,
+    global: Option<Res<GlobalConditionerConfig>>,
+    configs: Query<&ConditionerConfig>,
     channels: Res<RepliconChannels>,
-    mut state: ResMut<ServerConditionerState>,
+    mut conditioner: ResMut<ServerConditioner>,
     mut messages: ResMut<ServerMessages>,
 ) {
-    let now = time.elapsed();
-    let ServerConditionerState { inbound, rng, .. } = &mut *state;
-    if !conditioner.enabled() && inbound.is_empty() {
+    let global = global.map(|global| global.0);
+    if global.is_none() && configs.is_empty() && conditioner.buffer.is_empty() {
         return;
     }
 
+    let now = time.elapsed();
+    let ServerConditioner { buffer, rng } = &mut *conditioner;
     for channel_id in 0..channels.client_channels().len() {
         let channel = channels.client_channels()[channel_id];
         for (client, message) in messages.receive(channel_id) {
+            let config = configs.get(client).ok().copied().or(global);
             let key = (client.to_bits(), channel_id);
-            inbound.push(
+            buffer.accept(
                 now,
                 key,
                 channel_id,
                 channel,
                 (client, message),
-                &conditioner,
+                config.as_ref(),
                 rng,
             );
         }
     }
-    inbound.release_due(now, |channel_id, (client, message)| {
+    buffer.release(now, |channel_id, (client, message)| {
         messages.insert_received(client, channel_id, message);
     });
 }
 
-#[cfg(feature = "server")]
-fn condition_server_outbound(
-    time: Res<Time<Real>>,
-    conditioner: Res<LinkConditioner>,
-    channels: Res<RepliconChannels>,
-    mut state: ResMut<ServerConditionerState>,
-    mut messages: ResMut<ServerMessages>,
-) {
-    let now = time.elapsed();
-    let ServerConditionerState { outbound, rng, .. } = &mut *state;
-    if !conditioner.enabled() && outbound.is_empty() {
-        return;
-    }
-
-    for (client, channel_id, message) in messages.drain_sent() {
-        let channel = channels.server_channels()[channel_id];
-        let key = (client.to_bits(), channel_id);
-        outbound.push(
-            now,
-            key,
-            channel_id,
-            channel,
-            (client, message),
-            &conditioner,
-            rng,
-        );
-    }
-    outbound.release_due(now, |channel_id, (client, message)| {
-        messages.send(client, channel_id, message);
-    });
-}
-
-/// Per-direction delay buffers and shared RNG for the client.
+/// Delay buffer and RNG for the client's single connection.
 #[cfg(feature = "client")]
-#[derive(Resource)]
-struct ClientConditionerState {
-    inbound: DelayBuffer<usize, Bytes>,
-    outbound: DelayBuffer<usize, Bytes>,
+#[derive(Resource, Default)]
+struct ClientConditioner {
+    buffer: ConditionerBuffer<usize, Bytes>,
     rng: Rng,
 }
 
-#[cfg(feature = "client")]
-impl Default for ClientConditionerState {
-    fn default() -> Self {
-        Self {
-            inbound: DelayBuffer::default(),
-            outbound: DelayBuffer::default(),
-            rng: Rng::new(INITIAL_SEED),
-        }
-    }
-}
-
-/// Per-direction delay buffers and shared RNG for the server.
+/// Delay buffer and RNG shared across all server connections.
 #[cfg(feature = "server")]
-#[derive(Resource)]
-struct ServerConditionerState {
-    inbound: DelayBuffer<(u64, usize), (Entity, Bytes)>,
-    outbound: DelayBuffer<(u64, usize), (Entity, Bytes)>,
+#[derive(Resource, Default)]
+struct ServerConditioner {
+    buffer: ConditionerBuffer<(u64, usize), (Entity, Bytes)>,
     rng: Rng,
 }
 
-#[cfg(feature = "server")]
-impl Default for ServerConditionerState {
-    fn default() -> Self {
-        Self {
-            inbound: DelayBuffer::default(),
-            outbound: DelayBuffer::default(),
-            rng: Rng::new(INITIAL_SEED),
-        }
-    }
-}
-
-/// Messages held until their release time, in arrival order.
+/// Messages waiting for their release time, ordered earliest-first.
 ///
-/// `K` is the per-channel ordering key used to keep [`Channel::Ordered`] release times monotonic
-/// (the channel ID on a client, the client entity plus channel on a server).
-struct DelayBuffer<K, P> {
-    held: Vec<Held<P>>,
+/// `K` is the per-channel ordering key (the channel ID on a client, the client entity plus channel
+/// on a server). It keeps [`Channel::Ordered`] release times monotonic so ordered delivery is
+/// never reordered.
+struct ConditionerBuffer<K, P> {
+    queue: BinaryHeap<Pending<P>>,
+    next_seq: u64,
     next_ordered: BTreeMap<K, Duration>,
 }
 
-impl<K, P> Default for DelayBuffer<K, P> {
+impl<K, P> Default for ConditionerBuffer<K, P> {
     fn default() -> Self {
         Self {
-            held: Vec::new(),
+            queue: BinaryHeap::new(),
+            next_seq: 0,
             next_ordered: BTreeMap::new(),
         }
     }
 }
 
-impl<K: Ord, P: Clone> DelayBuffer<K, P> {
+impl<K: Ord, P: Clone> ConditionerBuffer<K, P> {
     fn is_empty(&self) -> bool {
-        self.held.is_empty()
+        self.queue.is_empty()
     }
 
-    /// Schedules a message for delivery, applying loss and duplication.
-    fn push(
+    /// Schedules a received message, applying loss, latency, jitter and duplication.
+    ///
+    /// Without a config the message is released immediately, preserving order.
+    fn accept(
         &mut self,
         now: Duration,
         order_key: K,
         channel_id: usize,
         channel: Channel,
         payload: P,
-        conditioner: &LinkConditioner,
+        config: Option<&ConditionerConfig>,
         rng: &mut Rng,
     ) {
-        if channel == Channel::Unreliable && rng.chance(conditioner.loss) {
+        let Some(config) = config else {
+            self.enqueue(now, channel_id, payload);
+            return;
+        };
+
+        if channel == Channel::Unreliable && rng.chance(config.loss) {
             return;
         }
 
-        let release = self.schedule(now, order_key, channel, conditioner, rng);
-        if channel == Channel::Unreliable && rng.chance(conditioner.duplication) {
-            let release = now + conditioner.delay(rng);
-            self.held.push(Held {
-                release,
-                channel_id,
-                payload: payload.clone(),
-            });
+        let release = self.schedule(now, order_key, channel, config, rng);
+        if channel == Channel::Unreliable && rng.chance(config.duplication) {
+            let duplicate = now + sample_delay(config, rng);
+            self.enqueue(duplicate, channel_id, payload.clone());
         }
-        self.held.push(Held {
-            release,
-            channel_id,
-            payload,
-        });
+        self.enqueue(release, channel_id, payload);
     }
 
     /// Returns the release time, clamped to keep ordered channels in order.
@@ -345,10 +281,10 @@ impl<K: Ord, P: Clone> DelayBuffer<K, P> {
         now: Duration,
         order_key: K,
         channel: Channel,
-        conditioner: &LinkConditioner,
+        config: &ConditionerConfig,
         rng: &mut Rng,
     ) -> Duration {
-        let release = now + conditioner.delay(rng);
+        let release = now + sample_delay(config, rng);
         if channel != Channel::Ordered {
             return release;
         }
@@ -358,24 +294,69 @@ impl<K: Ord, P: Clone> DelayBuffer<K, P> {
         *last
     }
 
-    /// Emits every message whose release time has passed, in arrival order.
-    fn release_due(&mut self, now: Duration, mut emit: impl FnMut(usize, P)) {
-        let mut kept = Vec::with_capacity(self.held.len());
-        for held in core::mem::take(&mut self.held) {
-            if held.release <= now {
-                emit(held.channel_id, held.payload);
-            } else {
-                kept.push(held);
-            }
+    fn enqueue(&mut self, release: Duration, channel_id: usize, payload: P) {
+        self.queue.push(Pending {
+            release,
+            seq: self.next_seq,
+            channel_id,
+            payload,
+        });
+        self.next_seq += 1;
+    }
+
+    /// Emits every message whose release time has passed, earliest first.
+    fn release(&mut self, now: Duration, mut emit: impl FnMut(usize, P)) {
+        while self
+            .queue
+            .peek()
+            .is_some_and(|pending| pending.release <= now)
+        {
+            let pending = self.queue.pop().expect("peek confirmed an item");
+            emit(pending.channel_id, pending.payload);
         }
-        self.held = kept;
     }
 }
 
-struct Held<P> {
+/// A message ordered by release time, then arrival, for the min-heap.
+struct Pending<P> {
     release: Duration,
+    seq: u64,
     channel_id: usize,
     payload: P,
+}
+
+impl<P> PartialEq for Pending<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.seq == other.seq
+    }
+}
+
+impl<P> Eq for Pending<P> {}
+
+impl<P> Ord for Pending<P> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reversed so the `BinaryHeap` max-heap yields the earliest release first.
+        other
+            .release
+            .cmp(&self.release)
+            .then_with(|| other.seq.cmp(&self.seq))
+    }
+}
+
+impl<P> PartialOrd for Pending<P> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Samples the delay for one message: base latency with jitter added or subtracted.
+fn sample_delay(config: &ConditionerConfig, rng: &mut Rng) -> Duration {
+    let mut millis = i64::from(config.latency);
+    if config.jitter > 0 {
+        let jitter = i64::from(rng.below(config.jitter));
+        millis += if rng.coin_flip() { jitter } else { -jitter };
+    }
+    Duration::from_millis(millis.max(0) as u64)
 }
 
 /// Fixed seed so conditioned runs are reproducible.
@@ -384,6 +365,12 @@ const INITIAL_SEED: u64 = 0x2545_F491_4F6C_DD1D;
 /// SplitMix64, an inline PRNG so the crate stays `no_std` without a `rand` dependency.
 struct Rng {
     state: u64,
+}
+
+impl Default for Rng {
+    fn default() -> Self {
+        Self::new(INITIAL_SEED)
+    }
 }
 
 impl Rng {
@@ -408,6 +395,19 @@ impl Rng {
     fn chance(&mut self, p: f32) -> bool {
         p > 0.0 && self.next_f32() < p
     }
+
+    fn coin_flip(&mut self) -> bool {
+        self.next_u64() & 1 == 1
+    }
+
+    /// Uniform value in `0..max`, or zero when `max` is zero.
+    fn below(&mut self, max: u16) -> u16 {
+        if max == 0 {
+            0
+        } else {
+            (self.next_u64() % u64::from(max)) as u16
+        }
+    }
 }
 
 #[cfg(all(test, any(feature = "client", feature = "server")))]
@@ -416,157 +416,168 @@ mod tests {
 
     use super::*;
 
-    const MSG: &[u8] = &[1, 2, 3];
+    fn buffer() -> ConditionerBuffer<usize, Bytes> {
+        ConditionerBuffer::default()
+    }
 
-    fn drained(buffer: &mut DelayBuffer<usize, Bytes>, now: Duration) -> Vec<usize> {
+    /// Drains every released message at `now`, returning each payload's first byte in pop order.
+    fn drain(buffer: &mut ConditionerBuffer<usize, Bytes>, now: Duration) -> Vec<u8> {
         let mut out = Vec::new();
-        buffer.release_due(now, |channel_id, _| out.push(channel_id));
+        buffer.release(now, |_, payload| out.push(payload[0]));
         out
+    }
+
+    fn message(tag: u8) -> Bytes {
+        Bytes::copy_from_slice(&[tag])
     }
 
     #[test]
     fn rng_stays_in_range() {
-        let mut rng = Rng::new(INITIAL_SEED);
+        let mut rng = Rng::default();
         for _ in 0..10_000 {
-            let value = rng.next_f32();
-            assert!((0.0..1.0).contains(&value));
+            assert!((0.0..1.0).contains(&rng.next_f32()));
         }
     }
 
     #[test]
-    fn passthrough_releases_immediately() {
-        let conditioner = LinkConditioner::default();
-        let mut rng = Rng::new(INITIAL_SEED);
-        let mut buffer = DelayBuffer::default();
+    fn without_config_releases_immediately() {
+        let mut rng = Rng::default();
+        let mut buffer = buffer();
 
-        buffer.push(
+        buffer.accept(
             Duration::ZERO,
             0,
             0,
             Channel::Ordered,
-            Bytes::from(MSG),
-            &conditioner,
+            message(7),
+            None,
             &mut rng,
         );
 
-        assert_eq!(drained(&mut buffer, Duration::ZERO), [0]);
+        assert_eq!(drain(&mut buffer, Duration::ZERO), [7]);
     }
 
     #[test]
     fn latency_delays_release() {
-        let conditioner = LinkConditioner {
-            latency: Duration::from_millis(100),
-            ..Default::default()
+        let config = ConditionerConfig {
+            latency: 100,
+            jitter: 0,
+            loss: 0.0,
+            duplication: 0.0,
         };
-        let mut rng = Rng::new(INITIAL_SEED);
-        let mut buffer = DelayBuffer::default();
+        let mut rng = Rng::default();
+        let mut buffer = buffer();
 
-        buffer.push(
+        buffer.accept(
             Duration::ZERO,
             0,
             0,
             Channel::Ordered,
-            Bytes::from(MSG),
-            &conditioner,
+            message(1),
+            Some(&config),
             &mut rng,
         );
 
-        assert!(drained(&mut buffer, Duration::from_millis(50)).is_empty());
-        assert_eq!(drained(&mut buffer, Duration::from_millis(100)), [0]);
+        assert!(drain(&mut buffer, Duration::from_millis(50)).is_empty());
+        assert_eq!(drain(&mut buffer, Duration::from_millis(100)), [1]);
     }
 
     #[test]
     fn loss_drops_only_unreliable() {
-        let conditioner = LinkConditioner {
+        let config = ConditionerConfig {
+            latency: 0,
+            jitter: 0,
             loss: 1.0,
-            ..Default::default()
+            duplication: 0.0,
         };
-        let mut rng = Rng::new(INITIAL_SEED);
-        let mut buffer = DelayBuffer::default();
+        let mut rng = Rng::default();
+        let mut buffer = buffer();
 
-        buffer.push(
+        buffer.accept(
             Duration::ZERO,
             0,
             0,
             Channel::Unreliable,
-            Bytes::from(MSG),
-            &conditioner,
+            message(1),
+            Some(&config),
             &mut rng,
         );
-        buffer.push(
+        buffer.accept(
             Duration::ZERO,
             1,
             1,
             Channel::Ordered,
-            Bytes::from(MSG),
-            &conditioner,
+            message(2),
+            Some(&config),
             &mut rng,
         );
 
-        assert_eq!(drained(&mut buffer, Duration::ZERO), [1]);
+        assert_eq!(drain(&mut buffer, Duration::ZERO), [2]);
     }
 
     #[test]
     fn duplication_doubles_only_unreliable() {
-        let conditioner = LinkConditioner {
+        let config = ConditionerConfig {
+            latency: 0,
+            jitter: 0,
+            loss: 0.0,
             duplication: 1.0,
-            ..Default::default()
         };
-        let mut rng = Rng::new(INITIAL_SEED);
-        let mut buffer = DelayBuffer::default();
+        let mut rng = Rng::default();
+        let mut buffer = buffer();
 
-        buffer.push(
+        buffer.accept(
             Duration::ZERO,
             0,
             0,
             Channel::Unreliable,
-            Bytes::from(MSG),
-            &conditioner,
+            message(1),
+            Some(&config),
             &mut rng,
         );
-        buffer.push(
+        buffer.accept(
             Duration::ZERO,
             1,
             1,
             Channel::Ordered,
-            Bytes::from(MSG),
-            &conditioner,
+            message(2),
+            Some(&config),
             &mut rng,
         );
 
-        assert_eq!(drained(&mut buffer, Duration::ZERO), [0, 0, 1]);
+        let drained = drain(&mut buffer, Duration::from_secs(1));
+        assert_eq!(drained.iter().filter(|&&tag| tag == 1).count(), 2);
+        assert_eq!(drained.iter().filter(|&&tag| tag == 2).count(), 1);
     }
 
     #[test]
-    fn ordered_release_is_monotonic() {
-        let conditioner = LinkConditioner {
-            jitter: Duration::from_millis(100),
-            ..Default::default()
+    fn ordered_keeps_arrival_order_under_jitter() {
+        let config = ConditionerConfig {
+            latency: 50,
+            jitter: 50,
+            loss: 0.0,
+            duplication: 0.0,
         };
-        let mut rng = Rng::new(INITIAL_SEED);
-        let mut buffer = DelayBuffer::<usize, Bytes>::default();
+        let mut rng = Rng::default();
+        let mut buffer = buffer();
 
-        for _ in 0..32 {
-            buffer.push(
+        for tag in 0..32 {
+            buffer.accept(
                 Duration::ZERO,
                 0,
                 0,
                 Channel::Ordered,
-                Bytes::from(MSG),
-                &conditioner,
+                message(tag),
+                Some(&config),
                 &mut rng,
             );
         }
 
-        let mut releases: Vec<Duration> = buffer.held.iter().map(|held| held.release).collect();
-        let mut sorted = releases.clone();
-        sorted.sort_unstable();
-        assert_eq!(releases, sorted, "ordered releases must not decrease");
-
-        releases.dedup();
-        assert!(
-            releases.len() > 1,
-            "jitter should still spread releases apart"
+        let drained = drain(&mut buffer, Duration::from_secs(1));
+        let expected: Vec<u8> = (0..32).collect();
+        assert_eq!(
+            drained, expected,
+            "ordered channel must preserve arrival order"
         );
     }
 }

--- a/src/shared/link_conditioner.rs
+++ b/src/shared/link_conditioner.rs
@@ -1,0 +1,572 @@
+//! Artificial network conditions for testing and debugging.
+//!
+//! [`LinkConditionerPlugin`] adds latency, jitter, packet loss and duplication to Replicon's
+//! message exchange. It operates on [`ClientMessages`] and [`ServerMessages`] rather than on a
+//! socket.
+//!
+//! The conditioning is reliability-aware so Replicon only ever sees conditions within its design:
+//! latency and jitter delay every channel, but loss and duplication apply only to
+//! [`Channel::Unreliable`], and [`Channel::Ordered`] delivery is never reordered. This mirrors what
+//! a real transport exposes to the application - reliable channels retransmit (so the application
+//! observes added delay, never loss), while unreliable ones can drop or arrive doubled.
+//!
+//! The plugin is opt-in and not part of [`RepliconPlugins`](crate::prelude::RepliconPlugins). Add it
+//! on the client, the server, or both; on a peer it conditions traffic in both directions.
+
+use alloc::{collections::BTreeMap, vec::Vec};
+use core::time::Duration;
+
+use bevy::prelude::*;
+#[cfg(any(feature = "client", feature = "server"))]
+use bytes::Bytes;
+
+use crate::shared::backend::channels::Channel;
+#[cfg(any(feature = "client", feature = "server"))]
+use crate::shared::backend::channels::RepliconChannels;
+#[cfg(feature = "client")]
+use crate::{client::ClientSystems, shared::backend::client_messages::ClientMessages};
+#[cfg(feature = "server")]
+use crate::{server::ServerSystems, shared::backend::server_messages::ServerMessages};
+
+/// Adds artificial network conditions to Replicon's message exchange.
+///
+/// Inserts the [`LinkConditioner`] resource (default conditions are a no-op) and the systems that
+/// hold and release messages around the backend's receive and send. See the [module
+/// documentation](self) for the behavior and guarantees.
+pub struct LinkConditionerPlugin;
+
+impl Plugin for LinkConditionerPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<LinkConditioner>();
+
+        #[cfg(feature = "client")]
+        app.init_resource::<ClientConditionerState>()
+            .add_systems(
+                PreUpdate,
+                condition_client_inbound
+                    .after(ClientSystems::ReceivePackets)
+                    .before(ClientSystems::Receive),
+            )
+            .add_systems(
+                PostUpdate,
+                condition_client_outbound
+                    .after(ClientSystems::Send)
+                    .before(ClientSystems::SendPackets),
+            );
+
+        #[cfg(feature = "server")]
+        app.init_resource::<ServerConditionerState>()
+            .add_systems(
+                PreUpdate,
+                condition_server_inbound
+                    .after(ServerSystems::ReceivePackets)
+                    .before(ServerSystems::Receive),
+            )
+            .add_systems(
+                PostUpdate,
+                condition_server_outbound
+                    .after(ServerSystems::Send)
+                    .before(ServerSystems::SendPackets),
+            );
+    }
+}
+
+/// Artificial network conditions applied by [`LinkConditionerPlugin`].
+///
+/// All fields default to zero, which is a transparent pass-through. Values apply per message and
+/// per direction, so setting them on one peer for a round trip roughly doubles the perceived
+/// latency.
+#[derive(Resource, Reflect, Clone, Debug, Default)]
+pub struct LinkConditioner {
+    /// Base delay added to every message.
+    pub latency: Duration,
+
+    /// Upper bound of an extra uniform-random delay added on top of [`Self::latency`], sampled per
+    /// message. Models jitter.
+    pub jitter: Duration,
+
+    /// Probability in `0.0..=1.0` to drop a message.
+    ///
+    /// Applies only to [`Channel::Unreliable`]; reliable channels are never dropped.
+    pub loss: f32,
+
+    /// Probability in `0.0..=1.0` to deliver an extra copy of a message.
+    ///
+    /// Applies only to [`Channel::Unreliable`]; the duplicate gets its own independent delay.
+    pub duplication: f32,
+}
+
+impl LinkConditioner {
+    /// Returns `false` when all conditions are zero, letting the systems skip idle work.
+    fn enabled(&self) -> bool {
+        !self.latency.is_zero()
+            || !self.jitter.is_zero()
+            || self.loss > 0.0
+            || self.duplication > 0.0
+    }
+
+    /// Samples the delay for a single message.
+    fn delay(&self, rng: &mut Rng) -> Duration {
+        if self.jitter.is_zero() {
+            self.latency
+        } else {
+            self.latency + self.jitter.mul_f32(rng.next_f32())
+        }
+    }
+}
+
+#[cfg(feature = "client")]
+fn condition_client_inbound(
+    time: Res<Time<Real>>,
+    conditioner: Res<LinkConditioner>,
+    channels: Res<RepliconChannels>,
+    mut state: ResMut<ClientConditionerState>,
+    mut messages: ResMut<ClientMessages>,
+) {
+    let now = time.elapsed();
+    let ClientConditionerState { inbound, rng, .. } = &mut *state;
+    if !conditioner.enabled() && inbound.is_empty() {
+        return;
+    }
+
+    for channel_id in 0..channels.server_channels().len() {
+        let channel = channels.server_channels()[channel_id];
+        for message in messages.receive(channel_id) {
+            inbound.push(
+                now,
+                channel_id,
+                channel_id,
+                channel,
+                message,
+                &conditioner,
+                rng,
+            );
+        }
+    }
+    inbound.release_due(now, |channel_id, message| {
+        messages.insert_received(channel_id, message);
+    });
+}
+
+#[cfg(feature = "client")]
+fn condition_client_outbound(
+    time: Res<Time<Real>>,
+    conditioner: Res<LinkConditioner>,
+    channels: Res<RepliconChannels>,
+    mut state: ResMut<ClientConditionerState>,
+    mut messages: ResMut<ClientMessages>,
+) {
+    let now = time.elapsed();
+    let ClientConditionerState { outbound, rng, .. } = &mut *state;
+    if !conditioner.enabled() && outbound.is_empty() {
+        return;
+    }
+
+    for (channel_id, message) in messages.drain_sent() {
+        let channel = channels.client_channels()[channel_id];
+        outbound.push(
+            now,
+            channel_id,
+            channel_id,
+            channel,
+            message,
+            &conditioner,
+            rng,
+        );
+    }
+    outbound.release_due(now, |channel_id, message| {
+        messages.send(channel_id, message);
+    });
+}
+
+#[cfg(feature = "server")]
+fn condition_server_inbound(
+    time: Res<Time<Real>>,
+    conditioner: Res<LinkConditioner>,
+    channels: Res<RepliconChannels>,
+    mut state: ResMut<ServerConditionerState>,
+    mut messages: ResMut<ServerMessages>,
+) {
+    let now = time.elapsed();
+    let ServerConditionerState { inbound, rng, .. } = &mut *state;
+    if !conditioner.enabled() && inbound.is_empty() {
+        return;
+    }
+
+    for channel_id in 0..channels.client_channels().len() {
+        let channel = channels.client_channels()[channel_id];
+        for (client, message) in messages.receive(channel_id) {
+            let key = (client.to_bits(), channel_id);
+            inbound.push(
+                now,
+                key,
+                channel_id,
+                channel,
+                (client, message),
+                &conditioner,
+                rng,
+            );
+        }
+    }
+    inbound.release_due(now, |channel_id, (client, message)| {
+        messages.insert_received(client, channel_id, message);
+    });
+}
+
+#[cfg(feature = "server")]
+fn condition_server_outbound(
+    time: Res<Time<Real>>,
+    conditioner: Res<LinkConditioner>,
+    channels: Res<RepliconChannels>,
+    mut state: ResMut<ServerConditionerState>,
+    mut messages: ResMut<ServerMessages>,
+) {
+    let now = time.elapsed();
+    let ServerConditionerState { outbound, rng, .. } = &mut *state;
+    if !conditioner.enabled() && outbound.is_empty() {
+        return;
+    }
+
+    for (client, channel_id, message) in messages.drain_sent() {
+        let channel = channels.server_channels()[channel_id];
+        let key = (client.to_bits(), channel_id);
+        outbound.push(
+            now,
+            key,
+            channel_id,
+            channel,
+            (client, message),
+            &conditioner,
+            rng,
+        );
+    }
+    outbound.release_due(now, |channel_id, (client, message)| {
+        messages.send(client, channel_id, message);
+    });
+}
+
+/// Per-direction delay buffers and shared RNG for the client.
+#[cfg(feature = "client")]
+#[derive(Resource)]
+struct ClientConditionerState {
+    inbound: DelayBuffer<usize, Bytes>,
+    outbound: DelayBuffer<usize, Bytes>,
+    rng: Rng,
+}
+
+#[cfg(feature = "client")]
+impl Default for ClientConditionerState {
+    fn default() -> Self {
+        Self {
+            inbound: DelayBuffer::default(),
+            outbound: DelayBuffer::default(),
+            rng: Rng::new(INITIAL_SEED),
+        }
+    }
+}
+
+/// Per-direction delay buffers and shared RNG for the server.
+#[cfg(feature = "server")]
+#[derive(Resource)]
+struct ServerConditionerState {
+    inbound: DelayBuffer<(u64, usize), (Entity, Bytes)>,
+    outbound: DelayBuffer<(u64, usize), (Entity, Bytes)>,
+    rng: Rng,
+}
+
+#[cfg(feature = "server")]
+impl Default for ServerConditionerState {
+    fn default() -> Self {
+        Self {
+            inbound: DelayBuffer::default(),
+            outbound: DelayBuffer::default(),
+            rng: Rng::new(INITIAL_SEED),
+        }
+    }
+}
+
+/// Messages held until their release time, in arrival order.
+///
+/// `K` is the per-channel ordering key used to keep [`Channel::Ordered`] release times monotonic
+/// (the channel ID on a client, the client entity plus channel on a server).
+struct DelayBuffer<K, P> {
+    held: Vec<Held<P>>,
+    next_ordered: BTreeMap<K, Duration>,
+}
+
+impl<K, P> Default for DelayBuffer<K, P> {
+    fn default() -> Self {
+        Self {
+            held: Vec::new(),
+            next_ordered: BTreeMap::new(),
+        }
+    }
+}
+
+impl<K: Ord, P: Clone> DelayBuffer<K, P> {
+    fn is_empty(&self) -> bool {
+        self.held.is_empty()
+    }
+
+    /// Schedules a message for delivery, applying loss and duplication.
+    fn push(
+        &mut self,
+        now: Duration,
+        order_key: K,
+        channel_id: usize,
+        channel: Channel,
+        payload: P,
+        conditioner: &LinkConditioner,
+        rng: &mut Rng,
+    ) {
+        if channel == Channel::Unreliable && rng.chance(conditioner.loss) {
+            return;
+        }
+
+        let release = self.schedule(now, order_key, channel, conditioner, rng);
+        if channel == Channel::Unreliable && rng.chance(conditioner.duplication) {
+            let release = now + conditioner.delay(rng);
+            self.held.push(Held {
+                release,
+                channel_id,
+                payload: payload.clone(),
+            });
+        }
+        self.held.push(Held {
+            release,
+            channel_id,
+            payload,
+        });
+    }
+
+    /// Returns the release time, clamped to keep ordered channels in order.
+    fn schedule(
+        &mut self,
+        now: Duration,
+        order_key: K,
+        channel: Channel,
+        conditioner: &LinkConditioner,
+        rng: &mut Rng,
+    ) -> Duration {
+        let release = now + conditioner.delay(rng);
+        if channel != Channel::Ordered {
+            return release;
+        }
+
+        let last = self.next_ordered.entry(order_key).or_insert(Duration::ZERO);
+        *last = release.max(*last);
+        *last
+    }
+
+    /// Emits every message whose release time has passed, in arrival order.
+    fn release_due(&mut self, now: Duration, mut emit: impl FnMut(usize, P)) {
+        let mut kept = Vec::with_capacity(self.held.len());
+        for held in core::mem::take(&mut self.held) {
+            if held.release <= now {
+                emit(held.channel_id, held.payload);
+            } else {
+                kept.push(held);
+            }
+        }
+        self.held = kept;
+    }
+}
+
+struct Held<P> {
+    release: Duration,
+    channel_id: usize,
+    payload: P,
+}
+
+/// Fixed seed so conditioned runs are reproducible.
+const INITIAL_SEED: u64 = 0x2545_F491_4F6C_DD1D;
+
+/// SplitMix64, an inline PRNG so the crate stays `no_std` without a `rand` dependency.
+struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform `f32` in `[0, 1)`, from the top 24 bits.
+    fn next_f32(&mut self) -> f32 {
+        (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32
+    }
+
+    /// Rolls against a probability, leaving the RNG untouched when `p` is zero.
+    fn chance(&mut self, p: f32) -> bool {
+        p > 0.0 && self.next_f32() < p
+    }
+}
+
+#[cfg(all(test, any(feature = "client", feature = "server")))]
+mod tests {
+    use test_log::test;
+
+    use super::*;
+
+    const MSG: &[u8] = &[1, 2, 3];
+
+    fn drained(buffer: &mut DelayBuffer<usize, Bytes>, now: Duration) -> Vec<usize> {
+        let mut out = Vec::new();
+        buffer.release_due(now, |channel_id, _| out.push(channel_id));
+        out
+    }
+
+    #[test]
+    fn rng_stays_in_range() {
+        let mut rng = Rng::new(INITIAL_SEED);
+        for _ in 0..10_000 {
+            let value = rng.next_f32();
+            assert!((0.0..1.0).contains(&value));
+        }
+    }
+
+    #[test]
+    fn passthrough_releases_immediately() {
+        let conditioner = LinkConditioner::default();
+        let mut rng = Rng::new(INITIAL_SEED);
+        let mut buffer = DelayBuffer::default();
+
+        buffer.push(
+            Duration::ZERO,
+            0,
+            0,
+            Channel::Ordered,
+            Bytes::from(MSG),
+            &conditioner,
+            &mut rng,
+        );
+
+        assert_eq!(drained(&mut buffer, Duration::ZERO), [0]);
+    }
+
+    #[test]
+    fn latency_delays_release() {
+        let conditioner = LinkConditioner {
+            latency: Duration::from_millis(100),
+            ..Default::default()
+        };
+        let mut rng = Rng::new(INITIAL_SEED);
+        let mut buffer = DelayBuffer::default();
+
+        buffer.push(
+            Duration::ZERO,
+            0,
+            0,
+            Channel::Ordered,
+            Bytes::from(MSG),
+            &conditioner,
+            &mut rng,
+        );
+
+        assert!(drained(&mut buffer, Duration::from_millis(50)).is_empty());
+        assert_eq!(drained(&mut buffer, Duration::from_millis(100)), [0]);
+    }
+
+    #[test]
+    fn loss_drops_only_unreliable() {
+        let conditioner = LinkConditioner {
+            loss: 1.0,
+            ..Default::default()
+        };
+        let mut rng = Rng::new(INITIAL_SEED);
+        let mut buffer = DelayBuffer::default();
+
+        buffer.push(
+            Duration::ZERO,
+            0,
+            0,
+            Channel::Unreliable,
+            Bytes::from(MSG),
+            &conditioner,
+            &mut rng,
+        );
+        buffer.push(
+            Duration::ZERO,
+            1,
+            1,
+            Channel::Ordered,
+            Bytes::from(MSG),
+            &conditioner,
+            &mut rng,
+        );
+
+        assert_eq!(drained(&mut buffer, Duration::ZERO), [1]);
+    }
+
+    #[test]
+    fn duplication_doubles_only_unreliable() {
+        let conditioner = LinkConditioner {
+            duplication: 1.0,
+            ..Default::default()
+        };
+        let mut rng = Rng::new(INITIAL_SEED);
+        let mut buffer = DelayBuffer::default();
+
+        buffer.push(
+            Duration::ZERO,
+            0,
+            0,
+            Channel::Unreliable,
+            Bytes::from(MSG),
+            &conditioner,
+            &mut rng,
+        );
+        buffer.push(
+            Duration::ZERO,
+            1,
+            1,
+            Channel::Ordered,
+            Bytes::from(MSG),
+            &conditioner,
+            &mut rng,
+        );
+
+        assert_eq!(drained(&mut buffer, Duration::ZERO), [0, 0, 1]);
+    }
+
+    #[test]
+    fn ordered_release_is_monotonic() {
+        let conditioner = LinkConditioner {
+            jitter: Duration::from_millis(100),
+            ..Default::default()
+        };
+        let mut rng = Rng::new(INITIAL_SEED);
+        let mut buffer = DelayBuffer::<usize, Bytes>::default();
+
+        for _ in 0..32 {
+            buffer.push(
+                Duration::ZERO,
+                0,
+                0,
+                Channel::Ordered,
+                Bytes::from(MSG),
+                &conditioner,
+                &mut rng,
+            );
+        }
+
+        let mut releases: Vec<Duration> = buffer.held.iter().map(|held| held.release).collect();
+        let mut sorted = releases.clone();
+        sorted.sort_unstable();
+        assert_eq!(releases, sorted, "ordered releases must not decrease");
+
+        releases.dedup();
+        assert!(
+            releases.len() > 1,
+            "jitter should still spread releases apart"
+        );
+    }
+}

--- a/tests/link_conditioner.rs
+++ b/tests/link_conditioner.rs
@@ -1,0 +1,77 @@
+use core::time::Duration;
+
+use bevy::{prelude::*, state::app::StatesPlugin, time::TimeUpdateStrategy};
+use bevy_replicon::{prelude::*, test_app::ServerTestAppExt};
+
+fn conditioned_app() -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        StatesPlugin,
+        RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        LinkConditionerPlugin,
+    ));
+    app.finish();
+    app
+}
+
+fn replicated_count(app: &mut App) -> usize {
+    app.world_mut().query::<&Remote>().iter(app.world()).len()
+}
+
+#[test]
+fn default_conditions_pass_through() {
+    let mut server_app = conditioned_app();
+    let mut client_app = conditioned_app();
+    server_app.connect_client(&mut client_app);
+
+    server_app.world_mut().spawn(Replicated);
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    assert_eq!(
+        replicated_count(&mut client_app),
+        1,
+        "a default conditioner must not change replication timing"
+    );
+}
+
+#[test]
+fn latency_holds_then_delivers() {
+    let mut server_app = conditioned_app();
+    let mut client_app = conditioned_app();
+
+    // Handshake first, unconditioned, so authorization isn't delayed.
+    server_app.connect_client(&mut client_app);
+
+    let latency = Duration::from_millis(250);
+    let step = Duration::from_millis(100);
+    client_app.insert_resource(TimeUpdateStrategy::ManualDuration(step));
+    client_app
+        .world_mut()
+        .resource_mut::<LinkConditioner>()
+        .latency = latency;
+
+    server_app.world_mut().spawn(Replicated);
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    // The spawn is now buffered on the client; the first update holds it.
+    client_app.update();
+    assert_eq!(
+        replicated_count(&mut client_app),
+        0,
+        "the spawn must be held while latency has not elapsed"
+    );
+
+    // Advance past the latency; the held spawn is released and applied.
+    for _ in 0..4 {
+        client_app.update();
+    }
+    assert_eq!(
+        replicated_count(&mut client_app),
+        1,
+        "the spawn must arrive once latency has elapsed"
+    );
+}

--- a/tests/link_conditioner.rs
+++ b/tests/link_conditioner.rs
@@ -45,13 +45,14 @@ fn latency_holds_then_delivers() {
     // Handshake first, unconditioned, so authorization isn't delayed.
     server_app.connect_client(&mut client_app);
 
-    let latency = Duration::from_millis(250);
     let step = Duration::from_millis(100);
     client_app.insert_resource(TimeUpdateStrategy::ManualDuration(step));
-    client_app
-        .world_mut()
-        .resource_mut::<LinkConditioner>()
-        .latency = latency;
+    client_app.insert_resource(GlobalConditionerConfig(ConditionerConfig {
+        latency: 250,
+        jitter: 0,
+        loss: 0.0,
+        duplication: 0.0,
+    }));
 
     server_app.world_mut().spawn(Replicated);
     server_app.update();


### PR DESCRIPTION
Multiplare that works on localhost can break under real latency or loss: prediction and interpolation hitches, reconciliation glitches, and ordering assumptions that only hold on a clean link. Reproducing that today means testing against a genuinely bad connection or reaching for OS-level tools like Network Link Conditioner or netem, none of which are deterministic or usable from tests

The repo already has a link conditioner, but it lives inside the example backend, so projects on renet, matchbox, or any other backend get nothing from it. This lifts the same idea into the core crate and applies it to the messages Replicon exchanges rather than to a socket, so every backend inherits it. It is opt-in behind a feature and does nothing until configured

Where it helps:
- Playtesting: pick a preset like "poor", or dial in your own latency, jitter, and loss, and feel how the game holds up without leaving the app or touching the OS network stack. Conditions can be global or set per client, so you can make one player laggy while the rest stay smooth
- Tests: over the in-process message exchange the delays and drops are deterministic, so you can assert that replication still converges under bad conditions instead of only on a perfect link
- Backend parity: the same conditions apply whether you run on renet, matchbox, or a test backend, so an issue found in one surfaces in all of them

It is reliability-aware, which is what makes it safe in core: latency and jitter affect every channel, but only unreliable channels drop or duplicate, and ordered channels are never reordered. That keeps the simulation within what Replicon already handles and matches what a real transport exposes, where reliable channels show up as added delay rather than loss

This intentionally leaves the example backend's own conditioner in place to keep the change focused