### PR TITLE
Refactor remove observers to check for despawns

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -478,7 +478,7 @@ fn collect_despawns(
 ) -> Result<()> {
     for entity in despawn_buffer.drain(..) {
         let entity_range = serialized.write_entity(entity)?;
-        for (client, mut message, mut ticks, mut priority, _visibility) in &mut clients {
+        for (client, mut message, mut ticks, mut priority, _) in &mut clients {
             if ticks.entities.remove(&entity).is_some() {
                 // Write despawn only if the entity was previously sent because
                 // spawn and despawn could happen during the same tick.

--- a/src/server.rs
+++ b/src/server.rs
@@ -477,19 +477,18 @@ fn collect_despawns(
         &mut Updates,
         &mut ClientTicks,
         &mut PriorityMap,
-        &mut ClientVisibility,
+        &ClientVisibility,
     )>,
 ) -> Result<()> {
     for entity in despawn_buffer.drain(..) {
         let entity_range = serialized.write_entity(entity)?;
-        for (client, mut message, mut ticks, mut priority, mut visibility) in &mut clients {
+        for (client, mut message, mut ticks, mut priority, _visibility) in &mut clients {
             if ticks.entities.remove(&entity).is_some() {
                 // Write despawn only if the entity was previously sent because
                 // spawn and despawn could happen during the same tick.
                 trace!("writing despawn for `{entity}` for client `{client}`");
                 message.add_despawn(entity_range.clone());
             }
-            visibility.remove_despawned(entity);
             priority.remove(&entity);
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -408,7 +408,6 @@ fn prepare_messages(
 
 /// Collects and writes any new entity mappings that happened in this tick.
 fn collect_mappings(
-    despawn_buffer: Res<DespawnBuffer>,
     registry: Res<FilterRegistry>,
     mut serialized: ResMut<SerializedData>,
     entities: Query<(Entity, &Signature), With<Replicated>>,
@@ -427,7 +426,7 @@ fn collect_mappings(
             let Ok((_, mut message, ticks, visibility)) = clients.get_mut(client) else {
                 continue;
             };
-            if should_send_mapping(entity, &despawn_buffer, &registry, &visibility, &ticks) {
+            if should_send_mapping(entity, &registry, &visibility, &ticks) {
                 trace!(
                     "writing mapping `{entity}` to 0x{hash:016x} dedicated for client `{client}`"
                 );
@@ -437,7 +436,7 @@ fn collect_mappings(
             }
         } else {
             for (client, mut message, ticks, visibility) in &mut clients {
-                if should_send_mapping(entity, &despawn_buffer, &registry, &visibility, &ticks) {
+                if should_send_mapping(entity, &registry, &visibility, &ticks) {
                     trace!("writing mapping `{entity}` to 0x{hash:016x} for client `{client}`");
                     let mapping_range =
                         serialized.write_cached_mapping(&mut mapping_range, entity, hash)?;
@@ -452,14 +451,11 @@ fn collect_mappings(
 
 fn should_send_mapping(
     entity: Entity,
-    despawn_buffer: &DespawnBuffer,
     registry: &FilterRegistry,
     visibility: &ClientVisibility,
     ticks: &ClientTicks,
 ) -> bool {
-    // Since despawns processed later, we need to explicitly check for them here
-    // because we can't distinguish between a despawn and removal of a visibility filter.
-    if visibility.get(entity).is_hidden(registry) || despawn_buffer.contains(&entity) {
+    if visibility.get(entity).is_hidden(registry) {
         return false;
     }
 

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -183,6 +183,13 @@ fn on_remove<F: VisibilityFilter>(
         return;
     }
 
+    if remove.trigger().new_archetype.is_none() {
+        for mut visibility in &mut clients {
+            visibility.remove_despawned(remove.entity);
+        }
+        return;
+    }
+
     let bit = registry.bit::<F>();
     debug!(
         "removing `{}` filter from entity `{}`",
@@ -203,6 +210,13 @@ fn on_client_remove<F: VisibilityFilter>(
     let Ok(mut visibility) = clients.get_mut(remove.entity) else {
         return;
     };
+
+    if remove.trigger().new_archetype.is_none() {
+        for (entity, _component) in &entities {
+            visibility.remove_despawned(entity);
+        }
+        return;
+    }
 
     let bit = registry.bit::<F>();
     for (entity, component) in &entities {

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -212,7 +212,7 @@ fn on_client_remove<F: VisibilityFilter>(
     };
 
     if remove.trigger().new_archetype.is_none() {
-        for (entity, _component) in &entities {
+        for (entity, _) in &entities {
             visibility.remove_despawned(entity);
         }
         return;

--- a/src/server/visibility/client_visibility.rs
+++ b/src/server/visibility/client_visibility.rs
@@ -35,11 +35,6 @@ impl ClientVisibility {
     }
 
     /// Removes a despawned entity tracked by this client.
-    ///
-    /// Since observers can't be ordered, we can't distinguish between
-    /// a despawn and removal of a visibility filter. As a workaround, we record
-    /// all changes and remove all despawned entities when processing despawns
-    /// during replication.
     pub(crate) fn remove_despawned(&mut self, entity: Entity) {
         self.hidden.remove(&entity);
         self.lost.remove(&entity);


### PR DESCRIPTION
Noticed the following comment while reading through the code:

```
/// Since observers can't be ordered, we can't distinguish between
/// a despawn and removal of a visibility filter. As a workaround, we record
/// all changes and remove all despawned entities when processing despawns
/// during replication.
```

There's now a way (since Bevy 0.19) to determine if an entity is despawned in an `On<Remove, T>` observer by checking `new_archetype` of the trigger context. So I figured this can be refactored a bit to get rid of some redundant inserts+removals. I can't confidently verify that I haven't broken anything but the tests seem to pass at least 😄 