### PR TITLE
Visibility lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `VisibilityFilter::LIFETIME` to control when a visibility scope is present on a client. You can now avoid removing scopes when visibility is lost or replicate their initial state even when they are not visible.
 - `ReplicationUserdata` and `UserdataReceived` to attach custom data to replication messages.
 - `DiffIndex::wrapping_cmp` to compare indices.
 - `ClientMessages::drain_received` and `ServerMessages::drain_received` to drain inbound messages on a channel.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,8 +772,8 @@ pub mod prelude {
                 signature::Signature,
                 storage::{EntityStorageCtx, ReplicationStorage},
                 visibility::{
-                    AllExcept, ComponentScope, ComponentsScope, FilterScope, SingleComponent,
-                    VisibilityFilter,
+                    AllExcept, ComponentScope, ComponentsScope, FilterScope, ScopeLifetime,
+                    SingleComponent, VisibilityFilter,
                 },
             },
             replicon_tick::RepliconTick,

--- a/src/server.rs
+++ b/src/server.rs
@@ -717,16 +717,16 @@ fn collect_changes(
                 for (client, mut updates, mut mutations, client_ticks, priority_map, visibility) in
                     &mut clients
                 {
-                    let scope_lifetime = visibility
+                    let hidden_lifetime = visibility
                         .get(entity.id())
                         .hidden_component_lifetime(&filter_registry, component_index);
-                    if scope_lifetime == Some(ScopeLifetime::WhileVisible) {
+                    if hidden_lifetime == Some(ScopeLifetime::WhileVisible) {
                         continue;
                     }
 
                     if let Some(entity_ticks) = client_ticks.entities.get(&entity.id())
                         && entity_ticks.components.contains(component_index)
-                        && scope_lifetime.is_none()
+                        && hidden_lifetime.is_none()
                     {
                         let base_priority = priority_map
                             .get(&entity.id())
@@ -770,7 +770,7 @@ fn collect_changes(
                             };
                             mutations.add_component(component_range);
                         }
-                    } else if scope_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent) {
+                    } else if hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent) {
                         trace!(
                             "writing `{:?}` insertion for `{}` for client `{client}`",
                             rule.fns_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -801,7 +801,7 @@ fn collect_changes(
 
                 let entity_ticks = ticks.entities.entry(entity.id());
                 let new_for_client = matches!(entity_ticks, Entry::Vacant(_));
-                let has_insertions = updates.changed_entity_added() && hidden_lifetime.is_none();
+                let has_insertions = updates.changed_entity_added();
                 let has_removals = removal_buffer.contains_key(&entity.id());
                 let starts_replication = new_for_client
                     && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent);
@@ -825,7 +825,7 @@ fn collect_changes(
                     );
                 }
 
-                if starts_replication && !updates.changed_entity_added() {
+                if starts_replication && !has_insertions {
                     trace!("writing empty `{}` for client `{client}`", entity.id());
 
                     // Force-write new entity even if it doesn't have any components.

--- a/src/server.rs
+++ b/src/server.rs
@@ -717,15 +717,16 @@ fn collect_changes(
                 for (client, mut updates, mut mutations, client_ticks, priority_map, visibility) in
                     &mut clients
                 {
-                    if visibility
+                    let visibility_lifetime = visibility
                         .get(entity.id())
-                        .is_component_hidden(&filter_registry, component_index)
-                    {
+                        .get_hidden_component_lowest_lifetime(&filter_registry, component_index);
+                    if visibility_lifetime == Some(VisibilityLifetime::WhenVisible) {
                         continue;
                     }
 
                     if let Some(entity_ticks) = client_ticks.entities.get(&entity.id())
                         && entity_ticks.components.contains(component_index)
+                        && visibility_lifetime.is_none()
                     {
                         let base_priority = priority_map
                             .get(&entity.id())
@@ -769,7 +770,7 @@ fn collect_changes(
                             };
                             mutations.add_component(component_range);
                         }
-                    } else {
+                    } else if visibility_lifetime.is_none_or(|l| l == VisibilityLifetime::Always) {
                         trace!(
                             "writing `{:?}` insertion for `{}` for client `{client}`",
                             rule.fns_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -458,7 +458,7 @@ fn should_send_mapping(
 ) -> bool {
     if visibility
         .get(entity)
-        .is_hidden(registry, ScopeLifetime::AfterFirstVisibility)
+        .hides_entity(registry, ScopeLifetime::AfterFirstVisibility)
     {
         return false;
     }
@@ -496,7 +496,7 @@ fn collect_despawns(
     for (client, mut message, mut ticks, mut priority, visibility) in clients {
         for (entity, filter_mask) in visibility.iter_lost() {
             // Skip visibility changes that hide only components.
-            if !filter_mask.is_hidden(&registry, ScopeLifetime::WhileVisible) {
+            if !filter_mask.hides_entity(&registry, ScopeLifetime::WhileVisible) {
                 continue;
             }
 
@@ -567,7 +567,7 @@ fn collect_removals(
 
     for (client, mut message, mut ticks, mut visibility) in &mut clients {
         for (entity, filter_mask) in visibility.drain_lost() {
-            if filter_mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible) {
+            if filter_mask.hides_entity(&filter_registry, ScopeLifetime::WhileVisible) {
                 // Was processed earlier during collecting despawns.
                 continue;
             }
@@ -719,7 +719,7 @@ fn collect_changes(
                 {
                     let scope_lifetime = visibility
                         .get(entity.id())
-                        .get_hidden_component_lowest_lifetime(&filter_registry, component_index);
+                        .hidden_component_lifetime(&filter_registry, component_index);
                     if scope_lifetime == Some(ScopeLifetime::WhileVisible) {
                         continue;
                     }
@@ -795,7 +795,7 @@ fn collect_changes(
             for (client, mut updates, mut mutations, mut ticks, _, visibility) in &mut clients {
                 let hidden_lifetime = visibility
                     .get(entity.id())
-                    .get_hidden_lowest_lifetime(&filter_registry);
+                    .hidden_entity_lifetime(&filter_registry);
                 if hidden_lifetime == Some(ScopeLifetime::WhileVisible) {
                     continue;
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,6 @@ use bevy::{
 use bytes::Buf;
 use log::{Level, debug, log_enabled, trace, warn};
 
-use crate::shared::replication::visibility::ScopeLifetime;
 use crate::{
     postcard_utils,
     prelude::*,

--- a/src/server.rs
+++ b/src/server.rs
@@ -726,7 +726,6 @@ fn collect_changes(
 
                     if let Some(entity_ticks) = client_ticks.entities.get(&entity.id())
                         && entity_ticks.components.contains(component_index)
-                        && hidden_lifetime.is_none()
                     {
                         let base_priority = priority_map
                             .get(&entity.id())
@@ -735,7 +734,8 @@ fn collect_changes(
                             .unwrap_or(1.0);
 
                         let tick_diff = **server_tick - entity_ticks.server_tick;
-                        if rule.mode != ReplicationMode::Once
+                        if hidden_lifetime.is_none()
+                            && rule.mode != ReplicationMode::Once
                             && base_priority * tick_diff as f32 >= 1.0
                             && ticks.is_changed(entity_ticks.system_tick, **change_tick)
                         {

--- a/src/server.rs
+++ b/src/server.rs
@@ -723,7 +723,10 @@ fn collect_changes(
                         continue;
                     }
 
-                    if let Some(entity_ticks) = client_ticks.entities.get(&entity.id())
+                    let entity_ticks = client_ticks.entities.get(&entity.id());
+                    let new_for_client = entity_ticks.is_none();
+
+                    if let Some(entity_ticks) = entity_ticks
                         && entity_ticks.components.contains(component_index)
                     {
                         let base_priority = priority_map
@@ -769,7 +772,9 @@ fn collect_changes(
                             };
                             mutations.add_component(component_range);
                         }
-                    } else if hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent) {
+                    } else if hidden_lifetime
+                        .is_none_or(|l| l == ScopeLifetime::AlwaysPresent && new_for_client)
+                    {
                         trace!(
                             "writing `{:?}` insertion for `{}` for client `{client}`",
                             rule.fns_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,7 @@ use bevy::{
 use bytes::Buf;
 use log::{Level, debug, log_enabled, trace, warn};
 
-use crate::shared::replication::visibility::VisibilityLifetime;
+use crate::shared::replication::visibility::ScopeLifetime;
 use crate::{
     postcard_utils,
     prelude::*,
@@ -458,7 +458,7 @@ fn should_send_mapping(
 ) -> bool {
     if visibility
         .get(entity)
-        .is_hidden(registry, VisibilityLifetime::OnceVisible)
+        .is_hidden(registry, ScopeLifetime::OnceVisible)
     {
         return false;
     }
@@ -496,7 +496,7 @@ fn collect_despawns(
     for (client, mut message, mut ticks, mut priority, visibility) in clients {
         for (entity, filter_mask) in visibility.iter_lost() {
             // Skip visibility changes that hide only components.
-            if !filter_mask.is_hidden(&registry, VisibilityLifetime::WhenVisible) {
+            if !filter_mask.is_hidden(&registry, ScopeLifetime::WhenVisible) {
                 continue;
             }
 
@@ -567,7 +567,7 @@ fn collect_removals(
 
     for (client, mut message, mut ticks, mut visibility) in &mut clients {
         for (entity, filter_mask) in visibility.drain_lost() {
-            if filter_mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible) {
+            if filter_mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible) {
                 // Was processed earlier during collecting despawns.
                 continue;
             }
@@ -717,16 +717,16 @@ fn collect_changes(
                 for (client, mut updates, mut mutations, client_ticks, priority_map, visibility) in
                     &mut clients
                 {
-                    let visibility_lifetime = visibility
+                    let scope_lifetime = visibility
                         .get(entity.id())
                         .get_hidden_component_lowest_lifetime(&filter_registry, component_index);
-                    if visibility_lifetime == Some(VisibilityLifetime::WhenVisible) {
+                    if scope_lifetime == Some(ScopeLifetime::WhenVisible) {
                         continue;
                     }
 
                     if let Some(entity_ticks) = client_ticks.entities.get(&entity.id())
                         && entity_ticks.components.contains(component_index)
-                        && visibility_lifetime.is_none()
+                        && scope_lifetime.is_none()
                     {
                         let base_priority = priority_map
                             .get(&entity.id())
@@ -770,7 +770,7 @@ fn collect_changes(
                             };
                             mutations.add_component(component_range);
                         }
-                    } else if visibility_lifetime.is_none_or(|l| l == VisibilityLifetime::Always) {
+                    } else if scope_lifetime.is_none_or(|l| l == ScopeLifetime::Always) {
                         trace!(
                             "writing `{:?}` insertion for `{}` for client `{client}`",
                             rule.fns_id,
@@ -796,7 +796,7 @@ fn collect_changes(
                 let hidden_lifetime = visibility
                     .get(entity.id())
                     .get_hidden_lowest_lifetime(&filter_registry);
-                if hidden_lifetime == Some(VisibilityLifetime::WhenVisible) {
+                if hidden_lifetime == Some(ScopeLifetime::WhenVisible) {
                     continue;
                 }
 
@@ -804,7 +804,7 @@ fn collect_changes(
                 let new_for_client = matches!(entity_ticks, Entry::Vacant(_));
                 // todo! does this correctly cover the case when an entity is spawned
                 //  and we want to merge other mutations into the same update?
-                if new_for_client && hidden_lifetime.is_none_or(|l| l == VisibilityLifetime::Always)
+                if new_for_client && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::Always)
                     || updates.changed_entity_added() && hidden_lifetime.is_none()
                     || removal_buffer.contains_key(&entity.id())
                 {
@@ -827,7 +827,7 @@ fn collect_changes(
                 }
 
                 if new_for_client
-                    && hidden_lifetime.is_none_or(|l| l == VisibilityLifetime::Always)
+                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::Always)
                     && !updates.changed_entity_added()
                 {
                     trace!("writing empty `{}` for client `{client}`", entity.id());

--- a/src/server.rs
+++ b/src/server.rs
@@ -458,7 +458,7 @@ fn should_send_mapping(
 ) -> bool {
     if visibility
         .get(entity)
-        .is_hidden(registry, ScopeLifetime::OnceVisible)
+        .is_hidden(registry, ScopeLifetime::AfterFirstVisibility)
     {
         return false;
     }
@@ -496,7 +496,7 @@ fn collect_despawns(
     for (client, mut message, mut ticks, mut priority, visibility) in clients {
         for (entity, filter_mask) in visibility.iter_lost() {
             // Skip visibility changes that hide only components.
-            if !filter_mask.is_hidden(&registry, ScopeLifetime::WhenVisible) {
+            if !filter_mask.is_hidden(&registry, ScopeLifetime::WhileVisible) {
                 continue;
             }
 
@@ -567,7 +567,7 @@ fn collect_removals(
 
     for (client, mut message, mut ticks, mut visibility) in &mut clients {
         for (entity, filter_mask) in visibility.drain_lost() {
-            if filter_mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible) {
+            if filter_mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible) {
                 // Was processed earlier during collecting despawns.
                 continue;
             }
@@ -720,7 +720,7 @@ fn collect_changes(
                     let scope_lifetime = visibility
                         .get(entity.id())
                         .get_hidden_component_lowest_lifetime(&filter_registry, component_index);
-                    if scope_lifetime == Some(ScopeLifetime::WhenVisible) {
+                    if scope_lifetime == Some(ScopeLifetime::WhileVisible) {
                         continue;
                     }
 
@@ -770,7 +770,7 @@ fn collect_changes(
                             };
                             mutations.add_component(component_range);
                         }
-                    } else if scope_lifetime.is_none_or(|l| l == ScopeLifetime::Always) {
+                    } else if scope_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent) {
                         trace!(
                             "writing `{:?}` insertion for `{}` for client `{client}`",
                             rule.fns_id,
@@ -796,7 +796,7 @@ fn collect_changes(
                 let hidden_lifetime = visibility
                     .get(entity.id())
                     .get_hidden_lowest_lifetime(&filter_registry);
-                if hidden_lifetime == Some(ScopeLifetime::WhenVisible) {
+                if hidden_lifetime == Some(ScopeLifetime::WhileVisible) {
                     continue;
                 }
 
@@ -804,7 +804,8 @@ fn collect_changes(
                 let new_for_client = matches!(entity_ticks, Entry::Vacant(_));
                 // todo! does this correctly cover the case when an entity is spawned
                 //  and we want to merge other mutations into the same update?
-                if new_for_client && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::Always)
+                if new_for_client
+                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent)
                     || updates.changed_entity_added() && hidden_lifetime.is_none()
                     || removal_buffer.contains_key(&entity.id())
                 {
@@ -827,7 +828,7 @@ fn collect_changes(
                 }
 
                 if new_for_client
-                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::Always)
+                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent)
                     && !updates.changed_entity_added()
                 {
                     trace!("writing empty `{}` for client `{client}`", entity.id());

--- a/src/server.rs
+++ b/src/server.rs
@@ -802,13 +802,12 @@ fn collect_changes(
 
                 let entity_ticks = ticks.entities.entry(entity.id());
                 let new_for_client = matches!(entity_ticks, Entry::Vacant(_));
-                // todo! does this correctly cover the case when an entity is spawned
-                //  and we want to merge other mutations into the same update?
-                if new_for_client
-                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent)
-                    || updates.changed_entity_added() && hidden_lifetime.is_none()
-                    || removal_buffer.contains_key(&entity.id())
-                {
+                let has_insertions = updates.changed_entity_added() && hidden_lifetime.is_none();
+                let has_removals = removal_buffer.contains_key(&entity.id());
+                let starts_replication = new_for_client
+                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent);
+
+                if starts_replication || has_insertions || has_removals {
                     // If there is any insertion, removal, or it's a new entity for a client, include all mutations
                     // into update message and bump the last acknowledged tick to keep entity updates atomic.
                     if mutations.entity_added() {
@@ -827,10 +826,7 @@ fn collect_changes(
                     );
                 }
 
-                if new_for_client
-                    && hidden_lifetime.is_none_or(|l| l == ScopeLifetime::AlwaysPresent)
-                    && !updates.changed_entity_added()
-                {
+                if starts_replication && !updates.changed_entity_added() {
                     trace!("writing empty `{}` for client `{client}`", entity.id());
 
                     // Force-write new entity even if it doesn't have any components.

--- a/src/server.rs
+++ b/src/server.rs
@@ -616,7 +616,7 @@ fn collect_removals(
                 Ok(())
             };
 
-            for scope in filter_mask.scopes(&filter_registry) {
+            for scope in filter_mask.scopes(&filter_registry, ScopeLifetime::WhileVisible) {
                 match scope {
                     VisibilityScope::Entity => {
                         unreachable!("entity filters are processed during despawn collection")

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,6 +25,7 @@ use bevy::{
 use bytes::Buf;
 use log::{Level, debug, log_enabled, trace, warn};
 
+use crate::shared::replication::visibility::VisibilityLifetime;
 use crate::{
     postcard_utils,
     prelude::*,
@@ -455,7 +456,10 @@ fn should_send_mapping(
     visibility: &ClientVisibility,
     ticks: &ClientTicks,
 ) -> bool {
-    if visibility.get(entity).is_hidden(registry) {
+    if visibility
+        .get(entity)
+        .is_hidden(registry, VisibilityLifetime::OnceVisible)
+    {
         return false;
     }
 
@@ -492,7 +496,7 @@ fn collect_despawns(
     for (client, mut message, mut ticks, mut priority, visibility) in clients {
         for (entity, filter_mask) in visibility.iter_lost() {
             // Skip visibility changes that hide only components.
-            if !filter_mask.is_hidden(&registry) {
+            if !filter_mask.is_hidden(&registry, VisibilityLifetime::WhenVisible) {
                 continue;
             }
 
@@ -563,7 +567,7 @@ fn collect_removals(
 
     for (client, mut message, mut ticks, mut visibility) in &mut clients {
         for (entity, filter_mask) in visibility.drain_lost() {
-            if filter_mask.is_hidden(&filter_registry) {
+            if filter_mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible) {
                 // Was processed earlier during collecting despawns.
                 continue;
             }
@@ -788,14 +792,19 @@ fn collect_changes(
             }
 
             for (client, mut updates, mut mutations, mut ticks, _, visibility) in &mut clients {
-                if visibility.get(entity.id()).is_hidden(&filter_registry) {
+                let hidden_lifetime = visibility
+                    .get(entity.id())
+                    .get_hidden_lowest_lifetime(&filter_registry);
+                if hidden_lifetime == Some(VisibilityLifetime::WhenVisible) {
                     continue;
                 }
 
                 let entity_ticks = ticks.entities.entry(entity.id());
                 let new_for_client = matches!(entity_ticks, Entry::Vacant(_));
-                if new_for_client
-                    || updates.changed_entity_added()
+                // todo! does this correctly cover the case when an entity is spawned
+                //  and we want to merge other mutations into the same update?
+                if new_for_client && hidden_lifetime.is_none_or(|l| l == VisibilityLifetime::Always)
+                    || updates.changed_entity_added() && hidden_lifetime.is_none()
                     || removal_buffer.contains_key(&entity.id())
                 {
                     // If there is any insertion, removal, or it's a new entity for a client, include all mutations
@@ -816,7 +825,10 @@ fn collect_changes(
                     );
                 }
 
-                if new_for_client && !updates.changed_entity_added() {
+                if new_for_client
+                    && hidden_lifetime.is_none_or(|l| l == VisibilityLifetime::Always)
+                    && !updates.changed_entity_added()
+                {
                     trace!("writing empty `{}` for client `{client}`", entity.id());
 
                     // Force-write new entity even if it doesn't have any components.

--- a/src/server.rs
+++ b/src/server.rs
@@ -408,6 +408,7 @@ fn prepare_messages(
 
 /// Collects and writes any new entity mappings that happened in this tick.
 fn collect_mappings(
+    despawn_buffer: Res<DespawnBuffer>,
     registry: Res<FilterRegistry>,
     mut serialized: ResMut<SerializedData>,
     entities: Query<(Entity, &Signature), With<Replicated>>,
@@ -426,7 +427,7 @@ fn collect_mappings(
             let Ok((_, mut message, ticks, visibility)) = clients.get_mut(client) else {
                 continue;
             };
-            if should_send_mapping(entity, &registry, &visibility, &ticks) {
+            if should_send_mapping(entity, &despawn_buffer, &registry, &visibility, &ticks) {
                 trace!(
                     "writing mapping `{entity}` to 0x{hash:016x} dedicated for client `{client}`"
                 );
@@ -436,7 +437,7 @@ fn collect_mappings(
             }
         } else {
             for (client, mut message, ticks, visibility) in &mut clients {
-                if should_send_mapping(entity, &registry, &visibility, &ticks) {
+                if should_send_mapping(entity, &despawn_buffer, &registry, &visibility, &ticks) {
                     trace!("writing mapping `{entity}` to 0x{hash:016x} for client `{client}`");
                     let mapping_range =
                         serialized.write_cached_mapping(&mut mapping_range, entity, hash)?;
@@ -451,13 +452,16 @@ fn collect_mappings(
 
 fn should_send_mapping(
     entity: Entity,
+    despawn_buffer: &DespawnBuffer,
     registry: &FilterRegistry,
     visibility: &ClientVisibility,
     ticks: &ClientTicks,
 ) -> bool {
+    // Since despawns processed later, we need to explicitly check for them.
     if visibility
         .get(entity)
         .hides_entity(registry, ScopeLifetime::AfterFirstVisibility)
+        || despawn_buffer.contains(&entity)
     {
         return false;
     }
@@ -476,18 +480,20 @@ fn collect_despawns(
         &mut Updates,
         &mut ClientTicks,
         &mut PriorityMap,
-        &ClientVisibility,
+        &mut ClientVisibility,
     )>,
 ) -> Result<()> {
     for entity in despawn_buffer.drain(..) {
         let entity_range = serialized.write_entity(entity)?;
-        for (client, mut message, mut ticks, mut priority, _) in &mut clients {
-            if ticks.entities.remove(&entity).is_some() {
-                // Write despawn only if the entity was previously sent because
-                // spawn and despawn could happen during the same tick.
+        for (client, mut message, mut ticks, mut priority, mut visibility) in &mut clients {
+            let hidden_lifetime = visibility.get(entity).hidden_entity_lifetime(&registry);
+            if ticks.entities.remove(&entity).is_some() && hidden_lifetime.is_none() {
+                // Write despawn only if the entity is not currently hidden and was
+                // previously sent because spawn and despawn could happen during the same tick.
                 trace!("writing despawn for `{entity}` for client `{client}`");
                 message.add_despawn(entity_range.clone());
             }
+            visibility.remove_despawned(entity);
             priority.remove(&entity);
         }
     }
@@ -541,8 +547,17 @@ fn collect_removals(
 
         for &(component_index, fns_id) in remove_ids {
             let mut fns_id_range = None;
-            for (client, mut message, mut ticks, _) in &mut clients {
-                // Only send removals for components that were previously sent.
+            for (client, mut message, mut ticks, visibility) in &mut clients {
+                let hidden_lifetime = visibility
+                    .get(entity)
+                    .hidden_component_lifetime(&filter_registry, component_index);
+                if hidden_lifetime.is_some() {
+                    // Ignore hidden entities.
+                    continue;
+                }
+
+                // Only send removals for components that were previously sent
+                // because insertion and removal could happen during the same tick
                 // If the entity was despawned or lost visibility, it was removed
                 // from ticks earlier during despawn collection.
                 let Some(entity_ticks) = ticks.entities.get_mut(&entity) else {

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -257,24 +257,24 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility1
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility2
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -299,24 +299,24 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility1
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility2
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -339,12 +339,12 @@ mod tests {
         assert!(
             visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         app.world_mut()
@@ -356,12 +356,12 @@ mod tests {
         assert!(
             !visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -390,12 +390,12 @@ mod tests {
         assert!(
             !visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -420,12 +420,12 @@ mod tests {
         assert!(
             visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -452,14 +452,14 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         // Hide entity from the first client too.
@@ -470,7 +470,7 @@ mod tests {
         assert!(
             visibility1
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         // Relax visibility constraints to make it visible to both.
@@ -481,14 +481,14 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             !visibility2
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhileVisible)
+                .hides_entity(registry, ScopeLifetime::WhileVisible)
         );
     }
 

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -233,7 +233,7 @@ fn on_client_remove<F: VisibilityFilter>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared::replication::visibility::VisibilityLifetime;
+    use crate::shared::replication::visibility::ScopeLifetime;
     use test_log::test;
 
     #[test]
@@ -257,24 +257,24 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             !visibility1
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             visibility2
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
     }
 
@@ -299,24 +299,24 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             !visibility1
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             visibility2
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
     }
 
@@ -339,12 +339,12 @@ mod tests {
         assert!(
             visibility
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             visibility
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         app.world_mut()
@@ -356,12 +356,12 @@ mod tests {
         assert!(
             !visibility
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             !visibility
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
     }
 
@@ -390,12 +390,12 @@ mod tests {
         assert!(
             !visibility
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             !visibility
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
     }
 
@@ -420,12 +420,12 @@ mod tests {
         assert!(
             visibility
                 .get(entity1)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
         assert!(
             visibility
                 .get(entity2)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
     }
 
@@ -452,14 +452,14 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         // Hide entity from the first client too.
@@ -470,7 +470,7 @@ mod tests {
         assert!(
             visibility1
                 .get(entity)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         // Relax visibility constraints to make it visible to both.
@@ -481,14 +481,14 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             !visibility2
                 .get(entity)
-                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhenVisible)
         );
     }
 

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -184,9 +184,9 @@ fn on_remove<F: VisibilityFilter>(
     }
 
     if remove.trigger().new_archetype.is_none() {
-        for mut visibility in &mut clients {
-            visibility.remove_despawned(remove.entity);
-        }
+        // The entity was despawned and will be removed from the visibility list
+        // during despawn collection. We keep it for now because we need to know
+        // whether replication for the entity was paused.
         return;
     }
 
@@ -212,9 +212,9 @@ fn on_client_remove<F: VisibilityFilter>(
     };
 
     if remove.trigger().new_archetype.is_none() {
-        for (entity, _) in &entities {
-            visibility.remove_despawned(entity);
-        }
+        // The entity was despawned and will be removed from the visibility list
+        // during despawn collection. We keep it for now because we need to know
+        // whether replication for the entity was paused.
         return;
     }
 

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -257,24 +257,24 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility1
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility2
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -299,24 +299,24 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility1
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility2
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -339,12 +339,12 @@ mod tests {
         assert!(
             visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         app.world_mut()
@@ -356,12 +356,12 @@ mod tests {
         assert!(
             !visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -390,12 +390,12 @@ mod tests {
         assert!(
             !visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             !visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -420,12 +420,12 @@ mod tests {
         assert!(
             visibility
                 .get(entity1)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
         assert!(
             visibility
                 .get(entity2)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
     }
 
@@ -452,14 +452,14 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             visibility2
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         // Hide entity from the first client too.
@@ -470,7 +470,7 @@ mod tests {
         assert!(
             visibility1
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         // Relax visibility constraints to make it visible to both.
@@ -481,14 +481,14 @@ mod tests {
         assert!(
             !visibility1
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
         assert!(
             !visibility2
                 .get(entity)
-                .is_hidden(registry, ScopeLifetime::WhenVisible)
+                .is_hidden(registry, ScopeLifetime::WhileVisible)
         );
     }
 

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -232,9 +232,9 @@ fn on_client_remove<F: VisibilityFilter>(
 
 #[cfg(test)]
 mod tests {
-    use test_log::test;
-    use crate::shared::replication::visibility::VisibilityLifetime;
     use super::*;
+    use crate::shared::replication::visibility::VisibilityLifetime;
+    use test_log::test;
 
     #[test]
     fn after_clients() {
@@ -254,12 +254,28 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(!visibility1.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility1
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            !visibility1
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(visibility2.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(visibility2.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            visibility2
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            visibility2
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
     }
 
     #[test]
@@ -280,12 +296,28 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(!visibility1.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility1
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            !visibility1
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(visibility2.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(visibility2.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            visibility2
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            visibility2
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
     }
 
     #[test]
@@ -304,8 +336,16 @@ mod tests {
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
 
-        assert!(visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            visibility
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            visibility
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         app.world_mut()
             .entity_mut(client)
@@ -313,8 +353,16 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
-        assert!(!visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(!visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            !visibility
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
     }
 
     #[test]
@@ -339,8 +387,16 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
-        assert!(!visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(!visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            !visibility
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
     }
 
     #[test]
@@ -361,8 +417,16 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
-        assert!(visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
-        assert!(visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            visibility
+                .get(entity1)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
+        assert!(
+            visibility
+                .get(entity2)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
     }
 
     #[test]
@@ -385,27 +449,47 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility1
+                .get(entity)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(visibility2.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            visibility2
+                .get(entity)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         // Hide entity from the first client too.
         app.world_mut().entity_mut(client1).remove::<ClientFilter>();
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(visibility1.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            visibility1
+                .get(entity)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         // Relax visibility constraints to make it visible to both.
         app.world_mut().entity_mut(entity).remove::<EntityFilter>();
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility1
+                .get(entity)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(!visibility2.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(
+            !visibility2
+                .get(entity)
+                .is_hidden(registry, VisibilityLifetime::WhenVisible)
+        );
     }
 
     #[derive(Component)]

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -232,9 +232,10 @@ fn on_client_remove<F: VisibilityFilter>(
 
 #[cfg(test)]
 mod tests {
+    use test_log::test;
+
     use super::*;
     use crate::shared::replication::visibility::ScopeLifetime;
-    use test_log::test;
 
     #[test]
     fn after_clients() {

--- a/src/server/visibility.rs
+++ b/src/server/visibility.rs
@@ -233,7 +233,7 @@ fn on_client_remove<F: VisibilityFilter>(
 #[cfg(test)]
 mod tests {
     use test_log::test;
-
+    use crate::shared::replication::visibility::VisibilityLifetime;
     use super::*;
 
     #[test]
@@ -254,12 +254,12 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity1).is_hidden(registry));
-        assert!(!visibility1.get(entity2).is_hidden(registry));
+        assert!(!visibility1.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(!visibility1.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(visibility2.get(entity1).is_hidden(registry));
-        assert!(visibility2.get(entity2).is_hidden(registry));
+        assert!(visibility2.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(visibility2.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
     }
 
     #[test]
@@ -280,12 +280,12 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity1).is_hidden(registry));
-        assert!(!visibility1.get(entity2).is_hidden(registry));
+        assert!(!visibility1.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(!visibility1.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(visibility2.get(entity1).is_hidden(registry));
-        assert!(visibility2.get(entity2).is_hidden(registry));
+        assert!(visibility2.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(visibility2.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
     }
 
     #[test]
@@ -304,8 +304,8 @@ mod tests {
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
 
-        assert!(visibility.get(entity1).is_hidden(registry));
-        assert!(visibility.get(entity2).is_hidden(registry));
+        assert!(visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         app.world_mut()
             .entity_mut(client)
@@ -313,8 +313,8 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
-        assert!(!visibility.get(entity1).is_hidden(registry));
-        assert!(!visibility.get(entity2).is_hidden(registry));
+        assert!(!visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(!visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
     }
 
     #[test]
@@ -339,8 +339,8 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
-        assert!(!visibility.get(entity1).is_hidden(registry));
-        assert!(!visibility.get(entity2).is_hidden(registry));
+        assert!(!visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(!visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
     }
 
     #[test]
@@ -361,8 +361,8 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility = app.world().get::<ClientVisibility>(client).unwrap();
-        assert!(visibility.get(entity1).is_hidden(registry));
-        assert!(visibility.get(entity2).is_hidden(registry));
+        assert!(visibility.get(entity1).is_hidden(registry, VisibilityLifetime::WhenVisible));
+        assert!(visibility.get(entity2).is_hidden(registry, VisibilityLifetime::WhenVisible));
     }
 
     #[test]
@@ -385,27 +385,27 @@ mod tests {
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity).is_hidden(registry));
+        assert!(!visibility1.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(visibility2.get(entity).is_hidden(registry));
+        assert!(visibility2.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         // Hide entity from the first client too.
         app.world_mut().entity_mut(client1).remove::<ClientFilter>();
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(visibility1.get(entity).is_hidden(registry));
+        assert!(visibility1.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         // Relax visibility constraints to make it visible to both.
         app.world_mut().entity_mut(entity).remove::<EntityFilter>();
 
         let registry = app.world().resource::<FilterRegistry>();
         let visibility1 = app.world().get::<ClientVisibility>(client1).unwrap();
-        assert!(!visibility1.get(entity).is_hidden(registry));
+        assert!(!visibility1.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
 
         let visibility2 = app.world().get::<ClientVisibility>(client2).unwrap();
-        assert!(!visibility2.get(entity).is_hidden(registry));
+        assert!(!visibility2.get(entity).is_hidden(registry, VisibilityLifetime::WhenVisible));
     }
 
     #[derive(Component)]

--- a/src/server/visibility/client_visibility.rs
+++ b/src/server/visibility/client_visibility.rs
@@ -61,6 +61,7 @@ impl ClientVisibility {
     ```
     use bevy::prelude::*;
     use bevy_replicon::{
+        prelude::*,
         server::visibility::{
             client_visibility::ClientVisibility, filters_mask::FilterBit, registry::FilterRegistry,
         },
@@ -108,7 +109,7 @@ impl ClientVisibility {
         fn from_world(world: &mut World) -> Self {
             let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
                 world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                    filter_registry.register_scope::<(Health, Stats)>(world, &mut registry)
+                    filter_registry.register_scope::<(Health, Stats)>(world, &mut registry, ScopeLifetime::WhileVisible)
                 })
             });
             Self(bit)
@@ -131,7 +132,7 @@ impl ClientVisibility {
         fn from_world(world: &mut World) -> Self {
             let bit = world.resource_scope(|world, mut filter_registry: Mut<FilterRegistry>| {
                 world.resource_scope(|world, mut registry: Mut<ReplicationRegistry>| {
-                    filter_registry.register_scope::<Entity>(world, &mut registry)
+                    filter_registry.register_scope::<Entity>(world, &mut registry, ScopeLifetime::WhileVisible)
                 })
             });
             Self(bit)

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -60,8 +60,8 @@ impl FiltersMask {
     ) -> Option<ScopeLifetime> {
         self.iter()
             .filter(|bit| matches!(registry.scope(*bit), VisibilityScope::Entity))
-            .max_by(|a, b| registry.lifetime(*a).cmp(&registry.lifetime(*b)).reverse())
             .map(|bit| registry.lifetime(bit))
+            .min()
     }
 
     /// Returns an iterator over the scope of each set filter.

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -43,7 +43,7 @@ impl FiltersMask {
     }
 
     /// Returns `true` if the entity is hidden by any of the filters.
-    pub(crate) fn is_hidden(
+    pub(crate) fn hides_entity(
         &self,
         registry: &FilterRegistry,
         max_valid_lifetime: ScopeLifetime,
@@ -54,7 +54,7 @@ impl FiltersMask {
         })
     }
 
-    pub(crate) fn get_hidden_lowest_lifetime(
+    pub(crate) fn hidden_entity_lifetime(
         &self,
         registry: &FilterRegistry,
     ) -> Option<ScopeLifetime> {
@@ -72,7 +72,7 @@ impl FiltersMask {
         self.iter().map(|bit| registry.scope(bit))
     }
 
-    pub(crate) fn get_hidden_component_lowest_lifetime(
+    pub(crate) fn hidden_component_lifetime(
         &self,
         registry: &FilterRegistry,
         index: ComponentIndex,

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -1,5 +1,6 @@
-use bevy::prelude::*;
 use core::iter;
+
+use bevy::prelude::*;
 
 use super::registry::FilterRegistry;
 use crate::{

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -72,23 +72,6 @@ impl FiltersMask {
         self.iter().map(|bit| registry.scope(bit))
     }
 
-    // TODO! remove in favour of `get_hidden_component_lowest_lifetime`
-    /// Returns `true` if the given component is hidden by any of the filters.
-    ///
-    /// Entity filters are treated as hiding all components.
-    pub(crate) fn is_component_hidden(
-        &self,
-        registry: &FilterRegistry,
-        index: ComponentIndex,
-        max_valid_lifetime: ScopeLifetime,
-    ) -> bool {
-        self.iter().any(|bit| match registry.scope(bit) {
-            VisibilityScope::Entity => true,
-            VisibilityScope::Components(component_mask) => component_mask.contains(index),
-            VisibilityScope::AllExcept(component_mask) => !component_mask.contains(index),
-        } && registry.lifetime(bit) <= max_valid_lifetime)
-    }
-
     pub(crate) fn get_hidden_component_lowest_lifetime(
         &self,
         registry: &FilterRegistry,

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -72,6 +72,7 @@ impl FiltersMask {
         self.iter().map(|bit| registry.scope(bit))
     }
 
+    // TODO! remove in favour of `get_hidden_component_lowest_lifetime`
     /// Returns `true` if the given component is hidden by any of the filters.
     ///
     /// Entity filters are treated as hiding all components.
@@ -79,12 +80,34 @@ impl FiltersMask {
         &self,
         registry: &FilterRegistry,
         index: ComponentIndex,
+        max_valid_lifetime: VisibilityLifetime,
     ) -> bool {
         self.iter().any(|bit| match registry.scope(bit) {
             VisibilityScope::Entity => true,
             VisibilityScope::Components(component_mask) => component_mask.contains(index),
             VisibilityScope::AllExcept(component_mask) => !component_mask.contains(index),
-        })
+        } && registry.lifetime(bit) <= max_valid_lifetime)
+    }
+
+    pub(crate) fn get_hidden_component_lowest_lifetime(
+        &self,
+        registry: &FilterRegistry,
+        index: ComponentIndex,
+    ) -> Option<VisibilityLifetime> {
+        self.iter()
+            .filter_map(|bit| {
+                let is_hidden = match registry.scope(bit) {
+                    VisibilityScope::Entity => true,
+                    VisibilityScope::Components(component_mask) => component_mask.contains(index),
+                    VisibilityScope::AllExcept(component_mask) => !component_mask.contains(index),
+                };
+                if is_hidden {
+                    Some(registry.lifetime(bit))
+                } else {
+                    None
+                }
+            })
+            .max_by(|a, b| a.cmp(b).reverse())
     }
 }
 

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -71,12 +71,16 @@ impl FiltersMask {
             .min()
     }
 
-    /// Returns an iterator over the scope of each set filter.
+    /// Returns an iterator over scopes hidden by filters
+    /// with at most `max_lifetime`.
     pub(crate) fn scopes(
         self,
         registry: &FilterRegistry,
+        max_lifetime: ScopeLifetime,
     ) -> impl Iterator<Item = &VisibilityScope> {
-        self.iter().map(|bit| registry.scope(bit))
+        self.iter()
+            .filter(move |&bit| registry.lifetime(bit) <= max_lifetime)
+            .map(|bit| registry.scope(bit))
     }
 
     /// Returns the shortest lifetime that hide the component.

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -42,18 +42,22 @@ impl FiltersMask {
         })
     }
 
-    /// Returns `true` if the entity is hidden by any of the filters.
+    /// Returns `true` if the entity is hidden by any of the filters
+    /// with at most `max_lifetime`.
     pub(crate) fn hides_entity(
         &self,
         registry: &FilterRegistry,
-        max_valid_lifetime: ScopeLifetime,
+        max_lifetime: ScopeLifetime,
     ) -> bool {
         self.iter().any(|bit| {
             matches!(registry.scope(bit), VisibilityScope::Entity)
-                && registry.lifetime(bit) <= max_valid_lifetime
+                && registry.lifetime(bit) <= max_lifetime
         })
     }
 
+    /// Returns the shortest lifetime that hide the entity.
+    ///
+    /// Returns [`None`] if no filter hides it.
     pub(crate) fn hidden_entity_lifetime(
         &self,
         registry: &FilterRegistry,
@@ -72,6 +76,11 @@ impl FiltersMask {
         self.iter().map(|bit| registry.scope(bit))
     }
 
+    /// Returns the shortest lifetime that hide the component.
+    ///
+    /// Returns [`None`] if no filter hides the component.
+    ///
+    /// Entity filters are treated as hiding all components.
     pub(crate) fn hidden_component_lifetime(
         &self,
         registry: &FilterRegistry,

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -2,8 +2,10 @@ use bevy::prelude::*;
 use core::iter;
 
 use super::registry::FilterRegistry;
-use crate::shared::replication::visibility::ScopeLifetime;
-use crate::shared::replication::{registry::ComponentIndex, visibility::VisibilityScope};
+use crate::{
+    prelude::*,
+    shared::replication::{registry::ComponentIndex, visibility::VisibilityScope},
+};
 
 /// Bitset of visibility filters for an entity for a client.
 ///

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -58,7 +58,7 @@ impl FiltersMask {
         })
     }
 
-    /// Returns the shortest lifetime that hide the entity.
+    /// Returns the shortest lifetime that hides the entity.
     ///
     /// Returns [`None`] if no filter hides it.
     pub(crate) fn hidden_entity_lifetime(
@@ -83,7 +83,7 @@ impl FiltersMask {
             .map(|bit| registry.scope(bit))
     }
 
-    /// Returns the shortest lifetime that hide the component.
+    /// Returns the shortest lifetime that hides the component.
     ///
     /// Returns [`None`] if no filter hides the component.
     ///

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use core::iter;
 
 use super::registry::FilterRegistry;
-use crate::shared::replication::visibility::VisibilityLifetime;
+use crate::shared::replication::visibility::ScopeLifetime;
 use crate::shared::replication::{registry::ComponentIndex, visibility::VisibilityScope};
 
 /// Bitset of visibility filters for an entity for a client.
@@ -46,7 +46,7 @@ impl FiltersMask {
     pub(crate) fn is_hidden(
         &self,
         registry: &FilterRegistry,
-        max_valid_lifetime: VisibilityLifetime,
+        max_valid_lifetime: ScopeLifetime,
     ) -> bool {
         self.iter().any(|bit| {
             matches!(registry.scope(bit), VisibilityScope::Entity)
@@ -57,7 +57,7 @@ impl FiltersMask {
     pub(crate) fn get_hidden_lowest_lifetime(
         &self,
         registry: &FilterRegistry,
-    ) -> Option<VisibilityLifetime> {
+    ) -> Option<ScopeLifetime> {
         self.iter()
             .filter(|bit| matches!(registry.scope(*bit), VisibilityScope::Entity))
             .max_by(|a, b| registry.lifetime(*a).cmp(&registry.lifetime(*b)).reverse())
@@ -80,7 +80,7 @@ impl FiltersMask {
         &self,
         registry: &FilterRegistry,
         index: ComponentIndex,
-        max_valid_lifetime: VisibilityLifetime,
+        max_valid_lifetime: ScopeLifetime,
     ) -> bool {
         self.iter().any(|bit| match registry.scope(bit) {
             VisibilityScope::Entity => true,
@@ -93,7 +93,7 @@ impl FiltersMask {
         &self,
         registry: &FilterRegistry,
         index: ComponentIndex,
-    ) -> Option<VisibilityLifetime> {
+    ) -> Option<ScopeLifetime> {
         self.iter()
             .filter_map(|bit| {
                 let is_hidden = match registry.scope(bit) {

--- a/src/server/visibility/filters_mask.rs
+++ b/src/server/visibility/filters_mask.rs
@@ -1,8 +1,8 @@
+use bevy::prelude::*;
 use core::iter;
 
-use bevy::prelude::*;
-
 use super::registry::FilterRegistry;
+use crate::shared::replication::visibility::VisibilityLifetime;
 use crate::shared::replication::{registry::ComponentIndex, visibility::VisibilityScope};
 
 /// Bitset of visibility filters for an entity for a client.
@@ -43,9 +43,25 @@ impl FiltersMask {
     }
 
     /// Returns `true` if the entity is hidden by any of the filters.
-    pub(crate) fn is_hidden(&self, registry: &FilterRegistry) -> bool {
+    pub(crate) fn is_hidden(
+        &self,
+        registry: &FilterRegistry,
+        max_valid_lifetime: VisibilityLifetime,
+    ) -> bool {
+        self.iter().any(|bit| {
+            matches!(registry.scope(bit), VisibilityScope::Entity)
+                && registry.lifetime(bit) <= max_valid_lifetime
+        })
+    }
+
+    pub(crate) fn get_hidden_lowest_lifetime(
+        &self,
+        registry: &FilterRegistry,
+    ) -> Option<VisibilityLifetime> {
         self.iter()
-            .any(|bit| matches!(registry.scope(bit), VisibilityScope::Entity))
+            .filter(|bit| matches!(registry.scope(*bit), VisibilityScope::Entity))
+            .max_by(|a, b| registry.lifetime(*a).cmp(&registry.lifetime(*b)).reverse())
+            .map(|bit| registry.lifetime(bit))
     }
 
     /// Returns an iterator over the scope of each set filter.

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -4,7 +4,6 @@ use bevy::{
 };
 
 use super::{FilterScope, filters_mask::FilterBit};
-use crate::shared::replication::visibility::ScopeLifetime;
 use crate::{
     prelude::*,
     shared::replication::{registry::ReplicationRegistry, visibility::VisibilityScope},

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -169,7 +169,10 @@ mod tests {
         assert!(mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+                .is_some()
+        );
     }
 
     #[test]
@@ -186,10 +189,16 @@ mod tests {
         assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+                .is_some()
+        );
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, b_index)
+                .is_none()
+        );
     }
 
     #[test]
@@ -206,13 +215,22 @@ mod tests {
         assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+                .is_some()
+        );
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, b_index)
+                .is_some()
+        );
 
         let (c_index, _) = registry.init_component_fns::<C>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, c_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, c_index)
+                .is_none()
+        );
     }
 
     #[test]
@@ -229,10 +247,16 @@ mod tests {
         assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+                .is_none()
+        );
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhileVisible));
+        assert!(
+            mask.get_hidden_component_lowest_lifetime(&filter_registry, b_index)
+                .is_some()
+        );
     }
 
     #[derive(Component)]

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -37,7 +37,6 @@ impl FilterRegistry {
                 ShortName::of::<F>()
             )
         }
-        assert_eq!(self.lifetimes.len(), *bit as usize);
     }
 
     /// Registers a new visibility scope and returns the [`FilterBit`] assigned to it.

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 
 use super::{FilterScope, filters_mask::FilterBit};
-use crate::shared::replication::visibility::VisibilityLifetime;
+use crate::shared::replication::visibility::ScopeLifetime;
 use crate::{
     prelude::*,
     shared::replication::{registry::ReplicationRegistry, visibility::VisibilityScope},
@@ -21,7 +21,7 @@ use crate::{
 pub struct FilterRegistry {
     bits: TypeIdMap<FilterBit>,
     scopes: Vec<VisibilityScope>,
-    lifetimes: Vec<VisibilityLifetime>,
+    lifetimes: Vec<ScopeLifetime>,
 }
 
 impl FilterRegistry {
@@ -52,7 +52,7 @@ impl FilterRegistry {
         &mut self,
         world: &mut World,
         registry: &mut ReplicationRegistry,
-        lifetime: VisibilityLifetime,
+        lifetime: ScopeLifetime,
     ) -> FilterBit {
         if self.scopes.len() >= u32::BITS as usize {
             panic!("number of visibility scopes can't exceed {}", u32::BITS);
@@ -81,7 +81,7 @@ impl FilterRegistry {
             .unwrap_or_else(|| panic!("scope for `{bit:?}` should've been registered"))
     }
 
-    pub(super) fn lifetime(&self, bit: FilterBit) -> VisibilityLifetime {
+    pub(super) fn lifetime(&self, bit: FilterBit) -> ScopeLifetime {
         self.lifetimes
             .get(*bit as usize)
             .copied()
@@ -130,7 +130,7 @@ mod tests {
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
             scopes: vec![VisibilityScope::Entity; 31],
-            lifetimes: vec![VisibilityLifetime::Always; 31],
+            lifetimes: vec![ScopeLifetime::Always; 31],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
@@ -143,7 +143,7 @@ mod tests {
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
             scopes: vec![VisibilityScope::Entity; 32],
-            lifetimes: vec![VisibilityLifetime::Always; 32],
+            lifetimes: vec![ScopeLifetime::Always; 32],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
@@ -170,14 +170,10 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
+        assert!(mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(
-            &filter_registry,
-            a_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
     }
 
     #[test]
@@ -191,21 +187,13 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
+        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(
-            &filter_registry,
-            a_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(!mask.is_component_hidden(
-            &filter_registry,
-            b_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(!mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhenVisible));
     }
 
     #[test]
@@ -219,28 +207,16 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
+        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(
-            &filter_registry,
-            a_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(
-            &filter_registry,
-            b_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhenVisible));
 
         let (c_index, _) = registry.init_component_fns::<C>(&mut world);
-        assert!(!mask.is_component_hidden(
-            &filter_registry,
-            c_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(!mask.is_component_hidden(&filter_registry, c_index, ScopeLifetime::WhenVisible));
     }
 
     #[test]
@@ -254,21 +230,13 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
+        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(!mask.is_component_hidden(
-            &filter_registry,
-            a_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(!mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(
-            &filter_registry,
-            b_index,
-            VisibilityLifetime::WhenVisible
-        ));
+        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhenVisible));
     }
 
     #[derive(Component)]

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -172,7 +172,11 @@ mod tests {
         assert!(mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index));
+        assert!(mask.is_component_hidden(
+            &filter_registry,
+            a_index,
+            VisibilityLifetime::WhenVisible
+        ));
     }
 
     #[test]
@@ -189,10 +193,18 @@ mod tests {
         assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index));
+        assert!(mask.is_component_hidden(
+            &filter_registry,
+            a_index,
+            VisibilityLifetime::WhenVisible
+        ));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, b_index));
+        assert!(!mask.is_component_hidden(
+            &filter_registry,
+            b_index,
+            VisibilityLifetime::WhenVisible
+        ));
     }
 
     #[test]
@@ -209,13 +221,25 @@ mod tests {
         assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index));
+        assert!(mask.is_component_hidden(
+            &filter_registry,
+            a_index,
+            VisibilityLifetime::WhenVisible
+        ));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, b_index));
+        assert!(mask.is_component_hidden(
+            &filter_registry,
+            b_index,
+            VisibilityLifetime::WhenVisible
+        ));
 
         let (c_index, _) = registry.init_component_fns::<C>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, c_index));
+        assert!(!mask.is_component_hidden(
+            &filter_registry,
+            c_index,
+            VisibilityLifetime::WhenVisible
+        ));
     }
 
     #[test]
@@ -232,10 +256,18 @@ mod tests {
         assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, a_index));
+        assert!(!mask.is_component_hidden(
+            &filter_registry,
+            a_index,
+            VisibilityLifetime::WhenVisible
+        ));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, b_index));
+        assert!(mask.is_component_hidden(
+            &filter_registry,
+            b_index,
+            VisibilityLifetime::WhenVisible
+        ));
     }
 
     #[derive(Component)]

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -127,7 +127,7 @@ mod tests {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
-            scopes: vec![(VisibilityScope::Entity, ScopeLifetime::WhenVisible); 31],
+            scopes: vec![(VisibilityScope::Entity, ScopeLifetime::WhileVisible); 31],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
@@ -139,7 +139,7 @@ mod tests {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
-            scopes: vec![(VisibilityScope::Entity, ScopeLifetime::WhenVisible); 32],
+            scopes: vec![(VisibilityScope::Entity, ScopeLifetime::WhileVisible); 32],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
@@ -166,10 +166,10 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
+        assert!(mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
+        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
     }
 
     #[test]
@@ -183,13 +183,13 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
+        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
+        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhenVisible));
+        assert!(!mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhileVisible));
     }
 
     #[test]
@@ -203,16 +203,16 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
+        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
+        assert!(mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhenVisible));
+        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhileVisible));
 
         let (c_index, _) = registry.init_component_fns::<C>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, c_index, ScopeLifetime::WhenVisible));
+        assert!(!mask.is_component_hidden(&filter_registry, c_index, ScopeLifetime::WhileVisible));
     }
 
     #[test]
@@ -226,13 +226,13 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhenVisible));
+        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
-        assert!(!mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhenVisible));
+        assert!(!mask.is_component_hidden(&filter_registry, a_index, ScopeLifetime::WhileVisible));
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
-        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhenVisible));
+        assert!(mask.is_component_hidden(&filter_registry, b_index, ScopeLifetime::WhileVisible));
     }
 
     #[derive(Component)]

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -20,8 +20,7 @@ use crate::{
 #[derive(Resource, Default)]
 pub struct FilterRegistry {
     bits: TypeIdMap<FilterBit>,
-    scopes: Vec<VisibilityScope>,
-    lifetimes: Vec<ScopeLifetime>,
+    scopes: Vec<(VisibilityScope, ScopeLifetime)>,
 }
 
 impl FilterRegistry {
@@ -57,12 +56,10 @@ impl FilterRegistry {
         if self.scopes.len() >= u32::BITS as usize {
             panic!("number of visibility scopes can't exceed {}", u32::BITS);
         }
-        assert_eq!(self.scopes.len(), self.lifetimes.len());
 
         let bit = FilterBit::new(self.scopes.len() as u8);
         let scope = S::visibility_scope(world, registry);
-        self.scopes.push(scope);
-        self.lifetimes.push(lifetime);
+        self.scopes.push((scope, lifetime));
         bit
     }
 
@@ -78,13 +75,14 @@ impl FilterRegistry {
     pub(super) fn scope(&self, bit: FilterBit) -> &VisibilityScope {
         self.scopes
             .get(*bit as usize)
+            .map(|(scope, _)| scope)
             .unwrap_or_else(|| panic!("scope for `{bit:?}` should've been registered"))
     }
 
     pub(super) fn lifetime(&self, bit: FilterBit) -> ScopeLifetime {
-        self.lifetimes
+        self.scopes
             .get(*bit as usize)
-            .copied()
+            .map(|&(_, lifetime)| lifetime)
             .unwrap_or_else(|| panic!("lifetime for `{bit:?}` should've been registered"))
     }
 }
@@ -129,8 +127,7 @@ mod tests {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
-            scopes: vec![VisibilityScope::Entity; 31],
-            lifetimes: vec![ScopeLifetime::Always; 31],
+            scopes: vec![(VisibilityScope::Entity, ScopeLifetime::WhenVisible); 31],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
@@ -142,8 +139,7 @@ mod tests {
         let mut world = World::new();
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
-            scopes: vec![VisibilityScope::Entity; 32],
-            lifetimes: vec![ScopeLifetime::Always; 32],
+            scopes: vec![(VisibilityScope::Entity, ScopeLifetime::WhenVisible); 32],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -4,6 +4,7 @@ use bevy::{
 };
 
 use super::{FilterScope, filters_mask::FilterBit};
+use crate::shared::replication::visibility::VisibilityLifetime;
 use crate::{
     prelude::*,
     shared::replication::{registry::ReplicationRegistry, visibility::VisibilityScope},
@@ -20,6 +21,7 @@ use crate::{
 pub struct FilterRegistry {
     bits: TypeIdMap<FilterBit>,
     scopes: Vec<VisibilityScope>,
+    lifetimes: Vec<VisibilityLifetime>,
 }
 
 impl FilterRegistry {
@@ -28,13 +30,14 @@ impl FilterRegistry {
         world: &mut World,
         registry: &mut ReplicationRegistry,
     ) {
-        let bit = self.register_scope::<F::Scope>(world, registry);
+        let bit = self.register_scope::<F::Scope>(world, registry, F::LIFETIME);
         if self.bits.insert_type::<F>(bit).is_some() {
             panic!(
                 "`{}` can't be registered more than once",
                 ShortName::of::<F>()
             )
         }
+        assert_eq!(self.lifetimes.len(), *bit as usize);
     }
 
     /// Registers a new visibility scope and returns the [`FilterBit`] assigned to it.
@@ -50,14 +53,17 @@ impl FilterRegistry {
         &mut self,
         world: &mut World,
         registry: &mut ReplicationRegistry,
+        lifetime: VisibilityLifetime,
     ) -> FilterBit {
         if self.scopes.len() >= u32::BITS as usize {
             panic!("number of visibility scopes can't exceed {}", u32::BITS);
         }
+        assert_eq!(self.scopes.len(), self.lifetimes.len());
 
         let bit = FilterBit::new(self.scopes.len() as u8);
         let scope = S::visibility_scope(world, registry);
         self.scopes.push(scope);
+        self.lifetimes.push(lifetime);
         bit
     }
 
@@ -74,6 +80,13 @@ impl FilterRegistry {
         self.scopes
             .get(*bit as usize)
             .unwrap_or_else(|| panic!("scope for `{bit:?}` should've been registered"))
+    }
+
+    pub(super) fn lifetime(&self, bit: FilterBit) -> VisibilityLifetime {
+        self.lifetimes
+            .get(*bit as usize)
+            .copied()
+            .unwrap_or_else(|| panic!("lifetime for `{bit:?}` should've been registered"))
     }
 }
 
@@ -156,7 +169,7 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(mask.is_hidden(&filter_registry));
+        assert!(mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(mask.is_component_hidden(&filter_registry, a_index));
@@ -173,7 +186,7 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry));
+        assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(mask.is_component_hidden(&filter_registry, a_index));
@@ -193,7 +206,7 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry));
+        assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(mask.is_component_hidden(&filter_registry, a_index));
@@ -216,7 +229,7 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry));
+        assert!(!mask.is_hidden(&filter_registry, VisibilityLifetime::WhenVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(!mask.is_component_hidden(&filter_registry, a_index));

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -166,11 +166,11 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
+        assert!(mask.hides_entity(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+            mask.hidden_component_lifetime(&filter_registry, a_index)
                 .is_some()
         );
     }
@@ -186,17 +186,17 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
+        assert!(!mask.hides_entity(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+            mask.hidden_component_lifetime(&filter_registry, a_index)
                 .is_some()
         );
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, b_index)
+            mask.hidden_component_lifetime(&filter_registry, b_index)
                 .is_none()
         );
     }
@@ -212,23 +212,23 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
+        assert!(!mask.hides_entity(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+            mask.hidden_component_lifetime(&filter_registry, a_index)
                 .is_some()
         );
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, b_index)
+            mask.hidden_component_lifetime(&filter_registry, b_index)
                 .is_some()
         );
 
         let (c_index, _) = registry.init_component_fns::<C>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, c_index)
+            mask.hidden_component_lifetime(&filter_registry, c_index)
                 .is_none()
         );
     }
@@ -244,17 +244,17 @@ mod tests {
         let mut mask = FiltersMask::default();
         mask.insert(bit);
 
-        assert!(!mask.is_hidden(&filter_registry, ScopeLifetime::WhileVisible));
+        assert!(!mask.hides_entity(&filter_registry, ScopeLifetime::WhileVisible));
 
         let (a_index, _) = registry.init_component_fns::<A>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, a_index)
+            mask.hidden_component_lifetime(&filter_registry, a_index)
                 .is_none()
         );
 
         let (b_index, _) = registry.init_component_fns::<B>(&mut world);
         assert!(
-            mask.get_hidden_component_lowest_lifetime(&filter_registry, b_index)
+            mask.hidden_component_lifetime(&filter_registry, b_index)
                 .is_some()
         );
     }

--- a/src/server/visibility/registry.rs
+++ b/src/server/visibility/registry.rs
@@ -130,6 +130,7 @@ mod tests {
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
             scopes: vec![VisibilityScope::Entity; 31],
+            lifetimes: vec![VisibilityLifetime::Always; 31],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);
@@ -142,6 +143,7 @@ mod tests {
         let mut registry = ReplicationRegistry::default();
         let mut filter_registry = FilterRegistry {
             scopes: vec![VisibilityScope::Entity; 32],
+            lifetimes: vec![VisibilityLifetime::Always; 32],
             ..Default::default()
         };
         filter_registry.register_filter::<EntityVisibility>(&mut world, &mut registry);

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -358,12 +358,20 @@ pub enum ScopeLifetime {
     /// It's not spawned/inserted until it first becomes visible. After
     /// that, it remains present when hidden, but receives changes only while
     /// visible.
+    ///
+    /// When visibility is regained, existing components receive their latest
+    /// state. However, component removals and entity despawns that happen while
+    /// hidden won't be reapplied, so the client may retain stale components
+    /// or entities.
     AfterFirstVisibility,
 
     /// The scope is always present, regardless of visibility.
     ///
     /// It's spawned/inserted regardless of the visibility, but receives changes
     /// only while visible.
+    ///
+    /// As with [`Self::AfterFirstVisibility`], removals and despawns that happen
+    /// while hidden are not reapplied.
     AlwaysPresent,
 }
 

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -142,7 +142,7 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
 
     /**
     Controls whether an entity or components get despawned or removed (respectively) when the filter
-    denies visibility. Is set to [`ScopeLifetime::WhenVisible`] by default.
+    denies visibility. Is set to [`ScopeLifetime::WhileVisible`] by default.
 
     For details, see [`ScopeLifetime`].
 
@@ -158,7 +158,7 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     impl VisibilityFilter for PauseReplication {
         type ClientComponent = Self;
         type Scope = Entity;
-        const LIFETIME: ScopeLifetime = ScopeLifetime::OnceVisible;
+        const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
 
         fn is_visible(&self, client: Entity, component: Option<&Self::ClientComponent>) -> bool {
             component.is_none()
@@ -166,7 +166,7 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     }
     ```
      */
-    const LIFETIME: ScopeLifetime = ScopeLifetime::WhenVisible;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::WhileVisible;
 
     /**
     Returns `true` if a client should see [`Self::Scope`] for an entity with this component
@@ -299,19 +299,33 @@ pub enum VisibilityScope {
     AllExcept(ComponentMask),
 }
 
-/// Controls when components or entities are inserted/spawned and removed/despawned based on their
-/// visibility.
+/// Controls when a [`VisibilityScope`] is present on a client.
+///
+/// See also [`VisibilityFilter::Scope`] and
+/// [`FilterRegistry::register_scope`](crate::server::visibility::registry::FilterRegistry::register_scope).
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub enum ScopeLifetime {
-    /// Component or entity is inserted/spawned when it becomes visible and despawns when loses
+    /// Inserted/spawned when it becomes visible and despawns when loses
     /// visibility.
-    WhenVisible,
-    /// Component or entity is inserted/spawned when it becomes visible and pauses updates while
-    /// without visibility.
-    OnceVisible,
-    /// Component or entity is inserted/spawned at once but receives updates only while
-    /// being visible.
-    Always,
+    ///
+    /// The scope is present only while it is visible.
+    ///
+    /// It's spawned/inserted when it becomes visible, and despawned/removed
+    /// when it becomes hidden.
+    WhileVisible,
+
+    /// The scope remains present after becoming visible for the first time.
+    ///
+    /// It's not spawned/inserted until it first becomes visible. After
+    /// that, it remains present when hidden, but receives updates only while
+    /// visible.
+    AfterFirstVisibility,
+
+    /// The scope is always present, regardless of visibility.
+    ///
+    /// It's spawned/inserted regardless of the visibility, but receives updates only while
+    /// visible.
+    AlwaysPresent,
 }
 
 /// Associates the type with a visibility scope.

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -356,14 +356,14 @@ pub enum ScopeLifetime {
     /// The scope remains present after becoming visible for the first time.
     ///
     /// It's not spawned/inserted until it first becomes visible. After
-    /// that, it remains present when hidden, but receives updates only while
+    /// that, it remains present when hidden, but receives changes only while
     /// visible.
     AfterFirstVisibility,
 
     /// The scope is always present, regardless of visibility.
     ///
-    /// It's spawned/inserted regardless of the visibility, but receives updates only while
-    /// visible.
+    /// It's spawned/inserted regardless of the visibility, but receives changes
+    /// only while visible.
     AlwaysPresent,
 }
 

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -303,10 +303,10 @@ pub enum VisibilityScope {
 /// visibility.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub enum VisibilityLifetime {
-    /// Component or entity is removed/despawned when it becomes visible and despawns when loses
+    /// Component or entity is inserted/spawned when it becomes visible and despawns when loses
     /// visibility.
     WhenVisible,
-    /// Component or entity is removed/despawned when it becomes visible and pauses updates while
+    /// Component or entity is inserted/spawned when it becomes visible and pauses updates while
     /// without visibility.
     OnceVisible,
     /// Component or entity is inserted/spawned at once but receives updates only while

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -303,7 +303,7 @@ pub enum VisibilityScope {
 ///
 /// See also [`VisibilityFilter::Scope`] and
 /// [`FilterRegistry::register_scope`](crate::server::visibility::registry::FilterRegistry::register_scope).
-#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
 pub enum ScopeLifetime {
     /// Inserted/spawned when it becomes visible and despawns when loses
     /// visibility.

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -141,6 +141,34 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     type Scope: FilterScope;
 
     /**
+    Controls whether an entity or components get despawned or removed (respectively) when the filter
+    denies visibility. Is set to [`VisibilityLifetime::WhenVisible`] by default.
+
+    For details, see [`VisibilityLifetime`].
+
+    # Examples
+
+    ```
+    # use bevy::prelude::*;
+    # use bevy_replicon::prelude::*;
+    #[derive(Component)]
+    #[component(immutable, storage = "SparseSet")]
+    struct PauseReplication;
+
+    impl VisibilityFilter for PauseReplication {
+        type ClientComponent = Self;
+        type Scope = Entity;
+        const LIFETIME: VisibilityLifetime = VisibilityLifetime::OnceVisible;
+
+        fn is_visible(&self, client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+            component.is_none()
+        }
+    }
+    ```
+     */
+    const LIFETIME: VisibilityLifetime = VisibilityLifetime::WhenVisible;
+
+    /**
     Returns `true` if a client should see [`Self::Scope`] for an entity with this component
     based on [`Self::ClientComponent`] .
 
@@ -269,6 +297,21 @@ pub enum VisibilityScope {
     Components(ComponentMask),
     /// All components on the entity, except these.
     AllExcept(ComponentMask),
+}
+
+/// Controls when components or entities are inserted/spawned and removed/despawned based on their
+/// visibility.
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub enum VisibilityLifetime {
+    /// Component or entity is removed/despawned when it becomes visible and despawns when loses
+    /// visibility.
+    WhenVisible,
+    /// Component or entity is removed/despawned when it becomes visible and pauses updates while
+    /// without visibility.
+    OnceVisible,
+    /// Component or entity is inserted/spawned at once but receives updates only while
+    /// being visible.
+    Always,
 }
 
 /// Associates the type with a visibility scope.

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -150,20 +150,57 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
 
     # Examples
 
+    Keep a previously discovered entity on the client when it leaves
+    the client's field of view.
+
     ```
     # use bevy::prelude::*;
     # use bevy_replicon::prelude::*;
     #[derive(Component)]
     #[component(immutable)]
-    struct PauseReplication;
+    struct VisibilityPosition(Vec2);
 
-    impl VisibilityFilter for PauseReplication {
-        type ClientComponent = Self;
+    impl VisibilityFilter for VisibilityPosition {
+        type ClientComponent = ClientView;
         type Scope = Entity;
         const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
 
-        fn is_visible(&self, client: Entity, component: Option<&Self::ClientComponent>) -> bool {
-            component.is_none()
+        fn is_visible(
+            &self,
+            _client: Entity,
+            component: Option<&Self::ClientComponent>,
+        ) -> bool {
+            component.is_some_and(|view| {
+                self.0.distance_squared(view.position) <= view.radius.powi(2)
+            })
+        }
+    }
+
+    #[derive(Component)]
+    #[component(immutable)]
+    struct ClientView {
+        position: Vec2,
+        radius: f32,
+    }
+    ```
+
+    Replicate an entity to all clients except its owner.
+    The owner receives only the initial state, but simulates on its own.
+
+    ```
+    # use bevy::prelude::*;
+    # use bevy_replicon::prelude::*;
+    #[derive(Component)]
+    #[component(immutable)]
+    struct OwnedBy(Entity);
+
+    impl VisibilityFilter for OwnedBy {
+        type ClientComponent = AuthorizedClient;
+        type Scope = Entity;
+        const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
+
+        fn is_visible(&self, client: Entity, _: Option<&Self::ClientComponent>) -> bool {
+            self.0 != client
         }
     }
     ```

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -142,9 +142,9 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
 
     /**
     Controls whether an entity or components get despawned or removed (respectively) when the filter
-    denies visibility. Is set to [`VisibilityLifetime::WhenVisible`] by default.
+    denies visibility. Is set to [`ScopeLifetime::WhenVisible`] by default.
 
-    For details, see [`VisibilityLifetime`].
+    For details, see [`ScopeLifetime`].
 
     # Examples
 
@@ -158,7 +158,7 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     impl VisibilityFilter for PauseReplication {
         type ClientComponent = Self;
         type Scope = Entity;
-        const LIFETIME: VisibilityLifetime = VisibilityLifetime::OnceVisible;
+        const LIFETIME: ScopeLifetime = ScopeLifetime::OnceVisible;
 
         fn is_visible(&self, client: Entity, component: Option<&Self::ClientComponent>) -> bool {
             component.is_none()
@@ -166,7 +166,7 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     }
     ```
      */
-    const LIFETIME: VisibilityLifetime = VisibilityLifetime::WhenVisible;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::WhenVisible;
 
     /**
     Returns `true` if a client should see [`Self::Scope`] for an entity with this component
@@ -302,7 +302,7 @@ pub enum VisibilityScope {
 /// Controls when components or entities are inserted/spawned and removed/despawned based on their
 /// visibility.
 #[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
-pub enum VisibilityLifetime {
+pub enum ScopeLifetime {
     /// Component or entity is inserted/spawned when it becomes visible and despawns when loses
     /// visibility.
     WhenVisible,

--- a/src/shared/replication/visibility.rs
+++ b/src/shared/replication/visibility.rs
@@ -141,10 +141,12 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     type Scope: FilterScope;
 
     /**
-    Controls whether an entity or components get despawned or removed (respectively) when the filter
-    denies visibility. Is set to [`ScopeLifetime::WhileVisible`] by default.
+    Controls when a [`Self::Scope`] is present on a client.
 
-    For details, see [`ScopeLifetime`].
+    - For an entity scope, this describes when the entity is spawned or despawned.
+    - For a component scope, it describes when the components are inserted or removed.
+
+    Changes are replicated only while the scope is visible.
 
     # Examples
 
@@ -152,7 +154,7 @@ pub trait VisibilityFilter: Component<Mutability = Immutable> {
     # use bevy::prelude::*;
     # use bevy_replicon::prelude::*;
     #[derive(Component)]
-    #[component(immutable, storage = "SparseSet")]
+    #[component(immutable)]
     struct PauseReplication;
 
     impl VisibilityFilter for PauseReplication {

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -293,14 +293,17 @@ fn hidden_entity() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
+    let server_entity1 = server_app
         .world_mut()
-        .spawn((
-            Replicated,
-            EntityVisibility,
-            EntityVisibilityAfterFirst,
-            EntityVisibilityAlwaysPresent,
-        ))
+        .spawn((Replicated, EntityVisibility))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAfterFirst))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAlwaysPresent))
         .id();
 
     server_app.update();
@@ -308,7 +311,9 @@ fn hidden_entity() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app.world_mut().despawn(server_entity);
+    server_app.world_mut().despawn(server_entity1);
+    server_app.world_mut().despawn(server_entity2);
+    server_app.world_mut().despawn(server_entity3);
 
     server_app.update();
 

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,5 +1,4 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
-use bevy_replicon::shared::replication::visibility::ScopeLifetime;
 use bevy_replicon::{
     prelude::*,
     shared::server_entity_map::ServerEntityMap,

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -321,7 +321,7 @@ fn hidden_entity() {
     assert_eq!(
         messages.drain_sent().len(),
         0,
-        "client shouldn't receive anything for a hidden entity"
+        "client shouldn't receive despawns for hidden entities"
     );
 }
 

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
-use bevy_replicon::shared::replication::visibility::VisibilityLifetime;
+use bevy_replicon::shared::replication::visibility::ScopeLifetime;
 use bevy_replicon::{
     prelude::*,
     shared::server_entity_map::ServerEntityMap,
@@ -521,7 +521,7 @@ struct TestPauseReplication;
 impl VisibilityFilter for TestPauseReplication {
     type ClientComponent = Self;
     type Scope = Entity;
-    const LIFETIME: VisibilityLifetime = VisibilityLifetime::OnceVisible;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::OnceVisible;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_none()

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -287,6 +287,8 @@ fn hidden_entity() {
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -294,7 +296,12 @@ fn hidden_entity() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, EntityVisibility))
+        .spawn((
+            Replicated,
+            EntityVisibility,
+            EntityVisibilityAfterFirst,
+            EntityVisibilityAlwaysPresent,
+        ))
         .id();
 
     server_app.update();
@@ -325,18 +332,27 @@ fn visibility_lose() {
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
     let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert(EntityVisibility);
+    server_app.world_mut().entity_mut(client).insert((
+        EntityVisibility,
+        EntityVisibilityAfterFirst,
+        EntityVisibilityAlwaysPresent,
+    ));
 
     server_app.world_mut().spawn((Replicated, EntityVisibility));
+    server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAfterFirst));
+    server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAlwaysPresent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -344,58 +360,13 @@ fn visibility_lose() {
     server_app.exchange_with_client(&mut client_app);
 
     let mut remote = client_app.world_mut().query::<&Remote>();
-    assert_eq!(remote.iter(client_app.world()).len(), 1);
+    assert_eq!(remote.iter(client_app.world()).len(), 3);
 
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .remove::<EntityVisibility>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(remote.iter(client_app.world()).len(), 0);
-}
-
-#[test]
-fn visibility_lose_with_after_first_lifetime() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .add_visibility_filter::<AfterFirstVisibilityFilter>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert(AfterFirstVisibilityFilter);
-
-    server_app
-        .world_mut()
-        .spawn((Replicated, AfterFirstVisibilityFilter));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut remote = client_app.world_mut().query::<&Remote>();
-    assert_eq!(remote.iter(client_app.world()).len(), 1);
-
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .remove::<AfterFirstVisibilityFilter>();
+    server_app.world_mut().entity_mut(client).remove::<(
+        EntityVisibility,
+        EntityVisibilityAfterFirst,
+        EntityVisibilityAlwaysPresent,
+    )>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -403,8 +374,9 @@ fn visibility_lose_with_after_first_lifetime() {
 
     assert_eq!(
         remote.iter(client_app.world()).len(),
-        1,
-        "client shouldn't receive a despawn due to lifetime"
+        2,
+        "client should receive despawn only for the entity \
+        with `WhileVisible` lifetime"
     );
 }
 
@@ -508,11 +480,12 @@ impl VisibilityFilter for EntityVisibility {
 
 #[derive(Component)]
 #[component(immutable)]
-struct ComponentVisibility;
+struct EntityVisibilityAfterFirst;
 
-impl VisibilityFilter for ComponentVisibility {
+impl VisibilityFilter for EntityVisibilityAfterFirst {
     type ClientComponent = Self;
-    type Scope = SingleComponent<TestComponent>;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()
@@ -521,12 +494,25 @@ impl VisibilityFilter for ComponentVisibility {
 
 #[derive(Component)]
 #[component(immutable)]
-struct AfterFirstVisibilityFilter;
+struct EntityVisibilityAlwaysPresent;
 
-impl VisibilityFilter for AfterFirstVisibilityFilter {
+impl VisibilityFilter for EntityVisibilityAlwaysPresent {
     type ClientComponent = Self;
     type Scope = Entity;
-    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibility;
+
+impl VisibilityFilter for ComponentVisibility {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<TestComponent>;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,4 +1,5 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy_replicon::shared::replication::visibility::ScopeLifetime;
 use bevy_replicon::{
     prelude::*,
     shared::server_entity_map::ServerEntityMap,
@@ -358,7 +359,7 @@ fn visibility_lose() {
 }
 
 #[test]
-fn visibility_lose_with_paused_replication() {
+fn visibility_lose_with_after_first_lifetime() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -367,8 +368,7 @@ fn visibility_lose_with_paused_replication() {
             StatesPlugin,
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
-        .add_visibility_filter::<EntityVisibility>()
-        .add_visibility_filter::<TestPauseReplication>()
+        .add_visibility_filter::<AfterFirstVisibilityFilter>()
         .finish();
     }
 
@@ -378,9 +378,11 @@ fn visibility_lose_with_paused_replication() {
     server_app
         .world_mut()
         .entity_mut(client)
-        .insert(EntityVisibility);
+        .insert(AfterFirstVisibilityFilter);
 
-    server_app.world_mut().spawn((Replicated, EntityVisibility));
+    server_app
+        .world_mut()
+        .spawn((Replicated, AfterFirstVisibilityFilter));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -393,13 +395,17 @@ fn visibility_lose_with_paused_replication() {
     server_app
         .world_mut()
         .entity_mut(client)
-        .insert(TestPauseReplication);
+        .remove::<AfterFirstVisibilityFilter>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    // assert_eq!(remote.iter(client_app.world()).len(), 0);
+    assert_eq!(
+        remote.iter(client_app.world()).len(),
+        1,
+        "client shouldn't receive a despawn due to lifetime"
+    );
 }
 
 #[test]
@@ -515,14 +521,14 @@ impl VisibilityFilter for ComponentVisibility {
 
 #[derive(Component)]
 #[component(immutable)]
-struct TestPauseReplication;
+struct AfterFirstVisibilityFilter;
 
-impl VisibilityFilter for TestPauseReplication {
+impl VisibilityFilter for AfterFirstVisibilityFilter {
     type ClientComponent = Self;
     type Scope = Entity;
     const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
-        component.is_none()
+        component.is_some()
     }
 }

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -1,4 +1,5 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy_replicon::shared::replication::visibility::VisibilityLifetime;
 use bevy_replicon::{
     prelude::*,
     shared::server_entity_map::ServerEntityMap,
@@ -358,6 +359,51 @@ fn visibility_lose() {
 }
 
 #[test]
+fn visibility_lose_with_paused_replication() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<TestPauseReplication>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert(EntityVisibility);
+
+    server_app.world_mut().spawn((Replicated, EntityVisibility));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut remote = client_app.world_mut().query::<&Remote>();
+    assert_eq!(remote.iter(client_app.world()).len(), 1);
+
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert(TestPauseReplication);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    // assert_eq!(remote.iter(client_app.world()).len(), 0);
+}
+
+#[test]
 fn visibility_lose_with_component_scope() {
     let mut server_app = App::new();
     let mut client_app = App::new();
@@ -465,5 +511,19 @@ impl VisibilityFilter for ComponentVisibility {
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct TestPauseReplication;
+
+impl VisibilityFilter for TestPauseReplication {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: VisibilityLifetime = VisibilityLifetime::OnceVisible;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_none()
     }
 }

--- a/tests/despawn.rs
+++ b/tests/despawn.rs
@@ -521,7 +521,7 @@ struct TestPauseReplication;
 impl VisibilityFilter for TestPauseReplication {
     type ClientComponent = Self;
     type Scope = Entity;
-    const LIFETIME: ScopeLifetime = ScopeLifetime::OnceVisible;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_none()

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -711,6 +711,8 @@ fn hidden_entity() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -718,7 +720,12 @@ fn hidden_entity() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, EntityVisibility))
+        .spawn((
+            Replicated,
+            EntityVisibility,
+            EntityVisibilityAfterFirst,
+            EntityVisibilityAlwaysPresent,
+        ))
         .id();
 
     server_app.update();
@@ -752,6 +759,8 @@ fn hidden_component() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<ComponentVisibilityAfterFirst>()
+        .add_visibility_filter::<ComponentVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -759,7 +768,12 @@ fn hidden_component() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, ComponentVisibility))
+        .spawn((
+            Replicated,
+            ComponentVisibility,
+            ComponentVisibilityAfterFirst,
+            ComponentVisibilityAlwaysPresent,
+        ))
         .id();
 
     server_app.update();
@@ -825,6 +839,8 @@ fn visibility_gain() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<ComponentVisibilityAfterFirst>()
+        .add_visibility_filter::<ComponentVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -833,6 +849,12 @@ fn visibility_gain() {
     server_app
         .world_mut()
         .spawn((Replicated, A, ComponentVisibility));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, ComponentVisibilityAfterFirst));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, ComponentVisibilityAlwaysPresent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -840,19 +862,24 @@ fn visibility_gain() {
     server_app.exchange_with_client(&mut client_app);
 
     let mut components = client_app.world_mut().query::<&A>();
-    assert_eq!(components.iter(client_app.world()).len(), 0);
+    assert_eq!(
+        components.iter(client_app.world()).len(),
+        1,
+        "client should receive the entity with `AlwaysPresent` lifetime"
+    );
 
     let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert(ComponentVisibility);
+    server_app.world_mut().entity_mut(client).insert((
+        ComponentVisibility,
+        ComponentVisibilityAfterFirst,
+        ComponentVisibilityAlwaysPresent,
+    ));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert_eq!(components.iter(client_app.world()).len(), 1);
+    assert_eq!(components.iter(client_app.world()).len(), 3);
 }
 
 #[derive(Component, Deserialize, Serialize)]
@@ -900,11 +927,67 @@ impl VisibilityFilter for EntityVisibility {
 
 #[derive(Component)]
 #[component(immutable)]
+struct EntityVisibilityAfterFirst;
+
+impl VisibilityFilter for EntityVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibilityAlwaysPresent;
+
+impl VisibilityFilter for EntityVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
 struct ComponentVisibility;
 
 impl VisibilityFilter for ComponentVisibility {
     type ClientComponent = Self;
     type Scope = SingleComponent<A>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibilityAfterFirst;
+
+impl VisibilityFilter for ComponentVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<A>;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibilityAlwaysPresent;
+
+impl VisibilityFilter for ComponentVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<A>;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -718,14 +718,17 @@ fn hidden_entity() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
+    let server_entity1 = server_app
         .world_mut()
-        .spawn((
-            Replicated,
-            EntityVisibility,
-            EntityVisibilityAfterFirst,
-            EntityVisibilityAlwaysPresent,
-        ))
+        .spawn((Replicated, EntityVisibility))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAfterFirst))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAlwaysPresent))
         .id();
 
     server_app.update();
@@ -733,7 +736,9 @@ fn hidden_entity() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app.world_mut().entity_mut(server_entity).insert(A);
+    server_app.world_mut().entity_mut(server_entity1).insert(A);
+    server_app.world_mut().entity_mut(server_entity2).insert(A);
+    server_app.world_mut().entity_mut(server_entity3).insert(A);
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -766,14 +771,17 @@ fn hidden_component() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
+    let server_entity1 = server_app
         .world_mut()
-        .spawn((
-            Replicated,
-            ComponentVisibility,
-            ComponentVisibilityAfterFirst,
-            ComponentVisibilityAlwaysPresent,
-        ))
+        .spawn((Replicated, ComponentVisibility))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((Replicated, ComponentVisibilityAfterFirst))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((Replicated, ComponentVisibilityAlwaysPresent))
         .id();
 
     server_app.update();
@@ -781,7 +789,9 @@ fn hidden_component() {
     client_app.update();
     server_app.exchange_with_client(&mut client_app);
 
-    server_app.world_mut().entity_mut(server_entity).insert(A);
+    server_app.world_mut().entity_mut(server_entity1).insert(A);
+    server_app.world_mut().entity_mut(server_entity2).insert(A);
+    server_app.world_mut().entity_mut(server_entity3).insert(A);
 
     server_app.update();
 

--- a/tests/insertion.rs
+++ b/tests/insertion.rs
@@ -748,7 +748,7 @@ fn hidden_entity() {
     assert_eq!(
         messages.drain_sent().len(),
         0,
-        "client shouldn't receive insertion for a hidden entity"
+        "client shouldn't receive insertions for hidden entities"
     );
 }
 
@@ -799,7 +799,7 @@ fn hidden_component() {
     assert_eq!(
         messages.drain_sent().len(),
         0,
-        "client shouldn't receive insertion for a hidden component"
+        "client shouldn't receive insertions for hidden components"
     );
 }
 

--- a/tests/mutations.rs
+++ b/tests/mutations.rs
@@ -1348,6 +1348,128 @@ fn after_pause() {
     );
 }
 
+#[test]
+fn hidden_entity() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<BoolComponent>()
+        .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity1 = server_app
+        .world_mut()
+        .spawn((Replicated, BoolComponent(false), EntityVisibility))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((Replicated, BoolComponent(false), EntityVisibilityAfterFirst))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((
+            Replicated,
+            BoolComponent(false),
+            EntityVisibilityAlwaysPresent,
+        ))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    for entity in [server_entity1, server_entity2, server_entity3] {
+        server_app
+            .world_mut()
+            .get_mut::<BoolComponent>(entity)
+            .unwrap()
+            .0 = true;
+    }
+
+    server_app.update();
+
+    let mut messages = server_app.world_mut().resource_mut::<ServerMessages>();
+    assert_eq!(
+        messages.drain_sent().len(),
+        0,
+        "client shouldn't receive mutations for hidden entities"
+    );
+}
+
+#[test]
+fn hidden_component() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<BoolComponent>()
+        .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<ComponentVisibilityAfterFirst>()
+        .add_visibility_filter::<ComponentVisibilityAlwaysPresent>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let server_entity1 = server_app
+        .world_mut()
+        .spawn((Replicated, BoolComponent(false), ComponentVisibility))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((
+            Replicated,
+            BoolComponent(false),
+            ComponentVisibilityAfterFirst,
+        ))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((
+            Replicated,
+            BoolComponent(false),
+            ComponentVisibilityAlwaysPresent,
+        ))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    for entity in [server_entity1, server_entity2, server_entity3] {
+        server_app
+            .world_mut()
+            .get_mut::<BoolComponent>(entity)
+            .unwrap()
+            .0 = true;
+    }
+
+    server_app.update();
+
+    let mut messages = server_app.world_mut().resource_mut::<ServerMessages>();
+    assert_eq!(
+        messages.drain_sent().len(),
+        0,
+        "client shouldn't receive mutations for hidden components"
+    );
+}
+
 #[derive(Component, Deserialize, Serialize)]
 struct TestComponent;
 
@@ -1377,6 +1499,88 @@ struct HistoryMarker;
 
 #[derive(Component, Deref, DerefMut)]
 struct BoolHistory(Vec<bool>);
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibility;
+
+impl VisibilityFilter for EntityVisibility {
+    type ClientComponent = Self;
+    type Scope = Entity;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibilityAfterFirst;
+
+impl VisibilityFilter for EntityVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibilityAlwaysPresent;
+
+impl VisibilityFilter for EntityVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibility;
+
+impl VisibilityFilter for ComponentVisibility {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<BoolComponent>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibilityAfterFirst;
+
+impl VisibilityFilter for ComponentVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<BoolComponent>;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibilityAlwaysPresent;
+
+impl VisibilityFilter for ComponentVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<BoolComponent>;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
 
 /// Deserializes [`OriginalComponent`], but inserts it as [`ReplacedComponent`].
 fn replace(

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,4 +1,5 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
+use bevy_replicon::shared::replication::visibility::VisibilityLifetime;
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
@@ -843,6 +844,54 @@ fn visibility_lose() {
     assert_eq!(components.iter(client_app.world()).len(), 0);
 }
 
+#[test]
+fn visibility_lose_with_paused_replication() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            StatesPlugin,
+            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
+        ))
+        .replicate::<A>()
+        .add_visibility_filter::<ComponentVisibility>()
+        .finish();
+    }
+
+    server_app.connect_client(&mut client_app);
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app
+        .world_mut()
+        .entity_mut(client)
+        .insert(ComponentVisibility);
+
+    let server_entity = server_app
+        .world_mut()
+        .spawn((Replicated, A, ComponentVisibility))
+        .id();
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut components = client_app.world_mut().query::<&A>();
+    assert_eq!(components.iter(client_app.world()).len(), 1);
+
+    server_app
+        .world_mut()
+        .entity_mut(server_entity)
+        .insert(TestPauseReplication);
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+
+    // assert_eq!(components.iter(client_app.world()).len(), 0);
+}
+
 #[derive(Component, Deserialize, Serialize)]
 #[require(Required)]
 struct A;
@@ -911,5 +960,19 @@ impl VisibilityFilter for AllExceptVisibilityB {
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct TestPauseReplication;
+
+impl VisibilityFilter for TestPauseReplication {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: VisibilityLifetime = VisibilityLifetime::OnceVisible;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_none()
     }
 }

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -521,6 +521,8 @@ fn hidden_entity() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -528,7 +530,13 @@ fn hidden_entity() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, EntityVisibility, A))
+        .spawn((
+            Replicated,
+            EntityVisibility,
+            EntityVisibilityAfterFirst,
+            EntityVisibilityAlwaysPresent,
+            A,
+        ))
         .id();
 
     server_app.update();
@@ -563,6 +571,8 @@ fn hidden_component() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<ComponentVisibilityAfterFirst>()
+        .add_visibility_filter::<ComponentVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -570,7 +580,13 @@ fn hidden_component() {
 
     let server_entity = server_app
         .world_mut()
-        .spawn((Replicated, ComponentVisibility, A))
+        .spawn((
+            Replicated,
+            ComponentVisibility,
+            ComponentVisibilityAfterFirst,
+            ComponentVisibilityAlwaysPresent,
+            A,
+        ))
         .id();
 
     server_app.update();
@@ -808,20 +824,29 @@ fn visibility_lose() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<ComponentVisibility>()
+        .add_visibility_filter::<ComponentVisibilityAfterFirst>()
+        .add_visibility_filter::<ComponentVisibilityAlwaysPresent>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
     let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert(ComponentVisibility);
+    server_app.world_mut().entity_mut(client).insert((
+        ComponentVisibility,
+        ComponentVisibilityAfterFirst,
+        ComponentVisibilityAlwaysPresent,
+    ));
 
     server_app
         .world_mut()
         .spawn((Replicated, A, ComponentVisibility));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, ComponentVisibilityAfterFirst));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, ComponentVisibilityAlwaysPresent));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -829,66 +854,24 @@ fn visibility_lose() {
     server_app.exchange_with_client(&mut client_app);
 
     let mut components = client_app.world_mut().query::<&A>();
-    assert_eq!(components.iter(client_app.world()).len(), 1);
+    assert_eq!(components.iter(client_app.world()).len(), 3);
 
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .remove::<ComponentVisibility>();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-
-    assert_eq!(components.iter(client_app.world()).len(), 0);
-}
-
-#[test]
-fn visibility_lose_with_paused_replication() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .replicate::<A>()
-        .add_visibility_filter::<ComponentVisibility>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    let client = **client_app.world().resource::<TestClientEntity>();
-    server_app
-        .world_mut()
-        .entity_mut(client)
-        .insert(ComponentVisibility);
-
-    let server_entity = server_app
-        .world_mut()
-        .spawn((Replicated, A, ComponentVisibility))
-        .id();
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut components = client_app.world_mut().query::<&A>();
-    assert_eq!(components.iter(client_app.world()).len(), 1);
-
-    server_app
-        .world_mut()
-        .entity_mut(server_entity)
-        .insert(TestPauseReplication);
+    server_app.world_mut().entity_mut(client).remove::<(
+        ComponentVisibility,
+        ComponentVisibilityAfterFirst,
+        ComponentVisibilityAlwaysPresent,
+    )>();
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    // assert_eq!(components.iter(client_app.world()).len(), 0);
+    assert_eq!(
+        components.iter(client_app.world()).len(),
+        2,
+        "client should receive removal only for the entity \
+        with `WhileVisible` lifetime"
+    );
 }
 
 #[derive(Component, Deserialize, Serialize)]
@@ -925,11 +908,67 @@ impl VisibilityFilter for EntityVisibility {
 
 #[derive(Component)]
 #[component(immutable)]
+struct EntityVisibilityAfterFirst;
+
+impl VisibilityFilter for EntityVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibilityAlwaysPresent;
+
+impl VisibilityFilter for EntityVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
 struct ComponentVisibility;
 
 impl VisibilityFilter for ComponentVisibility {
     type ClientComponent = Self;
     type Scope = SingleComponent<A>;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibilityAfterFirst;
+
+impl VisibilityFilter for ComponentVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<A>;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct ComponentVisibilityAlwaysPresent;
+
+impl VisibilityFilter for ComponentVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = SingleComponent<A>;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()
@@ -959,19 +998,5 @@ impl VisibilityFilter for AllExceptVisibilityB {
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()
-    }
-}
-
-#[derive(Component)]
-#[component(immutable)]
-struct TestPauseReplication;
-
-impl VisibilityFilter for TestPauseReplication {
-    type ClientComponent = Self;
-    type Scope = Entity;
-    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
-
-    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
-        component.is_none()
     }
 }

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -970,7 +970,7 @@ struct TestPauseReplication;
 impl VisibilityFilter for TestPauseReplication {
     type ClientComponent = Self;
     type Scope = Entity;
-    const LIFETIME: ScopeLifetime = ScopeLifetime::OnceVisible;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_none()

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,5 +1,4 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
-use bevy_replicon::shared::replication::visibility::ScopeLifetime;
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, state::app::StatesPlugin};
-use bevy_replicon::shared::replication::visibility::VisibilityLifetime;
+use bevy_replicon::shared::replication::visibility::ScopeLifetime;
 use bevy_replicon::{
     client::confirm_history::{ConfirmHistory, EntityReplicated},
     prelude::*,
@@ -970,7 +970,7 @@ struct TestPauseReplication;
 impl VisibilityFilter for TestPauseReplication {
     type ClientComponent = Self;
     type Scope = Entity;
-    const LIFETIME: VisibilityLifetime = VisibilityLifetime::OnceVisible;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::OnceVisible;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_none()

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -528,15 +528,17 @@ fn hidden_entity() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
+    let server_entity1 = server_app
         .world_mut()
-        .spawn((
-            Replicated,
-            EntityVisibility,
-            EntityVisibilityAfterFirst,
-            EntityVisibilityAlwaysPresent,
-            A,
-        ))
+        .spawn((Replicated, EntityVisibility, A))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAfterFirst, A))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((Replicated, EntityVisibilityAlwaysPresent, A))
         .id();
 
     server_app.update();
@@ -546,7 +548,15 @@ fn hidden_entity() {
 
     server_app
         .world_mut()
-        .entity_mut(server_entity)
+        .entity_mut(server_entity1)
+        .remove::<A>();
+    server_app
+        .world_mut()
+        .entity_mut(server_entity2)
+        .remove::<A>();
+    server_app
+        .world_mut()
+        .entity_mut(server_entity3)
         .remove::<A>();
 
     server_app.update();
@@ -578,15 +588,17 @@ fn hidden_component() {
 
     server_app.connect_client(&mut client_app);
 
-    let server_entity = server_app
+    let server_entity1 = server_app
         .world_mut()
-        .spawn((
-            Replicated,
-            ComponentVisibility,
-            ComponentVisibilityAfterFirst,
-            ComponentVisibilityAlwaysPresent,
-            A,
-        ))
+        .spawn((Replicated, ComponentVisibility, A))
+        .id();
+    let server_entity2 = server_app
+        .world_mut()
+        .spawn((Replicated, ComponentVisibilityAfterFirst, A))
+        .id();
+    let server_entity3 = server_app
+        .world_mut()
+        .spawn((Replicated, ComponentVisibilityAlwaysPresent, A))
         .id();
 
     server_app.update();
@@ -596,7 +608,15 @@ fn hidden_component() {
 
     server_app
         .world_mut()
-        .entity_mut(server_entity)
+        .entity_mut(server_entity1)
+        .remove::<A>();
+    server_app
+        .world_mut()
+        .entity_mut(server_entity2)
+        .remove::<A>();
+    server_app
+        .world_mut()
+        .entity_mut(server_entity3)
         .remove::<A>();
 
     server_app.update();

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -869,7 +869,7 @@ fn visibility_lose() {
     assert_eq!(
         components.iter(client_app.world()).len(),
         2,
-        "client should receive removal only for the entity \
+        "client should receive removal only for the component \
         with `WhileVisible` lifetime"
     );
 }

--- a/tests/removal.rs
+++ b/tests/removal.rs
@@ -565,7 +565,7 @@ fn hidden_entity() {
     assert_eq!(
         messages.drain_sent().len(),
         0,
-        "client shouldn't receive removal for a hidden entity"
+        "client shouldn't receive removals for hidden entities"
     );
 }
 
@@ -625,7 +625,7 @@ fn hidden_component() {
     assert_eq!(
         messages.drain_sent().len(),
         0,
-        "client shouldn't receive removal for a hidden component"
+        "client shouldn't receive removals for hidden components"
     );
 }
 

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -560,12 +560,19 @@ fn hidden_entity() {
             RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
         ))
         .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
         .finish();
     }
 
     server_app.connect_client(&mut client_app);
 
-    server_app.world_mut().spawn((Replicated, EntityVisibility));
+    server_app.world_mut().spawn((
+        Replicated,
+        EntityVisibility,
+        EntityVisibilityAfterFirst,
+        EntityVisibilityAlwaysPresent,
+    ));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
@@ -588,6 +595,8 @@ fn visibility_gain() {
         ))
         .replicate::<A>()
         .add_visibility_filter::<EntityVisibility>()
+        .add_visibility_filter::<EntityVisibilityAfterFirst>()
+        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
         .finish();
     }
 
@@ -595,24 +604,38 @@ fn visibility_gain() {
 
     server_app
         .world_mut()
-        .spawn((Replicated, EntityVisibility, A));
-
-    server_app.update();
-
-    let mut components = client_app.world_mut().query::<&A>();
-    assert_eq!(components.iter(client_app.world()).len(), 0);
-
-    let client = **client_app.world().resource::<TestClientEntity>();
+        .spawn((Replicated, A, EntityVisibility));
     server_app
         .world_mut()
-        .entity_mut(client)
-        .insert(EntityVisibility);
+        .spawn((Replicated, A, EntityVisibilityAfterFirst));
+    server_app
+        .world_mut()
+        .spawn((Replicated, A, EntityVisibilityAlwaysPresent));
+
+    server_app.update();
+    server_app.exchange_with_client(&mut client_app);
+    client_app.update();
+    server_app.exchange_with_client(&mut client_app);
+
+    let mut components = client_app.world_mut().query::<&A>();
+    assert_eq!(
+        components.iter(client_app.world()).len(),
+        1,
+        "client should receive the entity with `AlwaysPresent` lifetime"
+    );
+
+    let client = **client_app.world().resource::<TestClientEntity>();
+    server_app.world_mut().entity_mut(client).insert((
+        EntityVisibility,
+        EntityVisibilityAfterFirst,
+        EntityVisibilityAlwaysPresent,
+    ));
 
     server_app.update();
     server_app.exchange_with_client(&mut client_app);
     client_app.update();
 
-    assert_eq!(components.iter(client_app.world()).len(), 1);
+    assert_eq!(components.iter(client_app.world()).len(), 3);
 }
 
 #[test]
@@ -671,6 +694,34 @@ struct EntityVisibility;
 impl VisibilityFilter for EntityVisibility {
     type ClientComponent = Self;
     type Scope = Entity;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibilityAfterFirst;
+
+impl VisibilityFilter for EntityVisibilityAfterFirst {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AfterFirstVisibility;
+
+    fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
+        component.is_some()
+    }
+}
+
+#[derive(Component)]
+#[component(immutable)]
+struct EntityVisibilityAlwaysPresent;
+
+impl VisibilityFilter for EntityVisibilityAlwaysPresent {
+    type ClientComponent = Self;
+    type Scope = Entity;
+    const LIFETIME: ScopeLifetime = ScopeLifetime::AlwaysPresent;
 
     fn is_visible(&self, _client: Entity, component: Option<&Self::ClientComponent>) -> bool {
         component.is_some()

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -550,40 +550,6 @@ fn after_started_replication() {
 }
 
 #[test]
-fn hidden_entity() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            StatesPlugin,
-            RepliconPlugins.set(ServerPlugin::new(PostUpdate)),
-        ))
-        .add_visibility_filter::<EntityVisibility>()
-        .add_visibility_filter::<EntityVisibilityAfterFirst>()
-        .add_visibility_filter::<EntityVisibilityAlwaysPresent>()
-        .finish();
-    }
-
-    server_app.connect_client(&mut client_app);
-
-    server_app.world_mut().spawn((
-        Replicated,
-        EntityVisibility,
-        EntityVisibilityAfterFirst,
-        EntityVisibilityAlwaysPresent,
-    ));
-
-    server_app.update();
-    server_app.exchange_with_client(&mut client_app);
-    client_app.update();
-    server_app.exchange_with_client(&mut client_app);
-
-    let mut remote = client_app.world_mut().query::<&Remote>();
-    assert_eq!(remote.iter(client_app.world()).len(), 0);
-}
-
-#[test]
 fn visibility_gain() {
     let mut server_app = App::new();
     let mut client_app = App::new();


### PR DESCRIPTION
Hi! This PR is an early attempt to address #711 and cover 1 more additional use-case:
- don't despawn/remove an entity/component once invisible (`VisibilityLifetime::OnceVisible`)
- always spawn/insert an entity/component even if invisible (`VisibilityLifetime::Always`)

This is a working name for the enum, bikeshedding here is welcome :D

In both cases, an entity/component should be removed/despawned once removed on the server (regardless of current visibility), and updates for entities/components that were left spawned after becoming invisible should continue receiving replication updates once they become visible again.

At the moment of publishing the PR, the logic is likely broken, some of the old tests don't pass, and the new cases aren't yet covered with new tests. As I'm new to the codebase and still figuring things out, I thought I'd publish it anyway, in case you have any early feedback/direction or could point out some obvious flaws in the logic.