### PR TITLE
Add the ability to attach custom data to replication messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ReplicationUserdata` and `UserdataReceived` to attach custom data to replication messages.
+
 ### Changed
 
 - Removing `Replicated` from an entity now stops replication without despawning the entity on clients. Client-side despawns of `Remote` entities clean up their `ServerEntityMap` mappings. Despawning an entity still replicates as despawn.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,10 @@ required-features = ["client", "server"]
 name = "stats"
 required-features = ["client_diagnostics", "client", "server"]
 
+[[test]]
+name = "userdata"
+required-features = ["client", "server"]
+
 [lints.clippy]
 type_complexity = "allow"
 too_many_arguments = "allow"

--- a/src/client.rs
+++ b/src/client.rs
@@ -307,6 +307,10 @@ fn apply_update_message(
         };
 
         match flag {
+            UpdateFlags::USERDATA => {
+                apply_userdata(world, message)
+                    .map_err(|e| format!("unable to apply userdata: {e}"))?;
+            }
             UpdateFlags::MAPPINGS => {
                 let len = apply_array(array_kind, message, |message| {
                     apply_entity_mapping(world, params, message)
@@ -397,6 +401,10 @@ fn apply_mutate_message(
 
     for (_, flag) in mutate.flags.iter_names() {
         match flag {
+            MutateFlags::USERDATA => {
+                apply_userdata(world, &mut mutate.message)
+                    .map_err(|e| format!("unable to apply userdata: {e}"))?;
+            }
             MutateFlags::MESSAGES_COUNT => {
                 confirm_mutate_tick(world, params.mutate_ticks, mutate)
                     .map_err(|e| format!("unable to confirm mutate tick: {e}"))?;
@@ -613,6 +621,22 @@ fn apply_changes(
         .entity_buffer
         .spawn(unsafe { client_entity.world_mut() });
     client_entity.flush();
+
+    Ok(())
+}
+
+fn apply_userdata(world: &mut World, message: &mut Bytes) -> Result<()> {
+    let len = postcard_utils::from_buf(message)?;
+    if len > message.len() {
+        return Err(format!(
+            "userdata length ({len}) exceeds remaining message length ({})",
+            message.len()
+        )
+        .into());
+    }
+    world.trigger(UserdataReceived {
+        bytes: message.split_to(len),
+    });
 
     Ok(())
 }
@@ -952,3 +976,12 @@ pub struct ClientReplicationStats {
 #[derive(Component, Default, Reflect, Debug, Clone, Copy)]
 #[reflect(Component)]
 pub struct Remote;
+
+/// Triggered when user-defined bytes are received in a replication message.
+///
+/// This is emitted for data sent through [`ReplicationUserdata`](crate::server::ReplicationUserdata).
+#[derive(Event)]
+pub struct UserdataReceived {
+    /// Raw user-defined bytes received from the server.
+    pub bytes: Bytes,
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -308,7 +308,7 @@ fn apply_update_message(
 
         match flag {
             UpdateFlags::USERDATA => {
-                process_userdata(world, message)
+                process_userdata(world, message, message_tick)
                     .map_err(|e| format!("unable to process userdata: {e}"))?;
             }
             UpdateFlags::MAPPINGS => {
@@ -402,7 +402,7 @@ fn apply_mutate_message(
     for (_, flag) in mutate.flags.iter_names() {
         match flag {
             MutateFlags::USERDATA => {
-                process_userdata(world, &mut mutate.message)
+                process_userdata(world, &mut mutate.message, mutate.message_tick)
                     .map_err(|e| format!("unable to apply userdata: {e}"))?;
             }
             MutateFlags::MESSAGES_COUNT => {
@@ -625,7 +625,11 @@ fn apply_changes(
     Ok(())
 }
 
-fn process_userdata(world: &mut World, message: &mut Bytes) -> Result<()> {
+fn process_userdata(
+    world: &mut World,
+    message: &mut Bytes,
+    message_tick: RepliconTick,
+) -> Result<()> {
     let len = postcard_utils::from_buf(message)?;
     if len > message.len() {
         return Err(format!(
@@ -635,6 +639,7 @@ fn process_userdata(world: &mut World, message: &mut Bytes) -> Result<()> {
         .into());
     }
     world.trigger(UserdataReceived {
+        message_tick,
         bytes: message.split_to(len),
     });
 
@@ -982,6 +987,9 @@ pub struct Remote;
 /// This is emitted for data sent through [`ReplicationUserdata`](crate::server::ReplicationUserdata).
 #[derive(Event)]
 pub struct UserdataReceived {
+    /// Tick of the message with the metadata.
+    pub message_tick: RepliconTick,
+
     /// Raw user-defined bytes received from the server.
     pub bytes: Bytes,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -308,8 +308,8 @@ fn apply_update_message(
 
         match flag {
             UpdateFlags::USERDATA => {
-                apply_userdata(world, message)
-                    .map_err(|e| format!("unable to apply userdata: {e}"))?;
+                process_userdata(world, message)
+                    .map_err(|e| format!("unable to process userdata: {e}"))?;
             }
             UpdateFlags::MAPPINGS => {
                 let len = apply_array(array_kind, message, |message| {
@@ -402,7 +402,7 @@ fn apply_mutate_message(
     for (_, flag) in mutate.flags.iter_names() {
         match flag {
             MutateFlags::USERDATA => {
-                apply_userdata(world, &mut mutate.message)
+                process_userdata(world, &mut mutate.message)
                     .map_err(|e| format!("unable to apply userdata: {e}"))?;
             }
             MutateFlags::MESSAGES_COUNT => {
@@ -625,7 +625,7 @@ fn apply_changes(
     Ok(())
 }
 
-fn apply_userdata(world: &mut World, message: &mut Bytes) -> Result<()> {
+fn process_userdata(world: &mut World, message: &mut Bytes) -> Result<()> {
     let len = postcard_utils::from_buf(message)?;
     if len > message.len() {
         return Err(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,6 +641,11 @@ It's also possible to override despawns received from the server via
 [`ReplicationRegistry::despawn`](shared::replication::registry::ReplicationRegistry::despawn), which is also often used together
 with receive markers.
 
+### Replication userdata
+
+It's possible to attach arbitrary bytes to replication messages by writing to the [`ReplicationUserdata`](server::ReplicationUserdata)
+resource. When the client receives a replication message containing userdata, [`UserdataReceived`](client::UserdataReceived) is triggered.
+
 ### Ticks information
 
 This requires an understanding of how replication works. See the documentation on

--- a/src/server.rs
+++ b/src/server.rs
@@ -135,6 +135,7 @@ impl Plugin for ServerPlugin {
             .init_resource::<ServerTick>()
             .init_resource::<ServerChangeTick>()
             .init_resource::<ReplicatedArchetypes>()
+            .init_resource::<ReplicationUserdata>()
             .init_resource::<MessageBuffer>()
             .init_resource::<RelatedEntities>()
             .init_resource::<FilterRegistry>()
@@ -858,6 +859,7 @@ fn send_messages(
     server_tick: Res<ServerTick>,
     change_tick: Res<ServerChangeTick>,
     track_mutate_messages: Res<TrackMutateMessages>,
+    userdata: Res<ReplicationUserdata>,
     mut serialized: ResMut<SerializedData>,
     mut messages: ResMut<ServerMessages>,
     mut clients: Query<(
@@ -875,7 +877,13 @@ fn send_messages(
             let server_tick_range =
                 serialized.write_cached_tick(&mut server_tick_range, **server_tick)?;
 
-            updates.send(&mut messages, client, &serialized, server_tick_range)?;
+            updates.send(
+                &mut messages,
+                client,
+                &serialized,
+                &userdata,
+                server_tick_range,
+            )?;
         }
 
         if !mutations.is_empty() || **track_mutate_messages {
@@ -889,6 +897,7 @@ fn send_messages(
                 &mut split_buffer,
                 &serialized,
                 **track_mutate_messages,
+                &userdata,
                 server_tick_range,
                 **server_tick,
                 **change_tick,
@@ -1023,3 +1032,16 @@ struct TicksTracked;
 /// Value of the [`ServerPlugin::track_mutate_messages`].
 #[derive(Resource, Deref, Default, Debug, Clone, Copy)]
 struct TrackMutateMessages(bool);
+
+/// User-defined bytes appended to outgoing replication messages.
+///
+/// When this resource is non-empty, its contents are sent with every replication
+/// update and mutate message. On the client, the bytes are triggered as a
+/// [`UserdataReceived`](crate::client::UserdataReceived) before the rest of
+/// the message is applied.
+///
+/// This could be useful to store the game tick for prediction/interpolaton.
+///
+/// The bytes are not cleared after being sent.
+#[derive(Resource, Deref, DerefMut, Default)]
+pub struct ReplicationUserdata(pub Vec<u8>);

--- a/src/server/replication_messages/mutations.rs
+++ b/src/server/replication_messages/mutations.rs
@@ -8,6 +8,7 @@ use super::{entity_ranges::EntityRanges, serialized_data::SerializedData};
 use crate::{
     postcard_utils,
     prelude::*,
+    server::ReplicationUserdata,
     shared::{
         backend::channels::ServerChannel,
         replication::{
@@ -147,6 +148,7 @@ impl Mutations {
         split_buffer: &mut Vec<MutationsSplit>,
         serialized: &SerializedData,
         track_mutate_messages: bool,
+        userdata: &ReplicationUserdata,
         server_tick_range: Range<usize>,
         server_tick: RepliconTick,
         system_tick: Tick,
@@ -158,6 +160,9 @@ impl Mutations {
         let update_tick = postcard::to_slice(&ticks.update_tick, &mut tick_buffer)?;
         let mut base_header_size =
             size_of::<MutateFlags>() + update_tick.len() + server_tick_range.len();
+        if !userdata.is_empty() {
+            base_header_size += serialized_size(&userdata.len())? + userdata.len();
+        }
         if track_mutate_messages {
             // We don't know the number of messages ahead of time, so we assume the maximum
             // possible size during the splits calculation to avoid exceeding MTU.
@@ -237,6 +242,9 @@ impl Mutations {
         if track_mutate_messages {
             base_flags |= MutateFlags::MESSAGES_COUNT;
         }
+        if !userdata.is_empty() {
+            base_flags |= MutateFlags::USERDATA;
+        }
 
         for split in &*split_buffer {
             let mut message_size = split.message_size;
@@ -256,6 +264,10 @@ impl Mutations {
             postcard_utils::to_extend_mut(&split.mutate_index, &mut message)?;
             message.extend_from_slice(update_tick);
             message.extend_from_slice(&serialized[server_tick_range.clone()]);
+            if !userdata.is_empty() {
+                postcard_utils::to_extend_mut(&userdata.len(), &mut message)?;
+                message.extend_from_slice(userdata);
+            }
             if track_mutate_messages {
                 postcard_utils::to_extend_mut(&split_buffer.len(), &mut message)?;
             }
@@ -487,6 +499,7 @@ mod tests {
                 &mut Default::default(),
                 &serialized,
                 track_mutate_messages,
+                &Default::default(),
                 Default::default(),
                 Default::default(),
                 Default::default(),

--- a/src/server/replication_messages/updates.rs
+++ b/src/server/replication_messages/updates.rs
@@ -7,6 +7,7 @@ use super::{entity_ranges::EntityRanges, mutations::Mutations, serialized_data::
 use crate::{
     postcard_utils,
     prelude::*,
+    server::ReplicationUserdata,
     shared::{
         backend::channels::ServerChannel,
         replication::{
@@ -226,15 +227,19 @@ impl Updates {
         messages: &mut ServerMessages,
         client: Entity,
         serialized: &SerializedData,
+        userdata: &ReplicationUserdata,
         server_tick_range: Range<usize>,
     ) -> Result<()> {
-        let flags = self.flags();
+        let flags = self.flags(userdata);
         let last_flag = flags.last();
 
         // Precalculate size first to avoid extra allocations.
         let mut message_size = size_of::<UpdateFlags>() + server_tick_range.len();
         for (_, flag) in flags.iter_names() {
             match flag {
+                UpdateFlags::USERDATA => {
+                    message_size += serialized_size(&userdata.len())? + userdata.len();
+                }
                 UpdateFlags::MAPPINGS => {
                     if flag != last_flag {
                         message_size += serialized_size(&self.mappings_len)?;
@@ -274,6 +279,10 @@ impl Updates {
         message.extend_from_slice(&serialized[server_tick_range]);
         for (_, flag) in flags.iter_names() {
             match flag {
+                UpdateFlags::USERDATA => {
+                    postcard_utils::to_extend_mut(&userdata.len(), &mut message)?;
+                    message.extend_from_slice(userdata);
+                }
                 UpdateFlags::MAPPINGS => {
                     if flag != last_flag {
                         postcard_utils::to_extend_mut(&self.mappings_len, &mut message)?;
@@ -323,7 +332,7 @@ impl Updates {
         Ok(())
     }
 
-    fn flags(&self) -> UpdateFlags {
+    fn flags(&self, userdata: &ReplicationUserdata) -> UpdateFlags {
         let mut flags = UpdateFlags::default();
 
         if !self.mappings.is_empty() {
@@ -337,6 +346,9 @@ impl Updates {
         }
         if !self.changes.is_empty() {
             flags |= UpdateFlags::CHANGES;
+        }
+        if !userdata.is_empty() {
+            flags |= UpdateFlags::USERDATA;
         }
 
         flags

--- a/src/shared/replication/message_flags.rs
+++ b/src/shared/replication/message_flags.rs
@@ -7,10 +7,11 @@ bitflags! {
     /// Serialized at the beginning of the message.
     #[derive(Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
     pub(crate) struct UpdateFlags: u8 {
-        const MAPPINGS = 0b00000001;
-        const DESPAWNS = 0b00000010;
-        const REMOVALS = 0b00000100;
-        const CHANGES = 0b00001000;
+        const USERDATA = 0b00000001;
+        const MAPPINGS = 0b00000010;
+        const DESPAWNS = 0b00000100;
+        const REMOVALS = 0b00001000;
+        const CHANGES = 0b00010000;
     }
 }
 
@@ -30,8 +31,9 @@ bitflags! {
     /// Like [`UpdateFlags`], but for mutate messages.
     #[derive(Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
     pub(crate) struct MutateFlags: u8 {
-        const MESSAGES_COUNT = 0b00000001;
-        const MUTATIONS = 0b00000010;
+        const USERDATA = 0b00000001;
+        const MESSAGES_COUNT = 0b00000010;
+        const MUTATIONS = 0b00000100;
     }
 }
 

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -1,0 +1,106 @@
+use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy_replicon::{
+    client::UserdataReceived, prelude::*, server::ReplicationUserdata,
+    shared::backend::channels::ServerChannel, test_app::ServerTestAppExt,
+};
+use serde::{Deserialize, Serialize};
+use test_log::test;
+
+#[test]
+fn update_message() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .init_resource::<ReceivedUserdata>()
+        .add_observer(receive_userdata)
+        .replicate::<TestComponent>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let mut userdata = server_app.world_mut().resource_mut::<ReplicationUserdata>();
+    userdata.extend_from_slice(&USERDATA.to_le_bytes());
+
+    server_app.world_mut().spawn((Replicated, TestComponent));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let messages = client_app.world().resource::<ClientMessages>();
+    assert_eq!(messages.received_count(ServerChannel::Updates), 1);
+    assert_eq!(messages.received_count(ServerChannel::Mutations), 0);
+
+    client_app.update();
+
+    let received = client_app.world().resource::<ReceivedUserdata>();
+    assert_eq!(received.0, USERDATA);
+}
+
+#[test]
+fn mutate_message() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .init_resource::<ReceivedUserdata>()
+        .add_observer(receive_userdata)
+        .replicate::<TestComponent>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, TestComponent))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut component = server_app
+        .world_mut()
+        .get_mut::<TestComponent>(server_entity)
+        .unwrap();
+    component.set_changed();
+
+    let mut userdata = server_app.world_mut().resource_mut::<ReplicationUserdata>();
+    userdata.extend_from_slice(&USERDATA.to_le_bytes());
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let messages = client_app.world().resource::<ClientMessages>();
+    assert_eq!(messages.received_count(ServerChannel::Updates), 0);
+    assert_eq!(messages.received_count(ServerChannel::Mutations), 1);
+
+    client_app.update();
+
+    let received = client_app.world().resource::<ReceivedUserdata>();
+    assert_eq!(received.0, USERDATA);
+}
+
+const USERDATA: u32 = 42;
+
+#[derive(Component, Deserialize, Serialize)]
+struct TestComponent;
+
+#[derive(Resource, Default)]
+struct ReceivedUserdata(u32);
+
+fn receive_userdata(received: On<UserdataReceived>, mut storage: ResMut<ReceivedUserdata>) {
+    let bytes = received.bytes.as_ref().try_into().unwrap();
+    storage.0 = u32::from_le_bytes(bytes);
+}


### PR DESCRIPTION
Closes #707 and #712.

Adds `ReplicationUserdata` resource with bytes. When not empty, its bytes will be attached to every message. On the client `UserdataReceived` is triggered when the userdata is received before processing any data from the message. You can store your game tick inside it and on deserialization parse it and store in a resource.

@cBournhonesque could you try this? Note that the latest master also includes a tiny breaking change (85d0535a911492719e5bc5a6b6ac95e125cded07).
@PROMETHIA-27 you might be interested too since this should let you save some traffic.