### PR TITLE
Remove `Ord` and `PartialOrd` impl from `RepliconTick`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removing `Replicated` from an entity now stops replication without despawning the entity on clients. Client-side despawns of `Remote` entities clean up their `ServerEntityMap` mappings. Despawning an entity still replicates as despawn.
+- `RepliconTick` no longer implements `Ord` or `PartialOrd`, because these traits require transitivity. Use the `wrapping_cmp` method instead, or helpers like `is_newer` and `is_older`.
 - Replace `TrackAppExt::track_mutate_messages` function with `ServerPlugin::track_mutate_messages` field. This setting no longer affects the protocol hash and can be set only on the server.
 - `ServerMutateTicks` now always present with `ClientPlugin`.
 - Rename `DiffIndex::is_newer_than` to `DiffIndex::is_newer`.

--- a/src/client.rs
+++ b/src/client.rs
@@ -261,7 +261,7 @@ fn apply_replication(
     }
 
     buffered_mutations.0.retain_mut(|mutate| {
-        if mutate.update_tick > *update_tick {
+        if mutate.update_tick.is_newer(*update_tick) {
             return true;
         }
 
@@ -763,7 +763,7 @@ fn apply_mutations(
         .into());
     };
 
-    let new_tick = message_tick > history.last_tick();
+    let new_tick = message_tick.is_newer(history.last_tick());
     if new_tick {
         history.set_last_tick(message_tick);
     } else {
@@ -915,7 +915,7 @@ impl BufferedMutations {
     fn insert(&mut self, mutate: BufferedMutate) {
         let index = self
             .0
-            .partition_point(|other| mutate.message_tick < other.message_tick);
+            .partition_point(|other| mutate.message_tick.is_older(other.message_tick));
         self.0.insert(index, mutate);
     }
 }

--- a/src/client/confirm_history.rs
+++ b/src/client/confirm_history.rs
@@ -53,7 +53,7 @@ impl ConfirmHistory {
     ///
     /// All ticks older then 64 ticks since [`Self::last_tick`] are considered received.
     pub fn contains(&self, tick: RepliconTick) -> bool {
-        if tick > self.last_tick {
+        if tick.is_newer(self.last_tick) {
             return false;
         }
 
@@ -71,16 +71,16 @@ impl ConfirmHistory {
     /// Panics if `debug_assertions` are enabled and
     /// `start_tick` is greater then `end_tick`.
     pub fn contains_any(&self, start_tick: RepliconTick, end_tick: RepliconTick) -> bool {
-        debug_assert!(start_tick <= end_tick);
+        debug_assert!(start_tick.is_older_or_eq(end_tick));
 
-        if start_tick > self.last_tick {
+        if start_tick.is_newer(self.last_tick) {
             return false;
         }
-        if start_tick <= self.last_tick - u64::BITS {
+        if start_tick.is_older_or_eq(self.last_tick - u64::BITS) {
             return true;
         }
 
-        let end_tick = if end_tick < self.last_tick {
+        let end_tick = if end_tick.is_older(self.last_tick) {
             end_tick
         } else {
             self.last_tick
@@ -98,7 +98,7 @@ impl ConfirmHistory {
     ///
     /// Useful for unit tests.
     pub fn confirm(&mut self, tick: RepliconTick) {
-        if tick > self.last_tick {
+        if tick.is_newer(self.last_tick) {
             self.set_last_tick(tick);
         } else {
             let ago = self.last_tick - tick;
@@ -126,7 +126,7 @@ impl ConfirmHistory {
     /// Panics if `debug_assertions` are enabled and
     /// `tick` is less then the last tick.
     pub(super) fn set_last_tick(&mut self, tick: RepliconTick) {
-        debug_assert!(tick >= self.last_tick);
+        debug_assert!(tick.is_newer_or_eq(self.last_tick));
         let diff = tick - self.last_tick;
         self.mask = self.mask.wrapping_shl(diff);
         self.last_tick = tick;

--- a/src/client/server_mutate_ticks.rs
+++ b/src/client/server_mutate_ticks.rs
@@ -55,7 +55,7 @@ impl ServerMutateTicks {
     ///
     /// All ticks older than 64 ticks relative to [`Self::last_tick`] are considered received.
     pub fn contains(&self, tick: RepliconTick) -> bool {
-        if tick > self.last_tick {
+        if tick.is_newer(self.last_tick) {
             return false;
         }
 
@@ -75,16 +75,16 @@ impl ServerMutateTicks {
     ///
     /// Panics if `debug_assertions` are enabled and `start_tick` is greater than `end_tick`.
     pub fn contains_any(&self, start_tick: RepliconTick, end_tick: RepliconTick) -> bool {
-        debug_assert!(start_tick <= end_tick);
+        debug_assert!(start_tick.is_older_or_eq(end_tick));
 
-        if start_tick > self.last_tick {
+        if start_tick.is_newer(self.last_tick) {
             return false;
         }
-        if start_tick <= self.last_tick - self.ticks.len() as u32 {
+        if start_tick.is_older_or_eq(self.last_tick - self.ticks.len() as u32) {
             return true;
         }
 
-        let end_tick = if end_tick < self.last_tick {
+        let end_tick = if end_tick.is_older(self.last_tick) {
             end_tick
         } else {
             self.last_tick
@@ -112,7 +112,7 @@ impl ServerMutateTicks {
         let len = self.ticks.len();
         debug_assert_eq!(len, u64::BITS as usize);
 
-        if tick > self.last_tick {
+        if tick.is_newer(self.last_tick) {
             let delta = (tick - self.last_tick) as usize;
             trace!("confirming `{tick:?}` which is {delta} ticks since last");
             if delta >= len {

--- a/src/shared/message/server_message.rs
+++ b/src/shared/message/server_message.rs
@@ -498,7 +498,7 @@ impl ServerMessage {
 
         for mut message in client_messages.receive(self.channel_id) {
             if !self.independent {
-                let tick = match postcard_utils::from_buf(&mut message) {
+                let tick: RepliconTick = match postcard_utils::from_buf(&mut message) {
                     Ok(tick) => tick,
                     Err(e) => {
                         error!(
@@ -508,7 +508,7 @@ impl ServerMessage {
                         continue;
                     }
                 };
-                if tick > update_tick {
+                if tick.is_newer(update_tick) {
                     debug!("queuing message `{}` with `{tick:?}`", ShortName::of::<M>());
                     queue.insert(tick, message);
                     continue;

--- a/src/shared/message/server_message/message_queue.rs
+++ b/src/shared/message/server_message/message_queue.rs
@@ -1,9 +1,9 @@
-use alloc::collections::BTreeMap;
 use core::marker::PhantomData;
 
+use alloc::collections::VecDeque;
 use bevy::prelude::*;
 use bytes::Bytes;
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 
 use crate::prelude::*;
 
@@ -13,13 +13,20 @@ use crate::prelude::*;
 /// Needed to ensure that when an message is triggered, all the data that it affects or references already exists.
 #[derive(Resource)]
 pub(super) struct MessageQueue<M> {
-    map: BTreeMap<RepliconTick, SmallVec<[Bytes; 4]>>,
+    entries: VecDeque<(RepliconTick, SmallVec<[Bytes; 4]>)>,
     marker: PhantomData<M>,
 }
 
 impl<M> MessageQueue<M> {
     pub(super) fn insert(&mut self, tick: RepliconTick, message: Bytes) {
-        self.map.entry(tick).or_default().push(message);
+        let index = self.entries.partition_point(|&(t, _)| tick.is_newer(t));
+        if let Some((entry_tick, messages)) = self.entries.get_mut(index)
+            && *entry_tick == tick
+        {
+            messages.push(message);
+        } else {
+            self.entries.insert(index, (tick, smallvec![message]));
+        }
     }
 
     /// Pops the next message that is at least as old as the specified replicon tick.
@@ -27,31 +34,31 @@ impl<M> MessageQueue<M> {
         &mut self,
         update_tick: RepliconTick,
     ) -> Option<(RepliconTick, SmallVec<[Bytes; 4]>)> {
-        let entry = self.map.first_entry()?;
-        if *entry.key() > update_tick {
+        let (tick, _) = self.entries.front()?;
+        if tick.is_newer(update_tick) {
             return None;
         }
 
-        Some(entry.remove_entry())
+        self.entries.pop_front()
     }
 
     pub(super) fn len(&self) -> usize {
-        self.map.len()
+        self.entries.len()
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.entries.is_empty()
     }
 
     pub(super) fn clear(&mut self) {
-        self.map.clear();
+        self.entries.clear();
     }
 }
 
 impl<M> Default for MessageQueue<M> {
     fn default() -> Self {
         Self {
-            map: Default::default(),
+            entries: Default::default(),
             marker: PhantomData,
         }
     }

--- a/src/shared/replication/client_ticks.rs
+++ b/src/shared/replication/client_ticks.rs
@@ -77,7 +77,7 @@ impl ClientTicks {
 
             // Received tick could be outdated because we bump it
             // if we detect any insertion on the entity in `collect_changes`.
-            if entity_ticks.server_tick < mutate_info.server_tick {
+            if entity_ticks.server_tick.is_older(mutate_info.server_tick) {
                 entity_ticks.server_tick = mutate_info.server_tick;
                 entity_ticks.system_tick = mutate_info.system_tick;
                 entity_ticks.components |= &info.components;

--- a/src/shared/replicon_tick.rs
+++ b/src/shared/replicon_tick.rs
@@ -19,6 +19,9 @@ use serde::{Deserialize, Serialize};
 pub struct RepliconTick(u32);
 
 impl RepliconTick {
+    /// The maximum wrapping distance at which a tick is considered newer.
+    pub const MAX_NEWER_DISTANCE: u32 = u32::MAX / 2;
+
     /// Creates a new instance wrapping the given value.
     #[inline]
     pub fn new(value: u32) -> Self {
@@ -30,24 +33,42 @@ impl RepliconTick {
     pub fn get(self) -> u32 {
         self.0
     }
-}
 
-impl PartialOrd for RepliconTick {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for RepliconTick {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let difference = self.0.wrapping_sub(other.0);
-        if difference == 0 {
+    /// Compares ticks using wrapping semantics.
+    ///
+    /// This comparison is only meaningful when the ticks are at most
+    /// [`Self::MAX_NEWER_DISTANCE`] apart.
+    ///
+    /// We don't implement [`Ord`] because wrapping ordering is not transitive.
+    pub fn wrapping_cmp(self, other: Self) -> Ordering {
+        let distance = self.0.wrapping_sub(other.0);
+        if distance == 0 {
             Ordering::Equal
-        } else if difference > u32::MAX / 2 {
-            Ordering::Less
-        } else {
+        } else if distance <= Self::MAX_NEWER_DISTANCE {
             Ordering::Greater
+        } else {
+            Ordering::Less
         }
+    }
+
+    /// Tests if `self` is greater or equal than `other` using [`Self::wrapping_cmp`].
+    pub fn is_newer_or_eq(self, other: Self) -> bool {
+        self.wrapping_cmp(other).is_ge()
+    }
+
+    /// Tests if `self` is greater than `other` using [`Self::wrapping_cmp`].
+    pub fn is_newer(self, other: Self) -> bool {
+        self.wrapping_cmp(other).is_gt()
+    }
+
+    /// Tests if `self` is less than `other` using [`Self::wrapping_cmp`].
+    pub fn is_older(self, other: Self) -> bool {
+        self.wrapping_cmp(other).is_lt()
+    }
+
+    /// Tests if `self` is less or equal than `other` using [`Self::wrapping_cmp`].
+    pub fn is_older_or_eq(self, other: Self) -> bool {
+        self.wrapping_cmp(other).is_le()
     }
 }
 
@@ -94,7 +115,11 @@ mod tests {
     #[test]
     fn tick_comparison() {
         assert_eq!(RepliconTick::new(0), RepliconTick::new(0));
-        assert!(RepliconTick::new(0) < RepliconTick::new(1));
-        assert!(RepliconTick::new(0) > RepliconTick::new(u32::MAX));
+        assert!(RepliconTick::new(0).is_newer_or_eq(RepliconTick::new(0)));
+        assert!(RepliconTick::new(0).is_older_or_eq(RepliconTick::new(0)));
+        assert!(RepliconTick::new(1).is_newer(RepliconTick::new(0)));
+        assert!(RepliconTick::new(1).is_newer_or_eq(RepliconTick::new(0)));
+        assert!(RepliconTick::new(u32::MAX).is_older(RepliconTick::new(0)));
+        assert!(RepliconTick::new(u32::MAX).is_older_or_eq(RepliconTick::new(0)));
     }
 }


### PR DESCRIPTION
These traits require transitivity and our wrapping comparision breaks this rule.
Comparision now done via methods on the tick. I also had to replace `BTreeMap`
in `MessageQueue` with a `VecDeque`, but it's probably even better since we don't have a lot of pending events.