### PR TITLE
Fix max registered filters check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replicated removals now also remove all required components. This may be unexpected if you set `Replicated` as a required component, because removing it also pauses replication. Use `remove_without_requires` with `AppMarkerExt::set_receive_fns` to restore the old behavior.
 
+### Fixed
+
+- Visibility scope registration now allows up to `u32::BITS` scopes instead of incorrectly panicking after `u8::BITS` scopes.
+
 ## [0.40.3] - 2026-06-02
 
 ### Added

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -34,7 +34,7 @@ pub trait AppVisibilityExt {
     If the [`VisibilityFilter::Scope`] was previously visible, it will be despawned (for entities) or
     removed (for components).
 
-    To keep the representation compact, the total number of registered filters cannot exceed [`u32::MAX`].
+    To keep the representation compact, the total number of registered filters cannot exceed [`u32::BITS`].
     But a filter can itself represent multiple flags using a bitmask. See the example in [`VisibilityFilter`].
 
     See also [`ClientVisibility::set`] for manual visibility control.

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -51,7 +51,7 @@ impl FilterRegistry {
         world: &mut World,
         registry: &mut ReplicationRegistry,
     ) -> FilterBit {
-        if self.scopes.len() >= u8::BITS as usize {
+        if self.scopes.len() >= u32::BITS as usize {
             panic!("number of visibility scopes can't exceed {}", u32::BITS);
         }
 
@@ -113,8 +113,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn max() {
+        let mut world = World::new();
+        let mut registry = ReplicationRegistry::default();
+        let mut filter_registry = FilterRegistry {
+            scopes: vec![VisibilityScope::Entity; 31],
+            ..Default::default()
+        };
+        filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
+    }
+
+    #[test]
+    #[should_panic]
+    fn beyond_max() {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {


### PR DESCRIPTION
I believe there is a typo in `src/server/visibility/registry.rs` limiting the allowed number of registered filters to < 8 instead of < 32.

This PR 
- Updates to check to be against `u32::BITS` instead of `u8::BITS`, matching documentation and intention expressed in tests.
- Updates the `fn max` test to check registering the 31st filter is successful.
- Introduces a new test `fn beyond_max` to check registering the 32nd filter panics. 
- Updates a related doc comment from `u32::MAX` to `u32::BITS`